### PR TITLE
ci: build product artifacts in gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,8 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build WASI packages and inspector UI
+      - name: Build inspector WASI package and UI
         run: >-
           nix build --quiet
-          .#packages.x86_64-linux.wasm-smoke
-          .#packages.x86_64-linux.wasm-ledger-smoke
           .#packages.x86_64-linux.wasm-tx-inspector
           .#packages.x86_64-linux.tx-inspector-ui


### PR DESCRIPTION
## Summary

Trim the required Build Gate to the deliverable artifacts for this repo:

- `wasm-tx-inspector`, which reuses the same derivation already built in the extracted upstream worktree
- `tx-inspector-ui`, the browser bundle served by the preview

The optional smoke packages remain exposed by the flake and `just build-smokes`, but they should not make every CI run compile fresh WASI smoke closures.

## Verification

- `nix build --print-out-paths .#packages.x86_64-linux.wasm-tx-inspector .#packages.x86_64-linux.tx-inspector-ui`
- `nix build --no-link .#packages.x86_64-linux.wasm-tx-inspector .#packages.x86_64-linux.tx-inspector-ui`
