### PR TITLE
docs: avoid release API lookup

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,5 @@
 site_name: Cardano Ledger WASI
 site_url: https://lambdasistemi.github.io/cardano-ledger-wasi/
-repo_url: https://github.com/lambdasistemi/cardano-ledger-wasi
-repo_name: lambdasistemi/cardano-ledger-wasi
-edit_uri: edit/main/gh-docs/
 docs_dir: gh-docs
 
 theme:
@@ -34,6 +31,7 @@ nav:
   - Architecture: architecture.md
   - Functional Layer: functional-layer.md
   - Build and Artifacts: build.md
+  - Repository: https://github.com/lambdasistemi/cardano-ledger-wasi
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

Remove the MkDocs Material repository widget configuration that tries to fetch `releases/latest`. This repository has no GitHub releases yet, so the docs root produced a browser console 404 even though the page rendered correctly.

The docs still expose the repository link through the navigation and overview page.

## Verification

- `just build-pages-site`
- Playwright against local docs root: no console errors or warnings
