### PR TITLE
docs: define ledger functional API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,18 @@ jobs:
       - name: Build inspector UI
         run: nix build --quiet .#packages.x86_64-linux.tx-inspector-ui -o result-site
 
+      - name: Build OpenAPI artifact
+        run: nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
+
       - name: Prepare downloadable artifacts
         run: |
-          mkdir -p artifacts/wasm-tx-inspector artifacts/tx-inspector-ui
+          mkdir -p artifacts/wasm-tx-inspector artifacts/tx-inspector-ui artifacts/ledger-functional-openapi
           cp -L result-wasm/wasm-tx-inspector.wasm artifacts/wasm-tx-inspector/
           cp -L result-site/* artifacts/tx-inspector-ui/
+          cp -L result-openapi/* artifacts/ledger-functional-openapi/
           (cd artifacts/wasm-tx-inspector && sha256sum wasm-tx-inspector.wasm > SHA256SUMS)
           (cd artifacts/tx-inspector-ui && sha256sum index.html index.js > SHA256SUMS)
+          (cd artifacts/ledger-functional-openapi && sha256sum *.json > SHA256SUMS)
           chmod -R u+w artifacts
 
       - uses: actions/upload-artifact@v4
@@ -48,5 +53,12 @@ jobs:
         with:
           name: tx-inspector-ui
           path: artifacts/tx-inspector-ui
+          if-no-files-found: error
+          retention-days: 30
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ledger-functional-openapi
+          path: artifacts/ledger-functional-openapi
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build inspector UI
         run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
 
+      - name: Build OpenAPI artifact
+        run: nix --quiet build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
+
       - name: Build repository docs
         run: nix develop --quiet -c mkdocs build --strict --site-dir _site
 
@@ -38,6 +41,8 @@ jobs:
         run: |
           mkdir -p _site/inspector
           cp -L result-inspector/* _site/inspector/
+          mkdir -p _site/openapi
+          cp -L result-openapi/* _site/openapi/
           touch _site/.nojekyll
           chmod -R u+w _site
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build inspector UI
         run: nix --quiet build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
 
+      - name: Build OpenAPI artifact
+        run: nix --quiet build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
+
       - name: Build repository docs
         run: nix develop --quiet -c mkdocs build --strict --site-dir surge-site
 
@@ -34,6 +37,8 @@ jobs:
         run: |
           mkdir -p surge-site/inspector
           cp -L result-inspector/* surge-site/inspector/
+          mkdir -p surge-site/openapi
+          cp -L result-openapi/* surge-site/openapi/
           chmod -R u+w surge-site
 
       - name: Deploy to Surge

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ library.
 ```bash
 nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
 nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
+nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
 ```
 
 The WASI executable is `./result-wasm/wasm-tx-inspector.wasm`. The built
 browser bundle is `./result-site/{index.html,index.js}` after the UI build.
+The OpenAPI/Swagger artifact is `./result-openapi/cardano-ledger-functional.openapi.json`
+with the JSON schemas it references.
 
 You can also build directly from GitHub:
 
@@ -52,6 +55,10 @@ split `prebuiltDeps` path and rebuild much faster after the cache exists.
 
 Repository docs: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
 
+Functional API definition: <https://lambdasistemi.github.io/cardano-ledger-wasi/api/>
+
+Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-wasi/swagger/>
+
 Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-wasi/inspector/>
 
 Pull-request previews are published to Surge by the `PR preview` workflow.
@@ -62,6 +69,8 @@ Every `CI` workflow run uploads downloadable artifacts:
 
 - `wasm-tx-inspector` — `wasm-tx-inspector.wasm` plus `SHA256SUMS`.
 - `tx-inspector-ui` — static `index.html`, `index.js`, plus `SHA256SUMS`.
+- `ledger-functional-openapi` — OpenAPI JSON, referenced schemas, plus
+  `SHA256SUMS`.
 
 Open a workflow run under
 <https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml>

--- a/flake.nix
+++ b/flake.nix
@@ -105,11 +105,19 @@
             wasmArtifactName = "wasm-tx-inspector";
             src = ./docs/inspector;
           };
+
+          ledger-functional-openapi = pkgs.runCommand "ledger-functional-openapi" { } ''
+            mkdir -p $out
+            cp ${./specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json} \
+              $out/cardano-ledger-functional.openapi.json
+            cp ${./specs/001-ledger-functional-layer/schemas}/*.json $out/
+          '';
         in
         {
           packages = {
             inherit (wasmTargets) wasm-smoke wasm-ledger-smoke wasm-tx-inspector;
-            inherit tx-inspector-ui;
+            inherit ledger-functional-openapi tx-inspector-ui;
+            ledger-functional-swagger = ledger-functional-openapi;
             default = tx-inspector-ui;
           };
 

--- a/gh-docs/api.md
+++ b/gh-docs/api.md
@@ -1,0 +1,99 @@
+# API Definition
+
+The Cardano Ledger WASI API is a functional call boundary around Haskell ledger
+code compiled to WASI. It is not a stateful RPC service: each operation receives
+the current transaction CBOR and explicit arguments, then returns an explicit
+result.
+
+## Envelope
+
+Requests use JSON for control data and CBOR hex for the transaction:
+
+```json
+{
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
+  "tx_cbor": "<hex-encoded Conway transaction>",
+  "op": "tx.inspect",
+  "args": {}
+}
+```
+
+Successful responses use the same versioned envelope:
+
+```json
+{
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
+  "op": "tx.inspect",
+  "result": {}
+}
+```
+
+Transforming operations must return the new transaction bytes as
+`result.tx_cbor`.
+
+## Implemented Operations
+
+| Operation | Description |
+| --- | --- |
+| `tx.inspect` | Decode transaction CBOR with the Haskell ledger and return a compact summary plus the root browser view. |
+| `tx.browse` | Decode transaction CBOR and return a browser view at `args.path`. |
+
+`tx.browse` request paths are arrays of strings. Object fields use their key
+name and array indexes use `#<index>`, for example:
+
+```json
+{
+  "tx_cbor": "<hex>",
+  "op": "tx.browse",
+  "args": {
+    "path": ["body", "outputs", "#0"]
+  }
+}
+```
+
+## 0.1 Target Surface
+
+The next API surface is organized around ledger operations that are useful to
+wallets, inspectors, and transaction builders:
+
+| Operation | Description |
+| --- | --- |
+| `tx.identify` | Transaction id, body hash, era, byte size, and witness counts. |
+| `tx.witness.plan` | Required signatures, scripts, redeemers, datums, and reference inputs. |
+| `tx.validate` | Full ledger validation with explicit UTxO, protocol, epoch, slot, governance, and network context. |
+| `tx.evaluate.scripts` | Phase-2 script evaluation and execution-unit reporting with explicit context. |
+| `tx.patch` | Ledger-aware structural patches that return new transaction CBOR. |
+| `tx.balance` | Best-effort balancing of fees, change, collateral, and return value when the supplied context gives enough slack. |
+
+Submitting transactions, signing with private keys, and multi-transaction
+workspace management stay outside the ledger WASI layer.
+
+## Source Contract
+
+The detailed contract and schemas are tracked in the repository:
+
+- [Functional API contract](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+- [OpenAPI document](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json)
+- [Request schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json)
+- [Response schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json)
+- [Browser view schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/browser-view.schema.json)
+
+The same OpenAPI bundle is a flake output:
+
+```bash
+nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
+```
+
+It is also rendered in the published [Swagger UI](swagger.md).
+
+## Current WASI Errors
+
+The current WASI command writes no partial JSON response on failure. It writes
+an error category to stderr and exits non-zero:
+
+| Category | Meaning |
+| --- | --- |
+| `malformed_hex` | Transaction hex was not valid. |
+| `malformed_cbor` | Hex decoded, but the ledger CBOR decoder rejected the transaction. |
+| `malformed_ledger_operation` | stdin looked like JSON but did not parse as a ledger-operation request. |
+| `unknown_ledger_operation` | `op` is not implemented. |

--- a/gh-docs/assets/js/swagger-ui-init.js
+++ b/gh-docs/assets/js/swagger-ui-init.js
@@ -1,0 +1,39 @@
+(function () {
+  function ensureSwaggerStylesheet() {
+    if (document.querySelector("link[data-cardano-ledger-wasi-swagger]")) {
+      return;
+    }
+
+    var stylesheet = document.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = "https://unpkg.com/swagger-ui-dist@5/swagger-ui.css";
+    stylesheet.setAttribute("data-cardano-ledger-wasi-swagger", "true");
+    document.head.appendChild(stylesheet);
+  }
+
+  function initSwaggerUi() {
+    var target = document.getElementById("swagger-ui");
+    if (!target || typeof SwaggerUIBundle === "undefined") {
+      return;
+    }
+
+    ensureSwaggerStylesheet();
+
+    SwaggerUIBundle({
+      url: new URL(
+        "../openapi/cardano-ledger-functional.openapi.json",
+        window.location.href
+      ).toString(),
+      dom_id: "#swagger-ui",
+      deepLinking: true,
+      presets: [SwaggerUIBundle.presets.apis],
+      layout: "BaseLayout"
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initSwaggerUi);
+  } else {
+    initSwaggerUi();
+  }
+})();

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -1,14 +1,17 @@
 # Functional Layer
 
 The functional layer is the boundary between host tools and ledger-backed
-WASI operations.
+WASI operations. It is a functional API, not a stateful RPC service: the host
+owns workspace state and passes the selected transaction CBOR into every
+operation.
 
 ## Request Shape
 
-Operations use a JSON control envelope. Transaction bytes remain CBOR.
+Operations use a JSON control envelope. Transaction bytes remain CBOR hex.
 
 ```json
 {
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
   "tx_cbor": "84a4...",
   "op": "tx.inspect",
   "args": {
@@ -24,11 +27,14 @@ inspect it directly.
 
 ```json
 {
-  "ledger_functional_layer": "0.1",
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
   "op": "tx.inspect",
   "result": {}
 }
 ```
+
+Transforming operations must return the resulting transaction as
+`result.tx_cbor`.
 
 ## Current Operations
 
@@ -41,9 +47,10 @@ inspect it directly.
 
 ## Contract Source
 
-The detailed contract is tracked in the repository:
+The readable API page and detailed contract are tracked here:
 
-[`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+- [API definition](api.md)
+- [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
 
 ## Direction
 

--- a/gh-docs/index.md
+++ b/gh-docs/index.md
@@ -25,6 +25,8 @@ the browser, and renders a browsable result.
 
 - Repository: [lambdasistemi/cardano-ledger-wasi](https://github.com/lambdasistemi/cardano-ledger-wasi)
 - Inspector page: [GitHub Pages inspector](inspector/)
+- API definition: [Functional API](api.md)
+- Swagger UI: [OpenAPI reference](swagger.md)
 - CI artifacts: [CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml)
 - Constitution: [`.specify/memory/constitution.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/.specify/memory/constitution.md)
 - Functional API contract: [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)

--- a/gh-docs/swagger.md
+++ b/gh-docs/swagger.md
@@ -1,0 +1,14 @@
+# Swagger UI
+
+This page renders the OpenAPI document for the Cardano Ledger WASI functional
+API. The repository publishes the contract and WASI artifact; host adapters can
+use this HTTP shape for generated clients or service wrappers.
+
+<p>
+  <a href="../openapi/cardano-ledger-functional.openapi.json">Open raw OpenAPI JSON</a>
+</p>
+
+<div id="swagger-ui"></div>
+
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+<script src="../assets/js/swagger-ui-init.js"></script>

--- a/justfile
+++ b/justfile
@@ -7,6 +7,9 @@ build-wasm:
 build-ui:
     nix build .#packages.x86_64-linux.tx-inspector-ui
 
+build-openapi:
+    nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
+
 build-smokes:
     nix build .#packages.x86_64-linux.wasm-smoke
     nix build .#packages.x86_64-linux.wasm-ledger-smoke
@@ -19,10 +22,13 @@ ui-check:
 
 build-pages-site:
     nix build .#packages.x86_64-linux.tx-inspector-ui -o result-inspector
+    nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
     rm -rf _site
     nix develop --quiet -c mkdocs build --strict --site-dir _site
     mkdir -p _site/inspector
     cp -rL result-inspector/* _site/inspector/
+    mkdir -p _site/openapi
+    cp -rL result-openapi/* _site/openapi/
 
 deploy-surge-preview:
     nix build .#packages.x86_64-linux.tx-inspector-ui

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ nav:
   - Overview: index.md
   - Architecture: architecture.md
   - Functional Layer: functional-layer.md
+  - API Definition: api.md
+  - Swagger UI: swagger.md
   - Build and Artifacts: build.md
   - Repository: https://github.com/lambdasistemi/cardano-ledger-wasi
 

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -1,39 +1,87 @@
 # Cardano Ledger WASI Functional API
 
-The browser and any downstream application own transaction workspace state.
-The ledger layer receives explicit inputs and returns explicit results.
+Status: draft 0.1
 
-## Request
+Envelope: `cardano-ledger-functional/v1`
 
-Ledger operation requests are JSON:
+This contract defines the functional boundary between host applications and
+Cardano ledger code compiled to WASI. It is not a stateful RPC service. Each
+operation is a ledger-backed function over explicit inputs.
+
+The host owns transaction workspace state. The ledger layer receives the
+transaction CBOR plus operation arguments and returns explicit JSON results.
+
+## Design Rules
+
+- The Haskell ledger code is authoritative for decoding and ledger semantics.
+- `tx_cbor` is the canonical transaction document for every transaction
+  operation.
+- JSON is the control plane and response view language.
+- CBOR remains the data plane for full transactions and fidelity-sensitive
+  ledger values.
+- Validation, evaluation, balancing, and similar operations MUST receive all
+  external context explicitly in `args`.
+- Operations that transform a transaction MUST return the resulting
+  transaction as `result.tx_cbor`.
+
+## Invocation Model
+
+The first implementation is a WASI command:
+
+- stdin: either a JSON ledger-operation request or legacy raw transaction hex.
+- stdout: one successful JSON response.
+- stderr: one error category and detail on failure.
+- process status: zero on success, non-zero on failure.
+
+Embedders MAY expose the same contract through an in-process function call.
+They must preserve the same request and response shapes.
+
+## Request Envelope
+
+Canonical requests are JSON objects:
 
 ```json
 {
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
   "tx_cbor": "<hex-encoded Conway transaction>",
   "op": "tx.inspect",
   "args": {}
 }
 ```
 
-- `tx_cbor` is required and is the canonical transaction document for the
-  operation.
-- `op` names the pure ledger operation.
-- `args` contains operation-specific JSON control-plane arguments.
-- Fidelity-sensitive ledger values remain CBOR hex inside JSON fields.
+Fields:
 
-For browser navigation:
+`ledger_functional_layer`
+: Optional request envelope version. New callers SHOULD send
+  `cardano-ledger-functional/v1`. The current WASI executable ignores unknown
+  top-level fields, so this is advisory until request version enforcement is
+  added.
+
+`tx_cbor`
+: Required. Hex-encoded transaction CBOR. Whitespace may be accepted by a
+  command-line frontend, but callers SHOULD send continuous hex.
+
+`op`
+: Required. Ledger operation name.
+
+`args`
+: Optional. Operation-specific JSON arguments. Omitted `args` is equivalent to
+  `{}`.
+
+Browser navigation example:
 
 ```json
 {
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
   "tx_cbor": "<hex>",
   "op": "tx.browse",
   "args": {
-    "path": ["outputs", "#4", "assets"]
+    "path": ["body", "outputs", "#4", "value"]
   }
 }
 ```
 
-## Response
+## Response Envelope
 
 Successful ledger operations return JSON:
 
@@ -45,13 +93,126 @@ Successful ledger operations return JSON:
 }
 ```
 
-- `ledger_functional_layer` identifies the envelope version.
-- `op` echoes the operation that ran.
-- `result` is operation-specific JSON.
-- Mutating operations MUST include the resulting transaction CBOR in
-  `result.tx_cbor`.
+Fields:
 
-## Initial Operations
+`ledger_functional_layer`
+: Response envelope version.
+
+`op`
+: Operation that ran after compatibility normalization.
+
+`result`
+: Operation-specific JSON result.
+
+Mutating operations MUST include the resulting transaction CBOR in
+`result.tx_cbor`:
+
+```json
+{
+  "ledger_functional_layer": "cardano-ledger-functional/v1",
+  "op": "tx.patch",
+  "result": {
+    "tx_cbor": "<hex-encoded patched transaction>",
+    "changes": []
+  }
+}
+```
+
+## Error Model
+
+The current WASI command writes no partial JSON response on failure. It writes
+`<category>: <detail>` to stderr and exits non-zero.
+
+Current categories:
+
+`malformed_hex`
+: `tx_cbor` or legacy raw stdin was not valid hex.
+
+`malformed_cbor`
+: Hex decoded, but the ledger CBOR decoder rejected the transaction.
+
+`malformed_ledger_operation`
+: stdin looked like a JSON request but did not parse as a ledger-operation
+  request.
+
+`unknown_ledger_operation`
+: The request was well formed, but `op` is not implemented.
+
+A future host adapter may wrap these categories in a JSON error envelope, but
+the command-line WASI boundary is stderr plus exit status for draft 0.1.
+
+## Data Encoding
+
+`tx_cbor`
+: Hex string containing the full transaction CBOR.
+
+Ledger bytes
+: Hex strings. Field names should end in `_cbor`, `_hash`, `_id`, or another
+  precise suffix that identifies the value.
+
+Lovelace and token quantities
+: Decimal strings when exactness matters across JavaScript runtimes. Small
+  derived counts may be JSON numbers.
+
+Paths
+: Request paths are JSON arrays of strings. Object fields use their key name.
+  Array indexes use `#<zero-based-index>`, for example `"#0"`.
+
+Browser view paths
+: The current `tx.browse` response returns `currentPath`, breadcrumb `path`,
+  and row `path` as JSON-encoded path strings so the browser can pass them back
+  unchanged. New request calls still send `args.path` as an array.
+
+## Browser View
+
+`tx.inspect` and `tx.browse` return a browser view used by the transaction UI:
+
+```json
+{
+  "valid": true,
+  "title": "outputs",
+  "subtitle": "array / 5 items",
+  "currentPath": "[\"body\",\"outputs\"]",
+  "currentJson": "[...]",
+  "breadcrumbs": [
+    { "label": "tx", "path": "[]" },
+    { "label": "body", "path": "[\"body\"]" },
+    { "label": "outputs", "path": "[\"body\",\"outputs\"]" }
+  ],
+  "rows": [
+    {
+      "label": "#0",
+      "path": "[\"body\",\"outputs\",\"#0\"]",
+      "kind": "object",
+      "summary": "4 fields",
+      "copyValue": "{...}",
+      "canDive": true
+    }
+  ]
+}
+```
+
+`copyValue` is always the best available copyable representation for that row.
+For strings it is the raw string value. For objects, arrays, booleans, numbers,
+and null it is compact JSON.
+
+## Operation Registry
+
+| Operation | Status | Purpose |
+| --- | --- | --- |
+| `tx.inspect` | implemented | Decode transaction CBOR and return a compact summary plus root browser view. |
+| `tx.browse` | implemented | Decode transaction CBOR and return a browser view at a path. |
+| `tx.identify` | 0.1 target | Return stable identifiers and metadata such as transaction id, body hash, era, size, and witness counts. |
+| `tx.witness.plan` | 0.1 target | Explain required signatures, scripts, redeemers, datums, and reference inputs. |
+| `tx.validate` | 0.1 target | Run ledger validation with explicit UTxO, protocol, epoch, slot, and network context. |
+| `tx.evaluate.scripts` | 0.1 target | Evaluate phase-2 scripts and report execution units or failures with explicit context. |
+| `tx.patch` | 0.1 target | Apply a controlled structural patch and return new transaction CBOR. |
+| `tx.balance` | 0.1 target | Try to balance fees, change, collateral, and return value when explicit context gives enough slack. |
+| `tx.submit` | out of scope | Submission belongs to a node, wallet, or provider layer, not the ledger WASI layer. |
+| `tx.sign` | out of scope | Private key custody and signing are outside this repository. |
+| `workspace.*` | out of scope | Multi-transaction workspace state belongs to the host application. |
+
+## Implemented Operations
 
 ### `tx.inspect`
 
@@ -64,8 +225,14 @@ Decode the supplied transaction CBOR with the Haskell ledger and return:
 }
 ```
 
-`inspection` is the compact transaction summary. `browser` is the root browser
-view used by the UI tree.
+`inspection` is a compact transaction summary. `browser` is the root browser
+view used by the UI.
+
+Arguments:
+
+`path`
+: Optional path array. If supplied, the returned browser view opens at that
+  path. If omitted, the browser view opens at the transaction root.
 
 ### `tx.browse`
 
@@ -78,11 +245,240 @@ browser view at `args.path`:
 }
 ```
 
+Arguments:
+
+`path`
+: Optional path array. Invalid paths fall back to the transaction root in the
+  current implementation.
+
 The browser MUST send the full current `tx_cbor` on every browse operation.
 The ledger layer MAY cache decoded values, but cache state is not authoritative.
 
+## 0.1 Target Operations
+
+These operations define the next API surface. They are intentionally explicit
+about context because a transaction alone is not enough for full ledger checks
+or balancing.
+
+### `tx.identify`
+
+Return stable identifiers and byte-level metadata.
+
+Request:
+
+```json
+{
+  "tx_cbor": "<hex>",
+  "op": "tx.identify",
+  "args": {}
+}
+```
+
+Result:
+
+```json
+{
+  "era": "Conway",
+  "tx_id": "<transaction id hex>",
+  "body_hash": "<body hash hex>",
+  "tx_size_bytes": 1234,
+  "witness_counts": {
+    "vkey": 0,
+    "native_script": 0,
+    "plutus_v1": 0,
+    "plutus_v2": 0,
+    "plutus_v3": 0,
+    "redeemer": 0,
+    "datum": 0
+  }
+}
+```
+
+### `tx.witness.plan`
+
+Explain what witnesses are required or present. This is a planning operation,
+not signing.
+
+Arguments:
+
+`utxo`
+: Optional explicit UTxO set for referenced inputs when the plan needs output
+  addresses, scripts, datum hashes, or reference scripts.
+
+Result:
+
+```json
+{
+  "required_signers": [],
+  "present_vkey_witnesses": [],
+  "missing_vkey_witnesses": [],
+  "scripts": [],
+  "redeemers": [],
+  "datums": [],
+  "reference_inputs": [],
+  "warnings": []
+}
+```
+
+### `tx.validate`
+
+Run ledger validation for a transaction in an explicit context.
+
+Arguments:
+
+```json
+{
+  "network": "mainnet",
+  "slot": 0,
+  "epoch": 0,
+  "protocol_parameters": {},
+  "utxo": {},
+  "governance_state": {},
+  "cert_state": {},
+  "stake_distribution": {}
+}
+```
+
+The exact context schema will be refined against the ledger API used by the
+implementation. If a check requires state not supplied in `args`, the operation
+MUST return a structured missing-context failure rather than guessing.
+
+Result:
+
+```json
+{
+  "valid": true,
+  "checks": [],
+  "failures": [],
+  "warnings": []
+}
+```
+
+### `tx.evaluate.scripts`
+
+Evaluate scripts and report execution units or ledger failures.
+
+Arguments:
+
+```json
+{
+  "network": "mainnet",
+  "slot": 0,
+  "protocol_parameters": {},
+  "utxo": {},
+  "cost_models": {}
+}
+```
+
+Result:
+
+```json
+{
+  "valid": true,
+  "redeemers": [],
+  "total_ex_units": {
+    "memory": "0",
+    "steps": "0"
+  },
+  "failures": [],
+  "warnings": []
+}
+```
+
+### `tx.patch`
+
+Apply a controlled transaction patch and return new transaction CBOR.
+
+Arguments:
+
+```json
+{
+  "patches": [
+    {
+      "op": "replace",
+      "path": ["body", "fee"],
+      "value": { "lovelace": "200000" }
+    }
+  ]
+}
+```
+
+Patch operations should be ledger-aware rather than arbitrary JSON mutation.
+For example, replacing a fee must rebuild the transaction body through ledger
+types and return the new CBOR.
+
+Result:
+
+```json
+{
+  "tx_cbor": "<hex>",
+  "changes": [],
+  "warnings": []
+}
+```
+
+### `tx.balance`
+
+Best-effort transaction balancing. Balancing may fail when the transaction has
+insufficient slack, missing context, no suitable change output, or incompatible
+collateral requirements.
+
+Arguments:
+
+```json
+{
+  "network": "mainnet",
+  "slot": 0,
+  "protocol_parameters": {},
+  "utxo": {},
+  "change": {
+    "address": "<bech32 or hex address>",
+    "policy": "preserve-existing-or-add"
+  },
+  "constraints": {
+    "max_extra_inputs": 0,
+    "allow_output_reordering": false,
+    "allow_collateral_change": true
+  }
+}
+```
+
+Result:
+
+```json
+{
+  "balanced": true,
+  "tx_cbor": "<hex>",
+  "fee": { "lovelace": "0" },
+  "selected_inputs": [],
+  "change_outputs": [],
+  "warnings": []
+}
+```
+
+## Schemas
+
+Machine-readable draft schemas are tracked next to this contract:
+
+- `../openapi/cardano-ledger-functional.openapi.json`
+- `../schemas/ledger-operation-request.schema.json`
+- `../schemas/ledger-operation-response.schema.json`
+- `../schemas/browser-view.schema.json`
+
+The OpenAPI document is packaged as the `ledger-functional-openapi` flake
+output and rendered by the published Swagger UI. The schemas describe the draft
+0.1 envelopes and currently implemented browser view. Operation-specific result
+schemas will be added as each 0.1 target operation is implemented.
+
 ## Compatibility
 
-During the transition from the earlier browser prototype, the WASM executable
+During the transition from the earlier browser prototype, the WASI executable
 MAY accept legacy requests containing `method` and top-level `path`. New callers
 MUST use `op` and `args.path`.
+
+Legacy operation names are normalized:
+
+| Legacy | Canonical |
+| --- | --- |
+| `inspect` | `tx.inspect` |
+| `browse` | `tx.browse` |

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -1,0 +1,209 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cardano Ledger WASI Functional API",
+    "summary": "Functional ledger-operation boundary for Cardano transaction tooling.",
+    "description": "This OpenAPI document describes the JSON control envelope used by host adapters around the Cardano Ledger WASI functional layer. The repository does not publish a stateful hosted service. WASI callers use the same request and response schemas through stdin/stdout; HTTP adapters can expose the POST shape documented here.",
+    "version": "0.1.0-draft",
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE"
+    }
+  },
+  "externalDocs": {
+    "description": "Functional API contract",
+    "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md"
+  },
+  "servers": [
+    {
+      "url": "/",
+      "description": "Host adapter root. This repository publishes the contract and WASI artifact, not a public hosted ledger service."
+    }
+  ],
+  "tags": [
+    {
+      "name": "Ledger Operations",
+      "description": "Pure ledger-backed operations over explicit transaction CBOR and arguments."
+    }
+  ],
+  "paths": {
+    "/ledger/operations": {
+      "post": {
+        "tags": ["Ledger Operations"],
+        "operationId": "runLedgerOperation",
+        "summary": "Run a ledger functional operation",
+        "description": "Run one ledger-backed function over the supplied transaction CBOR. The host owns workspace state and sends the current transaction bytes on every call. WASI command failures are reported through stderr and process status; HTTP host adapters should map those failures to the JSON error shape documented here.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "ledger-operation-request.schema.json"
+              },
+              "examples": {
+                "inspect": {
+                  "summary": "Inspect a transaction",
+                  "value": {
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "tx_cbor": "84a4...",
+                    "op": "tx.inspect",
+                    "args": {}
+                  }
+                },
+                "browse": {
+                  "summary": "Browse a nested transaction value",
+                  "value": {
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "tx_cbor": "84a4...",
+                    "op": "tx.browse",
+                    "args": {
+                      "path": ["body", "outputs", "#0"]
+                    }
+                  }
+                },
+                "balance": {
+                  "summary": "Target shape for best-effort balancing",
+                  "value": {
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "tx_cbor": "84a4...",
+                    "op": "tx.balance",
+                    "args": {
+                      "network": "mainnet",
+                      "slot": 0,
+                      "protocol_parameters": {},
+                      "utxo": {},
+                      "change": {
+                        "address": "addr1...",
+                        "policy": "preserve-existing-or-add"
+                      },
+                      "constraints": {
+                        "max_extra_inputs": 0,
+                        "allow_output_reordering": false,
+                        "allow_collateral_change": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful ledger operation response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "ledger-operation-response.schema.json"
+                },
+                "examples": {
+                  "inspect": {
+                    "summary": "Inspection response envelope",
+                    "value": {
+                      "ledger_functional_layer": "cardano-ledger-functional/v1",
+                      "op": "tx.inspect",
+                      "result": {
+                        "inspection": {
+                          "era": "Conway",
+                          "fee_lovelace": "0"
+                        },
+                        "browser": {
+                          "valid": true,
+                          "title": "tx",
+                          "subtitle": "object / 10 fields",
+                          "currentPath": "[]",
+                          "currentJson": "{}",
+                          "breadcrumbs": [
+                            {
+                              "label": "tx",
+                              "path": "[]"
+                            }
+                          ],
+                          "rows": []
+                        }
+                      }
+                    }
+                  },
+                  "patch": {
+                    "summary": "Target shape for a transforming operation",
+                    "value": {
+                      "ledger_functional_layer": "cardano-ledger-functional/v1",
+                      "op": "tx.patch",
+                      "result": {
+                        "tx_cbor": "84a4...",
+                        "changes": [],
+                        "warnings": []
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed request, malformed transaction bytes, or ledger operation failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerOperationError"
+                },
+                "examples": {
+                  "unknownOperation": {
+                    "summary": "Unknown operation",
+                    "value": {
+                      "error": {
+                        "category": "unknown_ledger_operation",
+                        "detail": "tx.unknown"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LedgerOperationRequest": {
+        "$ref": "ledger-operation-request.schema.json"
+      },
+      "LedgerOperationResponse": {
+        "$ref": "ledger-operation-response.schema.json"
+      },
+      "BrowserView": {
+        "$ref": "browser-view.schema.json"
+      },
+      "LedgerOperationError": {
+        "type": "object",
+        "required": ["error"],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": ["category", "detail"],
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": [
+                  "malformed_hex",
+                  "malformed_cbor",
+                  "malformed_ledger_operation",
+                  "unknown_ledger_operation",
+                  "ledger_operation_failed",
+                  "missing_context"
+                ]
+              },
+              "detail": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/specs/001-ledger-functional-layer/schemas/browser-view.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/browser-view.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/browser-view.schema.json",
+  "title": "Cardano Ledger WASI Browser View",
+  "type": "object",
+  "required": [
+    "valid",
+    "title",
+    "subtitle",
+    "currentPath",
+    "currentJson",
+    "breadcrumbs",
+    "rows"
+  ],
+  "properties": {
+    "valid": {
+      "type": "boolean"
+    },
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "currentPath": {
+      "type": "string",
+      "description": "JSON-encoded path array for the current browser location."
+    },
+    "currentJson": {
+      "type": "string",
+      "description": "Copyable representation of the current value."
+    },
+    "breadcrumbs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/browserLink"
+      }
+    },
+    "rows": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/browserRow"
+      }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "browserLink": {
+      "type": "object",
+      "required": ["label", "path"],
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "JSON-encoded path array."
+        }
+      },
+      "additionalProperties": true
+    },
+    "browserRow": {
+      "type": "object",
+      "required": [
+        "label",
+        "path",
+        "kind",
+        "summary",
+        "copyValue",
+        "canDive"
+      ],
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "description": "JSON-encoded path array."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["null", "boolean", "number", "string", "array", "object"]
+        },
+        "summary": {
+          "type": "string"
+        },
+        "copyValue": {
+          "type": "string"
+        },
+        "canDive": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/ledger-operation-request.schema.json",
+  "title": "Cardano Ledger WASI Ledger Operation Request",
+  "type": "object",
+  "required": ["tx_cbor", "op"],
+  "properties": {
+    "ledger_functional_layer": {
+      "type": "string",
+      "const": "cardano-ledger-functional/v1"
+    },
+    "tx_cbor": {
+      "type": "string",
+      "minLength": 2,
+      "pattern": "^[0-9A-Fa-f\\s]+$",
+      "description": "Hex-encoded transaction CBOR."
+    },
+    "op": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9]*)+$",
+      "description": "Canonical ledger operation name."
+    },
+    "args": {
+      "type": "object",
+      "default": {},
+      "additionalProperties": true
+    },
+    "method": {
+      "type": "string",
+      "deprecated": true,
+      "description": "Legacy operation field accepted by the current WASI executable."
+    },
+    "path": {
+      "$ref": "#/$defs/path",
+      "deprecated": true,
+      "description": "Legacy top-level browser path accepted by the current WASI executable."
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "path": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/ledger-operation-response.schema.json",
+  "title": "Cardano Ledger WASI Ledger Operation Response",
+  "type": "object",
+  "required": ["ledger_functional_layer", "op", "result"],
+  "properties": {
+    "ledger_functional_layer": {
+      "type": "string",
+      "const": "cardano-ledger-functional/v1"
+    },
+    "op": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:\\.[a-z][a-z0-9]*)+$"
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary
- expand the ledger functional API contract with envelope, error model, browser view, implemented ops, and 0.1 target operations
- add JSON schemas plus an OpenAPI/Swagger document
- expose the OpenAPI bundle as flake outputs and CI artifacts, and publish it under MkDocs with a Swagger UI page

## Verification
- jq parses OpenAPI and schema JSON
- nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
- nix build --quiet .#packages.x86_64-linux.ledger-functional-swagger -o result-swagger
- just build-pages-site
- Playwright local check of /swagger/ renders the OpenAPI document with no console errors