### PR TITLE
ci: expose build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,31 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build inspector WASI package and UI
-        run: >-
-          nix build --quiet
-          .#packages.x86_64-linux.wasm-tx-inspector
-          .#packages.x86_64-linux.tx-inspector-ui
+      - name: Build inspector WASI package
+        run: nix build --quiet .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+
+      - name: Build inspector UI
+        run: nix build --quiet .#packages.x86_64-linux.tx-inspector-ui -o result-site
+
+      - name: Prepare downloadable artifacts
+        run: |
+          mkdir -p artifacts/wasm-tx-inspector artifacts/tx-inspector-ui
+          cp -L result-wasm/wasm-tx-inspector.wasm artifacts/wasm-tx-inspector/
+          cp -L result-site/* artifacts/tx-inspector-ui/
+          (cd artifacts/wasm-tx-inspector && sha256sum wasm-tx-inspector.wasm > SHA256SUMS)
+          (cd artifacts/tx-inspector-ui && sha256sum index.html index.js > SHA256SUMS)
+          chmod -R u+w artifacts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm-tx-inspector
+          path: artifacts/wasm-tx-inspector
+          if-no-files-found: error
+          retention-days: 30
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tx-inspector-ui
+          path: artifacts/tx-inspector-ui
+          if-no-files-found: error
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 result
 result-*
+artifacts/
 dist-newstyle/
 .direnv/
 .envrc

--- a/README.md
+++ b/README.md
@@ -22,12 +22,19 @@ library.
 ## Build
 
 ```bash
-nix build .#packages.x86_64-linux.wasm-tx-inspector
-nix build .#packages.x86_64-linux.tx-inspector-ui
+nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
 ```
 
-The built browser bundle is in `./result/{index.html,index.js}` after the UI
-build.
+The WASI executable is `./result-wasm/wasm-tx-inspector.wasm`. The built
+browser bundle is `./result-site/{index.html,index.js}` after the UI build.
+
+You can also build directly from GitHub:
+
+```bash
+nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.wasm-tx-inspector
+nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.tx-inspector-ui
+```
 
 ## Development
 
@@ -46,6 +53,17 @@ split `prebuiltDeps` path and rebuild much faster after the cache exists.
 Canonical site: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
 
 Pull-request previews are published to Surge by the `PR preview` workflow.
+
+## CI Artifacts
+
+Every `CI` workflow run uploads downloadable artifacts:
+
+- `wasm-tx-inspector` — `wasm-tx-inspector.wasm` plus `SHA256SUMS`.
+- `tx-inspector-ui` — static `index.html`, `index.js`, plus `SHA256SUMS`.
+
+Open a workflow run under
+<https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml>
+and download them from the run's **Artifacts** section.
 
 ## License
 


### PR DESCRIPTION
## Summary

Expose the build outputs that users actually need from every CI run:

- upload `wasm-tx-inspector` containing `wasm-tx-inspector.wasm` and `SHA256SUMS`
- upload `tx-inspector-ui` containing `index.html`, `index.js`, and `SHA256SUMS`
- document the artifact download path and direct Nix build commands
- ignore local `artifacts/` packaging output

This means users can either use the GitHub Pages hosted app, download artifacts from a CI run, or build the same flake outputs locally.

## Verification

- local artifact packaging produced:
  - `artifacts/wasm-tx-inspector/wasm-tx-inspector.wasm`
  - `artifacts/wasm-tx-inspector/SHA256SUMS`
  - `artifacts/tx-inspector-ui/index.html`
  - `artifacts/tx-inspector-ui/index.js`
  - `artifacts/tx-inspector-ui/SHA256SUMS`
