### PR TITLE
fix: declutter inspector summary copy controls

### DIFF
--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -497,25 +497,23 @@
         padding: 0.64rem 0.7rem;
       }
 
-      .identity-copy {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.6rem;
-        min-width: 0;
-      }
-
       .identity-label {
         color: var(--muted);
         font-size: 0.84rem;
         font-weight: 700;
       }
 
-      .identity-row code {
+      .identity-row.is-copied {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px rgba(31, 191, 161, 0.2);
+      }
+
+      .identity-value {
         display: block;
         min-height: 1.8rem;
         overflow-wrap: anywhere;
         white-space: normal;
+        user-select: text;
       }
 
       .metric-grid {
@@ -611,6 +609,11 @@
         background: #f7fffd;
       }
 
+      .browser-row.is-copied {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px rgba(31, 191, 161, 0.2);
+      }
+
       .browser-children {
         display: grid;
         gap: 8px;
@@ -643,6 +646,17 @@
 
       .browser-summary {
         overflow-wrap: anywhere;
+      }
+
+      .summary-copy-target {
+        cursor: copy;
+        border-radius: 6px;
+      }
+
+      .summary-copy-target:hover,
+      .identity-row.is-copied .summary-copy-target,
+      .browser-row.is-copied .summary-copy-target {
+        color: var(--accent-strong);
       }
 
       .kind-badge {

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -472,27 +472,35 @@ inspectorComponent initial =
       ]
 
   renderIdentityRow state row =
-    HH.div
-      [ classNames [ "identity-row" ] ]
-      [ HH.div
-          [ classNames [ "identity-copy" ] ]
-          [ HH.span
-              [ classNames [ "identity-label" ] ]
-              [ HH.text row.label ]
-          , HH.button
-              [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
-              , classNames [ "inline-action" ]
-              ]
-              [ HH.text
-                  ( if state.copiedPath == Just row.path then
-                      "Copied"
-                    else
-                      "Copy"
-                  )
-              ]
+    let
+      canCopy = identityRowCanCopy row.path
+      copied = state.copiedPath == Just row.path
+      rowClasses =
+        if copied then [ "identity-row", "is-copied" ]
+        else [ "identity-row" ]
+      valueClasses =
+        if canCopy then [ "identity-value", "summary-copy-target" ]
+        else [ "identity-value" ]
+      valueProps =
+        if canCopy then
+          [ classNames valueClasses
+          , HE.onClick (\_ -> CopyValue row.path row.copyValue)
+          , HP.title "Copy value"
           ]
-      , HH.code_ [ HH.text row.value ]
+        else
+          [ classNames valueClasses ]
+    in
+    HH.div
+      [ classNames rowClasses ]
+      [ HH.span
+          [ classNames [ "identity-label" ] ]
+          [ HH.text row.label ]
+      , HH.code valueProps [ HH.text row.value ]
       ]
+
+  identityRowCanCopy path =
+    path == "[\"identification\",\"tx_id\"]"
+      || path == "[\"identification\",\"body_hash\"]"
 
   renderBrowser state browser =
     HH.div
@@ -533,13 +541,16 @@ inspectorComponent initial =
     let
       expanded = isExpanded row.path state.expandedPaths
       child = browserAt row.path state.browserNodes
+      copied = state.copiedPath == Just row.path
     in
       [ HH.div
           [ classNames
               ( if expanded then
-                  [ "browser-row", "is-expanded" ]
+                  if copied then [ "browser-row", "is-expanded", "is-copied" ]
+                  else [ "browser-row", "is-expanded" ]
                 else
-                  [ "browser-row" ]
+                  if copied then [ "browser-row", "is-copied" ]
+                  else [ "browser-row" ]
               )
           ]
           [ HH.div
@@ -552,30 +563,23 @@ inspectorComponent initial =
                       [ HH.text row.kind ]
                   ]
               , HH.div
-                  [ classNames [ "browser-summary" ] ]
+                  [ classNames [ "browser-summary", "summary-copy-target" ]
+                  , HE.onClick (\_ -> CopyValue row.path row.copyValue)
+                  , HP.title "Copy value"
+                  ]
                   [ HH.text row.summary ]
               ]
-          , HH.div
-              [ classNames [ "browser-actions" ] ]
-              [ if row.canDive then
+          , if row.canDive then
+              HH.div
+                [ classNames [ "browser-actions" ] ]
+                [
                   HH.button
                     [ HE.onClick (\_ -> BrowseJson row.path)
                     , classNames [ "inline-action" ]
                     ]
                     [ HH.text (if expanded then "Close" else "Open") ]
-                else HH.text ""
-              , HH.button
-                  [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
-                  , classNames [ "inline-action" ]
-                  ]
-                  [ HH.text
-                      ( if state.copiedPath == Just row.path then
-                          "Copied"
-                        else
-                          "Copy"
-                      )
-                  ]
-              ]
+                ]
+            else HH.text ""
           ]
       ] <> if expanded then
         [ HH.div

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -38,7 +38,7 @@ async function decodeFixture(page) {
   ).toBeVisible();
 }
 
-test("decodes a Conway transaction and exposes copyable identity values", async ({
+test("decodes a Conway transaction and exposes compact identity values", async ({
   page,
 }) => {
   await decodeFixture(page);
@@ -48,9 +48,25 @@ test("decodes a Conway transaction and exposes copyable identity values", async 
   await expect(page.getByText("Witnesses", { exact: true })).toBeVisible();
   await expect(page.getByText("Redeemers", { exact: true })).toBeVisible();
 
+  await expect(page.locator(".identity-panel").getByRole("button")).toHaveCount(
+    0,
+  );
+
   const txIdRow = page.locator(".identity-row", { hasText: "Transaction ID" });
-  await txIdRow.getByRole("button", { name: "Copy" }).click();
-  await expect(txIdRow.getByRole("button", { name: "Copied" })).toBeVisible();
+  const txId = await txIdRow.locator("code").innerText();
+  await txIdRow.locator("code").click();
+  await expect(txIdRow).toHaveClass(/is-copied/);
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(txId);
+
+  const bodyHashRow = page.locator(".identity-row", { hasText: "Body hash" });
+  const bodyHash = await bodyHashRow.locator("code").innerText();
+  await bodyHashRow.locator("code").click();
+  await expect(bodyHashRow).toHaveClass(/is-copied/);
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(bodyHash);
 });
 
 test("opens browser rows in place without losing identity context", async ({
@@ -62,6 +78,11 @@ test("opens browser rows in place without losing identity context", async ({
     .locator(".browser-row")
     .filter({ has: page.locator("code", { hasText: "inputs" }) })
     .first();
+
+  await expect(inputsRow.getByRole("button", { name: "Copy" })).toHaveCount(0);
+  await inputsRow.locator(".browser-summary").click();
+  await expect(inputsRow).toHaveClass(/is-copied/);
+
   await inputsRow.getByRole("button", { name: "Open" }).click();
 
   await expect(page.locator(".browser-children").first()).toBeVisible();


### PR DESCRIPTION
## Summary
- remove visible Copy buttons from transaction identity summary cards
- replace per-row browser Copy buttons with click-to-copy summary text and subtle copied styling
- update Playwright coverage so summaries stay compact while browser values remain copyable

## Tests
- just ui-check
- just test