### PR TITLE
docs: make Pages host repository docs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,12 +29,15 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build inspector UI
-        run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+        run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
+
+      - name: Build repository docs
+        run: nix develop --quiet -c mkdocs build --strict --site-dir _site
 
       - name: Prepare Pages artifact
         run: |
-          mkdir -p _site
-          cp -L result-site/* _site/
+          mkdir -p _site/inspector
+          cp -L result-inspector/* _site/inspector/
           touch _site/.nojekyll
           chmod -R u+w _site
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -25,13 +25,19 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build inspector UI
-        run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+        run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
+
+      - name: Build repository docs
+        run: nix develop --quiet -c mkdocs build --strict --site-dir surge-site
+
+      - name: Prepare Surge site
+        run: |
+          mkdir -p surge-site/inspector
+          cp -L result-inspector/* surge-site/inspector/
+          chmod -R u+w surge-site
 
       - name: Deploy to Surge
         run: |
-          mkdir -p surge-site
-          cp -L result-site/* surge-site/
-          chmod -R u+w surge-site
           nix --quiet shell nixpkgs#nodePackages.surge -c surge \
             surge-site \
             ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 result
 result-*
 artifacts/
+_site/
+site/
+surge-site/
 dist-newstyle/
 .direnv/
 .envrc

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ split `prebuiltDeps` path and rebuild much faster after the cache exists.
 
 ## Published Site
 
-Canonical site: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
+Repository docs: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
+
+Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-wasi/inspector/>
 
 Pull-request previews are published to Surge by the `PR preview` workflow.
 

--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,14 @@
             ];
           };
 
+          mkdocsEnv = pkgs.python3.withPackages (
+            ps: with ps; [
+              mkdocs
+              mkdocs-material
+              pymdown-extensions
+            ]
+          );
+
           wasmTargets = import ./nix/wasm-targets.nix {
             inherit pkgs;
             libWasm = self.lib.wasm;
@@ -113,6 +121,7 @@
               pkgs.curl
               pkgs.nixfmt-rfc-style
               pkgs.haskellPackages.fourmolu
+              mkdocsEnv
               psPkgs.purs
               psPkgs.spago-unstable
               psPkgs.esbuild

--- a/gh-docs/architecture.md
+++ b/gh-docs/architecture.md
@@ -1,0 +1,49 @@
+# Architecture
+
+The project splits the browser experience from ledger semantics.
+
+```mermaid
+flowchart LR
+  UI[PureScript browser UI]
+  WASI[wasm-tx-inspector.wasm]
+  Ledger[Cardano ledger packages]
+  Tx[Transaction CBOR]
+  Result[JSON result]
+
+  UI -->|operation envelope| WASI
+  Tx --> WASI
+  WASI --> Ledger
+  Ledger --> WASI
+  WASI --> Result
+  Result --> UI
+```
+
+## Layers
+
+### Browser Layer
+
+`docs/inspector/` contains the PureScript workbench. It is responsible for
+fetching or accepting transaction CBOR, managing local browser state, invoking
+the WASI module, and presenting operation results.
+
+### WASI Layer
+
+`nix/wasm/tx-inspector/` contains the Haskell executable compiled to
+`wasm32-wasi`. It reads operation requests from stdin and emits JSON. The
+browser loads the executable with `@bjorn3/browser_wasi_shim`.
+
+### Ledger Layer
+
+The Haskell executable depends on Cardano ledger packages and uses those APIs
+for transaction decoding and operations. This keeps the browser tool aligned
+with ledger behavior instead of maintaining a second transaction model.
+
+## State Model
+
+Host applications own state. A browser or CLI can manage many transactions,
+select one, and pass its CBOR to a WASI operation. The WASI operation itself
+receives explicit inputs and returns explicit outputs.
+
+This keeps operations reproducible while still allowing richer host workflows,
+such as transaction collections, comparison views, or future editing and
+balancing tools.

--- a/gh-docs/build.md
+++ b/gh-docs/build.md
@@ -1,0 +1,55 @@
+# Build and Artifacts
+
+## Build Locally
+
+Build the WASI executable:
+
+```bash
+nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+```
+
+The executable is:
+
+```text
+result-wasm/wasm-tx-inspector.wasm
+```
+
+Build the browser bundle:
+
+```bash
+nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+```
+
+The browser bundle is:
+
+```text
+result-site/index.html
+result-site/index.js
+```
+
+## Build From GitHub
+
+```bash
+nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.wasm-tx-inspector
+nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.tx-inspector-ui
+```
+
+## Download CI Artifacts
+
+Every `CI` workflow run uploads two downloadable artifacts:
+
+| Artifact | Contents |
+| --- | --- |
+| `wasm-tx-inspector` | `wasm-tx-inspector.wasm`, `SHA256SUMS` |
+| `tx-inspector-ui` | `index.html`, `index.js`, `SHA256SUMS` |
+
+Download them from the artifact section of a CI run:
+
+[CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml)
+
+## Published Documentation Site
+
+GitHub Pages publishes this documentation site and mounts the transaction
+inspector at:
+
+<https://lambdasistemi.github.io/cardano-ledger-wasi/inspector/>

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -1,0 +1,54 @@
+# Functional Layer
+
+The functional layer is the boundary between host tools and ledger-backed
+WASI operations.
+
+## Request Shape
+
+Operations use a JSON control envelope. Transaction bytes remain CBOR.
+
+```json
+{
+  "tx_cbor": "84a4...",
+  "op": "tx.inspect",
+  "args": {
+    "path": []
+  }
+}
+```
+
+## Response Shape
+
+The response is JSON so browser tools, tests, and command-line users can
+inspect it directly.
+
+```json
+{
+  "ledger_functional_layer": "0.1",
+  "op": "tx.inspect",
+  "result": {}
+}
+```
+
+## Current Operations
+
+`tx.inspect`
+: Decode and summarize the transaction using the ledger code.
+
+`tx.browse`
+: Return a navigable representation suitable for expanding transaction
+  structure in the UI.
+
+## Contract Source
+
+The detailed contract is tracked in the repository:
+
+[`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+
+## Direction
+
+The 0.1 surface should grow around useful ledger operations: inspection,
+validation, verification, transformation, patching, and eventually balancing
+where the transaction has enough slack. Each operation should keep the same
+boundary discipline: explicit inputs, ledger-owned semantics, CBOR for
+transaction bytes, JSON for control and results.

--- a/gh-docs/index.md
+++ b/gh-docs/index.md
@@ -1,0 +1,40 @@
+# Cardano Ledger WASI
+
+Cardano Ledger WASI packages selected Cardano ledger operations as
+`wasm32-wasi` executables and browser artifacts. The project exists so
+tools can call the ledger code directly from WASI rather than reimplementing
+ledger semantics in JavaScript or PureScript.
+
+## Transaction Inspector
+
+The transaction inspector is the first published workbench built on this
+layer. It accepts transaction CBOR, runs the Haskell ledger WASI module in
+the browser, and renders a browsable result.
+
+[Open the inspector](inspector/){ .md-button .md-button--primary }
+
+## Repository Scope
+
+- WASI builds for selected ledger executables.
+- A browser workbench that embeds the WASI artifact.
+- A functional operation contract with JSON control messages and CBOR data.
+- Nix and CI workflows for reproducible builds, GitHub Pages, and downloadable
+  artifacts.
+
+## Important Links
+
+- Repository: [lambdasistemi/cardano-ledger-wasi](https://github.com/lambdasistemi/cardano-ledger-wasi)
+- Inspector page: [GitHub Pages inspector](inspector/)
+- CI artifacts: [CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml)
+- Constitution: [`.specify/memory/constitution.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/.specify/memory/constitution.md)
+- Functional API contract: [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+
+## Design Commitments
+
+The ledger code is authoritative. UI and host code may choose which operation
+to run and how to present the result, but transaction interpretation belongs
+to the Haskell ledger layer.
+
+Transaction CBOR is the durable data plane. JSON is the control and response
+language for operation requests because it is inspectable, easy to version,
+and friendly to browser tooling.

--- a/justfile
+++ b/justfile
@@ -18,7 +18,11 @@ ui-check:
     nix develop --quiet -c sh -c 'cd docs/inspector && spago build'
 
 build-pages-site:
-    nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+    nix build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
+    rm -rf _site
+    nix develop --quiet -c mkdocs build --strict --site-dir _site
+    mkdir -p _site/inspector
+    cp -rL result-inspector/* _site/inspector/
 
 deploy-surge-preview:
     nix build .#packages.x86_64-linux.tx-inspector-ui

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,54 @@
+site_name: Cardano Ledger WASI
+site_url: https://lambdasistemi.github.io/cardano-ledger-wasi/
+repo_url: https://github.com/lambdasistemi/cardano-ledger-wasi
+repo_name: lambdasistemi/cardano-ledger-wasi
+edit_uri: edit/main/gh-docs/
+docs_dir: gh-docs
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.indexes
+    - navigation.sections
+    - navigation.path
+    - toc.integrate
+    - content.code.copy
+
+nav:
+  - Overview: index.md
+  - Architecture: architecture.md
+  - Functional Layer: functional-layer.md
+  - Build and Artifacts: build.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - tables
+  - footnotes
+  - def_list
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true


### PR DESCRIPTION
## Summary

Make GitHub Pages the repository documentation site, with the inspector mounted as one important page instead of replacing the whole docs root.

- add MkDocs Material configuration using `gh-docs/` as the documentation source
- add overview, architecture, functional-layer, and build/artifact docs
- publish the inspector bundle under `/inspector/` inside the Pages artifact
- update README links so it indexes both repository docs and the inspector page
- add the MkDocs Python environment to the flake dev shell

Surge remains only for pull-request previews.

## Verification

- `just build-pages-site`
- checked local built docs root at `http://127.0.0.1:8123/`
- checked local built inspector page at `http://127.0.0.1:8123/inspector/`
