### PR TITLE
docs: publish inspector with GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,46 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: nixos
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build inspector UI
+        run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+
+      - name: Prepare Pages artifact
+        run: |
+          mkdir -p _site
+          cp -L result-site/* _site/
+          touch _site/.nojekyll
+          chmod -R u+w _site
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ The first full WASI ledger build can take a long time because Cabal populates a
 fresh dependency cache. Haskell-only edits inside the tx inspector use the
 split `prebuiltDeps` path and rebuild much faster after the cache exists.
 
-## Live Preview
+## Published Site
 
-Current preview: <https://cardano-tx-inspector.surge.sh>
+Canonical site: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
+
+Pull-request previews are published to Surge by the `PR preview` workflow.
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -17,7 +17,10 @@ format-check:
 ui-check:
     nix develop --quiet -c sh -c 'cd docs/inspector && spago build'
 
-deploy-preview:
+build-pages-site:
+    nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+
+deploy-surge-preview:
     nix build .#packages.x86_64-linux.tx-inspector-ui
     rm -rf /tmp/cardano-ledger-wasi-surge
     mkdir -p /tmp/cardano-ledger-wasi-surge


### PR DESCRIPTION
## Summary

Make GitHub Pages the canonical public host for the inspector bundle:

- add a `GitHub Pages` workflow that builds `tx-inspector-ui` through Nix and deploys the static output with `actions/deploy-pages`
- keep Surge only for pull-request previews
- update the README to point at `https://lambdasistemi.github.io/cardano-ledger-wasi/`
- rename the local Surge deployment recipe so it is not presented as the main preview path

## Verification

- `nix build --no-link .#packages.x86_64-linux.tx-inspector-ui`
- `just --list`

GitHub Pages has been enabled for workflow deployments on the repository.
