### PR TITLE
ci: verify generated Swagger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build OpenAPI artifact
         run: nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
 
+      - name: Check committed Swagger is generated
+        run: nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
+
       - name: Prepare downloadable artifacts
         run: |
           mkdir -p artifacts/wasm-tx-inspector artifacts/tx-inspector-ui artifacts/ledger-functional-openapi

--- a/README.md
+++ b/README.md
@@ -45,11 +45,15 @@ nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.tx-insp
 just --list
 just build-wasm
 just build-ui
+just check-openapi
+just check-swagger
 ```
 
 The first full WASI ledger build can take a long time because Cabal populates a
 fresh dependency cache. Haskell-only edits inside the tx inspector use the
 split `prebuiltDeps` path and rebuild much faster after the cache exists.
+`just check-openapi` and `just check-swagger` regenerate the OpenAPI document
+through Nix and fail if it differs from the committed Swagger JSON.
 
 ## Published Site
 

--- a/flake.nix
+++ b/flake.nix
@@ -106,19 +106,52 @@
             src = ./docs/inspector;
           };
 
+          ledgerFunctionalOpenapiSpec = import ./nix/ledger-functional-openapi.nix;
+
+          ledgerFunctionalOpenapiSource = pkgs.writeText
+            "cardano-ledger-functional.openapi.raw.json"
+            (builtins.toJSON ledgerFunctionalOpenapiSpec);
+
+          ledger-functional-openapi-generated =
+            pkgs.runCommand "ledger-functional-openapi-generated" { } ''
+              mkdir -p $out
+              ${pkgs.jq}/bin/jq --sort-keys . ${ledgerFunctionalOpenapiSource} \
+                > $out/cardano-ledger-functional.openapi.json
+            '';
+
           ledger-functional-openapi = pkgs.runCommand "ledger-functional-openapi" { } ''
             mkdir -p $out
-            cp ${./specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json} \
+            cp ${ledger-functional-openapi-generated}/cardano-ledger-functional.openapi.json \
               $out/cardano-ledger-functional.openapi.json
             cp ${./specs/001-ledger-functional-layer/schemas}/*.json $out/
           '';
+
+          ledger-functional-openapi-check =
+            pkgs.runCommand "ledger-functional-openapi-check" { } ''
+              mkdir -p generated $out
+              cp ${ledger-functional-openapi-generated}/cardano-ledger-functional.openapi.json \
+                generated/cardano-ledger-functional.openapi.json
+              ${pkgs.diffutils}/bin/diff -u \
+                ${./specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json} \
+                generated/cardano-ledger-functional.openapi.json
+              touch $out/passed
+            '';
         in
         {
           packages = {
             inherit (wasmTargets) wasm-smoke wasm-ledger-smoke wasm-tx-inspector;
-            inherit ledger-functional-openapi tx-inspector-ui;
+            inherit
+              ledger-functional-openapi
+              ledger-functional-openapi-generated
+              tx-inspector-ui
+              ;
             ledger-functional-swagger = ledger-functional-openapi;
             default = tx-inspector-ui;
+          };
+
+          checks = {
+            inherit ledger-functional-openapi-check;
+            ledger-functional-swagger-check = ledger-functional-openapi-check;
           };
 
           devShells.default = pkgs.mkShell {

--- a/justfile
+++ b/justfile
@@ -10,6 +10,12 @@ build-ui:
 build-openapi:
     nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
 
+check-openapi:
+    nix build .#checks.x86_64-linux.ledger-functional-openapi-check
+
+check-swagger:
+    nix build .#checks.x86_64-linux.ledger-functional-swagger-check
+
 build-smokes:
     nix build .#packages.x86_64-linux.wasm-smoke
     nix build .#packages.x86_64-linux.wasm-ledger-smoke

--- a/nix/ledger-functional-openapi.nix
+++ b/nix/ledger-functional-openapi.nix
@@ -1,0 +1,216 @@
+{
+  openapi = "3.1.0";
+  info = {
+    title = "Cardano Ledger WASI Functional API";
+    summary = "Functional ledger-operation boundary for Cardano transaction tooling.";
+    description = "This OpenAPI document describes the JSON control envelope used by host adapters around the Cardano Ledger WASI functional layer. The repository does not publish a stateful hosted service. WASI callers use the same request and response schemas through stdin/stdout; HTTP adapters can expose the POST shape documented here.";
+    version = "0.1.0-draft";
+    license = {
+      name = "Apache-2.0";
+      url = "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE";
+    };
+  };
+  externalDocs = {
+    description = "Functional API contract";
+    url = "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md";
+  };
+  servers = [
+    {
+      url = "/";
+      description = "Host adapter root. This repository publishes the contract and WASI artifact, not a public hosted ledger service.";
+    }
+  ];
+  tags = [
+    {
+      name = "Ledger Operations";
+      description = "Pure ledger-backed operations over explicit transaction CBOR and arguments.";
+    }
+  ];
+  paths = {
+    "/ledger/operations" = {
+      post = {
+        tags = [ "Ledger Operations" ];
+        operationId = "runLedgerOperation";
+        summary = "Run a ledger functional operation";
+        description = "Run one ledger-backed function over the supplied transaction CBOR. The host owns workspace state and sends the current transaction bytes on every call. WASI command failures are reported through stderr and process status; HTTP host adapters should map those failures to the JSON error shape documented here.";
+        requestBody = {
+          required = true;
+          content = {
+            "application/json" = {
+              schema = {
+                "$ref" = "ledger-operation-request.schema.json";
+              };
+              examples = {
+                inspect = {
+                  summary = "Inspect a transaction";
+                  value = {
+                    ledger_functional_layer = "cardano-ledger-functional/v1";
+                    tx_cbor = "84a4...";
+                    op = "tx.inspect";
+                    args = { };
+                  };
+                };
+                browse = {
+                  summary = "Browse a nested transaction value";
+                  value = {
+                    ledger_functional_layer = "cardano-ledger-functional/v1";
+                    tx_cbor = "84a4...";
+                    op = "tx.browse";
+                    args = {
+                      path = [
+                        "body"
+                        "outputs"
+                        "#0"
+                      ];
+                    };
+                  };
+                };
+                balance = {
+                  summary = "Target shape for best-effort balancing";
+                  value = {
+                    ledger_functional_layer = "cardano-ledger-functional/v1";
+                    tx_cbor = "84a4...";
+                    op = "tx.balance";
+                    args = {
+                      network = "mainnet";
+                      slot = 0;
+                      protocol_parameters = { };
+                      utxo = { };
+                      change = {
+                        address = "addr1...";
+                        policy = "preserve-existing-or-add";
+                      };
+                      constraints = {
+                        max_extra_inputs = 0;
+                        allow_output_reordering = false;
+                        allow_collateral_change = true;
+                      };
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+        responses = {
+          "200" = {
+            description = "Successful ledger operation response.";
+            content = {
+              "application/json" = {
+                schema = {
+                  "$ref" = "ledger-operation-response.schema.json";
+                };
+                examples = {
+                  inspect = {
+                    summary = "Inspection response envelope";
+                    value = {
+                      ledger_functional_layer = "cardano-ledger-functional/v1";
+                      op = "tx.inspect";
+                      result = {
+                        inspection = {
+                          era = "Conway";
+                          fee_lovelace = "0";
+                        };
+                        browser = {
+                          valid = true;
+                          title = "tx";
+                          subtitle = "object / 10 fields";
+                          currentPath = "[]";
+                          currentJson = "{}";
+                          breadcrumbs = [
+                            {
+                              label = "tx";
+                              path = "[]";
+                            }
+                          ];
+                          rows = [ ];
+                        };
+                      };
+                    };
+                  };
+                  patch = {
+                    summary = "Target shape for a transforming operation";
+                    value = {
+                      ledger_functional_layer = "cardano-ledger-functional/v1";
+                      op = "tx.patch";
+                      result = {
+                        tx_cbor = "84a4...";
+                        changes = [ ];
+                        warnings = [ ];
+                      };
+                    };
+                  };
+                };
+              };
+            };
+          };
+          "400" = {
+            description = "Malformed request, malformed transaction bytes, or ledger operation failure.";
+            content = {
+              "application/json" = {
+                schema = {
+                  "$ref" = "#/components/schemas/LedgerOperationError";
+                };
+                examples = {
+                  unknownOperation = {
+                    summary = "Unknown operation";
+                    value = {
+                      error = {
+                        category = "unknown_ledger_operation";
+                        detail = "tx.unknown";
+                      };
+                    };
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  components = {
+    schemas = {
+      LedgerOperationRequest = {
+        "$ref" = "ledger-operation-request.schema.json";
+      };
+      LedgerOperationResponse = {
+        "$ref" = "ledger-operation-response.schema.json";
+      };
+      BrowserView = {
+        "$ref" = "browser-view.schema.json";
+      };
+      LedgerOperationError = {
+        type = "object";
+        required = [ "error" ];
+        properties = {
+          error = {
+            type = "object";
+            required = [
+              "category"
+              "detail"
+            ];
+            properties = {
+              category = {
+                type = "string";
+                enum = [
+                  "malformed_hex"
+                  "malformed_cbor"
+                  "malformed_ledger_operation"
+                  "unknown_ledger_operation"
+                  "ledger_operation_failed"
+                  "missing_context"
+                ];
+              };
+              detail = {
+                type = "string";
+              };
+            };
+            additionalProperties = true;
+          };
+        };
+        additionalProperties = true;
+      };
+    };
+  };
+}

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -1,101 +1,133 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "Cardano Ledger WASI Functional API",
-    "summary": "Functional ledger-operation boundary for Cardano transaction tooling.",
-    "description": "This OpenAPI document describes the JSON control envelope used by host adapters around the Cardano Ledger WASI functional layer. The repository does not publish a stateful hosted service. WASI callers use the same request and response schemas through stdin/stdout; HTTP adapters can expose the POST shape documented here.",
-    "version": "0.1.0-draft",
-    "license": {
-      "name": "Apache-2.0",
-      "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE"
+  "components": {
+    "schemas": {
+      "BrowserView": {
+        "$ref": "browser-view.schema.json"
+      },
+      "LedgerOperationError": {
+        "additionalProperties": true,
+        "properties": {
+          "error": {
+            "additionalProperties": true,
+            "properties": {
+              "category": {
+                "enum": [
+                  "malformed_hex",
+                  "malformed_cbor",
+                  "malformed_ledger_operation",
+                  "unknown_ledger_operation",
+                  "ledger_operation_failed",
+                  "missing_context"
+                ],
+                "type": "string"
+              },
+              "detail": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "category",
+              "detail"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "type": "object"
+      },
+      "LedgerOperationRequest": {
+        "$ref": "ledger-operation-request.schema.json"
+      },
+      "LedgerOperationResponse": {
+        "$ref": "ledger-operation-response.schema.json"
+      }
     }
   },
   "externalDocs": {
     "description": "Functional API contract",
     "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md"
   },
-  "servers": [
-    {
-      "url": "/",
-      "description": "Host adapter root. This repository publishes the contract and WASI artifact, not a public hosted ledger service."
-    }
-  ],
-  "tags": [
-    {
-      "name": "Ledger Operations",
-      "description": "Pure ledger-backed operations over explicit transaction CBOR and arguments."
-    }
-  ],
+  "info": {
+    "description": "This OpenAPI document describes the JSON control envelope used by host adapters around the Cardano Ledger WASI functional layer. The repository does not publish a stateful hosted service. WASI callers use the same request and response schemas through stdin/stdout; HTTP adapters can expose the POST shape documented here.",
+    "license": {
+      "name": "Apache-2.0",
+      "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE"
+    },
+    "summary": "Functional ledger-operation boundary for Cardano transaction tooling.",
+    "title": "Cardano Ledger WASI Functional API",
+    "version": "0.1.0-draft"
+  },
+  "openapi": "3.1.0",
   "paths": {
     "/ledger/operations": {
       "post": {
-        "tags": ["Ledger Operations"],
-        "operationId": "runLedgerOperation",
-        "summary": "Run a ledger functional operation",
         "description": "Run one ledger-backed function over the supplied transaction CBOR. The host owns workspace state and sends the current transaction bytes on every call. WASI command failures are reported through stderr and process status; HTTP host adapters should map those failures to the JSON error shape documented here.",
+        "operationId": "runLedgerOperation",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "ledger-operation-request.schema.json"
-              },
               "examples": {
-                "inspect": {
-                  "summary": "Inspect a transaction",
-                  "value": {
-                    "ledger_functional_layer": "cardano-ledger-functional/v1",
-                    "tx_cbor": "84a4...",
-                    "op": "tx.inspect",
-                    "args": {}
-                  }
-                },
-                "browse": {
-                  "summary": "Browse a nested transaction value",
-                  "value": {
-                    "ledger_functional_layer": "cardano-ledger-functional/v1",
-                    "tx_cbor": "84a4...",
-                    "op": "tx.browse",
-                    "args": {
-                      "path": ["body", "outputs", "#0"]
-                    }
-                  }
-                },
                 "balance": {
                   "summary": "Target shape for best-effort balancing",
                   "value": {
-                    "ledger_functional_layer": "cardano-ledger-functional/v1",
-                    "tx_cbor": "84a4...",
-                    "op": "tx.balance",
                     "args": {
-                      "network": "mainnet",
-                      "slot": 0,
-                      "protocol_parameters": {},
-                      "utxo": {},
                       "change": {
                         "address": "addr1...",
                         "policy": "preserve-existing-or-add"
                       },
                       "constraints": {
-                        "max_extra_inputs": 0,
+                        "allow_collateral_change": true,
                         "allow_output_reordering": false,
-                        "allow_collateral_change": true
-                      }
-                    }
+                        "max_extra_inputs": 0
+                      },
+                      "network": "mainnet",
+                      "protocol_parameters": {},
+                      "slot": 0,
+                      "utxo": {}
+                    },
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "op": "tx.balance",
+                    "tx_cbor": "84a4..."
+                  }
+                },
+                "browse": {
+                  "summary": "Browse a nested transaction value",
+                  "value": {
+                    "args": {
+                      "path": [
+                        "body",
+                        "outputs",
+                        "#0"
+                      ]
+                    },
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "op": "tx.browse",
+                    "tx_cbor": "84a4..."
+                  }
+                },
+                "inspect": {
+                  "summary": "Inspect a transaction",
+                  "value": {
+                    "args": {},
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "op": "tx.inspect",
+                    "tx_cbor": "84a4..."
                   }
                 }
+              },
+              "schema": {
+                "$ref": "ledger-operation-request.schema.json"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
-            "description": "Successful ledger operation response.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "ledger-operation-response.schema.json"
-                },
                 "examples": {
                   "inspect": {
                     "summary": "Inspection response envelope",
@@ -103,23 +135,23 @@
                       "ledger_functional_layer": "cardano-ledger-functional/v1",
                       "op": "tx.inspect",
                       "result": {
-                        "inspection": {
-                          "era": "Conway",
-                          "fee_lovelace": "0"
-                        },
                         "browser": {
-                          "valid": true,
-                          "title": "tx",
-                          "subtitle": "object / 10 fields",
-                          "currentPath": "[]",
-                          "currentJson": "{}",
                           "breadcrumbs": [
                             {
                               "label": "tx",
                               "path": "[]"
                             }
                           ],
-                          "rows": []
+                          "currentJson": "{}",
+                          "currentPath": "[]",
+                          "rows": [],
+                          "subtitle": "object / 10 fields",
+                          "title": "tx",
+                          "valid": true
+                        },
+                        "inspection": {
+                          "era": "Conway",
+                          "fee_lovelace": "0"
                         }
                       }
                     }
@@ -130,23 +162,23 @@
                       "ledger_functional_layer": "cardano-ledger-functional/v1",
                       "op": "tx.patch",
                       "result": {
-                        "tx_cbor": "84a4...",
                         "changes": [],
+                        "tx_cbor": "84a4...",
                         "warnings": []
                       }
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "ledger-operation-response.schema.json"
                 }
               }
-            }
+            },
+            "description": "Successful ledger operation response."
           },
           "400": {
-            "description": "Malformed request, malformed transaction bytes, or ledger operation failure.",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LedgerOperationError"
-                },
                 "examples": {
                   "unknownOperation": {
                     "summary": "Unknown operation",
@@ -157,53 +189,32 @@
                       }
                     }
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/LedgerOperationError"
                 }
               }
-            }
+            },
+            "description": "Malformed request, malformed transaction bytes, or ledger operation failure."
           }
-        }
+        },
+        "summary": "Run a ledger functional operation",
+        "tags": [
+          "Ledger Operations"
+        ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "LedgerOperationRequest": {
-        "$ref": "ledger-operation-request.schema.json"
-      },
-      "LedgerOperationResponse": {
-        "$ref": "ledger-operation-response.schema.json"
-      },
-      "BrowserView": {
-        "$ref": "browser-view.schema.json"
-      },
-      "LedgerOperationError": {
-        "type": "object",
-        "required": ["error"],
-        "properties": {
-          "error": {
-            "type": "object",
-            "required": ["category", "detail"],
-            "properties": {
-              "category": {
-                "type": "string",
-                "enum": [
-                  "malformed_hex",
-                  "malformed_cbor",
-                  "malformed_ledger_operation",
-                  "unknown_ledger_operation",
-                  "ledger_operation_failed",
-                  "missing_context"
-                ]
-              },
-              "detail": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": true
-          }
-        },
-        "additionalProperties": true
-      }
+  "servers": [
+    {
+      "description": "Host adapter root. This repository publishes the contract and WASI artifact, not a public hosted ledger service.",
+      "url": "/"
     }
-  }
+  ],
+  "tags": [
+    {
+      "description": "Pure ledger-backed operations over explicit transaction CBOR and arguments.",
+      "name": "Ledger Operations"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- generate the OpenAPI/Swagger JSON from a Nix source definition
- keep the published OpenAPI flake output based on the generated file
- add flake checks that diff generated Swagger against the committed JSON byte-for-byte
- run the Swagger generation check in CI before uploading artifacts

## Verification
- nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
- nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
- just build-pages-site
- cmp committed OpenAPI JSON with result-openapi/cardano-ledger-functional.openapi.json