### PR TITLE
docs: render Mermaid diagrams

### DIFF
--- a/gh-docs/assets/js/mermaid-init.js
+++ b/gh-docs/assets/js/mermaid-init.js
@@ -1,0 +1,41 @@
+(function () {
+  var counter = 0;
+
+  function renderMermaid() {
+    if (!window.mermaid) {
+      return;
+    }
+
+    window.mermaid.initialize({ startOnLoad: false });
+
+    document.querySelectorAll(".mermaid").forEach(function (node) {
+      if (node.dataset.processed === "true" || node.querySelector("svg")) {
+        return;
+      }
+
+      var source = node.textContent.trim();
+      if (!source) {
+        return;
+      }
+
+      node.dataset.processed = "true";
+      window.mermaid.render("mermaid-diagram-" + counter++, source).then(function (result) {
+        node.innerHTML = result.svg;
+        if (typeof result.bindFunctions === "function") {
+          result.bindFunctions(node);
+        }
+      }).catch(function (error) {
+        node.dataset.processed = "false";
+        console.error("Mermaid render failed", error);
+      });
+    });
+  }
+
+  if (window.document$ && typeof window.document$.subscribe === "function") {
+    window.document$.subscribe(renderMermaid);
+  } else if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", renderMermaid);
+  } else {
+    renderMermaid();
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,10 @@ nav:
 plugins:
   - search
 
+extra_javascript:
+  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - assets/js/mermaid-init.js
+
 markdown_extensions:
   - attr_list
   - admonition
@@ -45,7 +49,11 @@ markdown_extensions:
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:


### PR DESCRIPTION
## Summary

Fix Mermaid rendering on the architecture page.

- configure `pymdownx.superfences` with a `mermaid` custom fence
- emit Mermaid as a direct `.mermaid` div
- add a small docs-side initializer that loads and renders Mermaid diagrams deterministically on MkDocs Material pages

## Verification

- `just build-pages-site`
- Playwright local check on `/architecture/`: `svgInMermaid: 1`
- Playwright local console check: no warnings or errors
