### PR TITLE
feat: implement tx.witness.plan vertical slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Smoke tx.identify operation
         run: nix build --quiet .#checks.x86_64-linux.tx-identify-smoke
 
+      - name: Smoke tx.witness.plan operation
+        run: nix build --quiet .#checks.x86_64-linux.tx-witness-plan-smoke
+
       - name: Run inspector Playwright tests
         run: nix develop --quiet -c just test-playwright
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ just build-ui
 just check-openapi
 just check-swagger
 just check-identify
+just check-witness-plan
 just test-playwright
 just test
 ```
@@ -59,6 +60,8 @@ split `prebuiltDeps` path and rebuild much faster after the cache exists.
 through Nix and fail if it differs from the committed Swagger JSON.
 `just check-identify` runs the WASI executable against a committed Conway
 transaction fixture and verifies the `tx.identify` response shape.
+`just check-witness-plan` verifies the implemented `tx.witness.plan` response
+shape against the same fixture.
 `just test-playwright` runs the Playwright E2E suite against the packaged inspector UI.
 `just test` runs the feature smoke check plus the browser suite.
 

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -518,6 +518,41 @@
         white-space: normal;
       }
 
+      .witness-plan {
+        background: #ffffff;
+      }
+
+      .witness-section {
+        display: grid;
+        gap: 8px;
+      }
+
+      .witness-row-list {
+        display: grid;
+        gap: 8px;
+      }
+
+      .witness-row {
+        background: #ffffff;
+      }
+
+      .witness-detail,
+      .witness-empty {
+        color: var(--muted);
+        font-size: 0.82rem;
+      }
+
+      .witness-warnings {
+        display: grid;
+        gap: 6px;
+        border: 1px solid #f4d47c;
+        border-radius: 8px;
+        background: var(--warning-soft);
+        padding: 0.72rem 0.8rem;
+        color: #5f4300;
+        font-size: 0.86rem;
+      }
+
       .metric-grid {
         display: grid;
         grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/docs/inspector/src/FFI/Json.js
+++ b/docs/inspector/src/FFI/Json.js
@@ -58,6 +58,7 @@ const invalidIdentification = (title, subtitle) => ({
 });
 
 const identifyPath = (...segments) => JSON.stringify(["identification", ...segments]);
+const witnessPlanPath = (...segments) => JSON.stringify(["witness_plan", ...segments]);
 
 const identityRow = (label, value, path, copyValue = value) => ({
   label,
@@ -155,6 +156,181 @@ const normalizeIdentification = (identification) => {
         identifyPath("witness_counts", "redeemer")
       ),
       identityRow("Datums", witnessCount(counts, "datum"), identifyPath("witness_counts", "datum")),
+    ],
+  };
+};
+
+const invalidWitnessPlan = (title, subtitle) => ({
+  valid: false,
+  title,
+  subtitle,
+  metrics: [],
+  warnings: [],
+  sections: [],
+});
+
+const witnessRow = (label, value, path, copyValue = value, detail = "") => ({
+  label,
+  value: text(value),
+  copyValue: text(copyValue),
+  path,
+  detail: text(detail),
+});
+
+const sourceDetail = (item) => text(item && item.source ? item.source : "");
+
+const signerRows = (items, pathRoot) =>
+  (Array.isArray(items) ? items : []).map((item, index) =>
+    witnessRow(
+      sourceDetail(item) || `#${index}`,
+      item?.hash,
+      witnessPlanPath(pathRoot, `#${index}`, "hash"),
+      item?.hash,
+      sourceDetail(item)
+    )
+  );
+
+const normalizeWitnessPlan = (plan) => {
+  if (!plan || typeof plan !== "object") {
+    return invalidWitnessPlan(
+      "Witness plan",
+      "Ledger operation response missing witness_plan."
+    );
+  }
+
+  const summary = plan.summary && typeof plan.summary === "object" ? plan.summary : {};
+  const requiredSigners = Array.isArray(plan.required_signers)
+    ? plan.required_signers
+    : [];
+  const vkeyWitnesses = Array.isArray(plan.present_vkey_witnesses)
+    ? plan.present_vkey_witnesses
+    : [];
+  const bootstrapWitnesses = Array.isArray(plan.present_bootstrap_witnesses)
+    ? plan.present_bootstrap_witnesses
+    : [];
+  const missingWitnesses = Array.isArray(plan.missing_vkey_witnesses)
+    ? plan.missing_vkey_witnesses
+    : [];
+  const scripts = Array.isArray(plan.scripts) ? plan.scripts : [];
+  const redeemers = Array.isArray(plan.redeemers) ? plan.redeemers : [];
+  const datums = Array.isArray(plan.datums) ? plan.datums : [];
+  const referenceInputs = Array.isArray(plan.reference_inputs)
+    ? plan.reference_inputs
+    : [];
+  const warnings = Array.isArray(plan.warnings) ? plan.warnings.map(text) : [];
+
+  const missingCount = Number(summary.missing_vkey_witness_count ?? missingWitnesses.length);
+  const subtitle =
+    missingCount > 0
+      ? `${missingCount} missing declared signer${missingCount === 1 ? "" : "s"}`
+      : `${vkeyWitnesses.length + bootstrapWitnesses.length} present key witness${
+          vkeyWitnesses.length + bootstrapWitnesses.length === 1 ? "" : "es"
+        }`;
+
+  return {
+    valid: true,
+    title: "Witness plan",
+    subtitle,
+    metrics: [
+      metric("Required signers", summary.required_signer_count ?? requiredSigners.length),
+      metric("VKey witnesses", summary.present_vkey_witness_count ?? vkeyWitnesses.length),
+      metric(
+        "Bootstrap witnesses",
+        summary.present_bootstrap_witness_count ?? bootstrapWitnesses.length
+      ),
+      metric("Missing signers", summary.missing_vkey_witness_count ?? missingWitnesses.length),
+      metric("Scripts", summary.script_count ?? scripts.length),
+      metric("Redeemers", summary.redeemer_count ?? redeemers.length),
+      metric("Datums", summary.datum_count ?? datums.length),
+      metric("Reference inputs", summary.reference_input_count ?? referenceInputs.length),
+    ],
+    warnings,
+    sections: [
+      {
+        title: "Required signers",
+        empty: "None declared.",
+        rows: signerRows(requiredSigners, "required_signers"),
+      },
+      {
+        title: "Missing declared signers",
+        empty: "None missing.",
+        rows: missingWitnesses.map((item, index) =>
+          witnessRow(
+            item?.reason || `#${index}`,
+            item?.hash,
+            witnessPlanPath("missing_vkey_witnesses", `#${index}`, "hash"),
+            item?.hash,
+            item?.reason
+          )
+        ),
+      },
+      {
+        title: "Present vkey witnesses",
+        empty: "None present.",
+        rows: signerRows(vkeyWitnesses, "present_vkey_witnesses"),
+      },
+      {
+        title: "Present bootstrap witnesses",
+        empty: "None present.",
+        rows: signerRows(bootstrapWitnesses, "present_bootstrap_witnesses"),
+      },
+      {
+        title: "Script witnesses",
+        empty: "None in the witness set.",
+        rows: scripts.map((item, index) =>
+          witnessRow(
+            item?.language || `#${index}`,
+            item?.hash,
+            witnessPlanPath("scripts", `#${index}`, "hash"),
+            item?.hash,
+            sourceDetail(item)
+          )
+        ),
+      },
+      {
+        title: "Redeemers",
+        empty: "None present.",
+        rows: redeemers.map((item, index) => {
+          const exUnits =
+            item?.ex_units && typeof item.ex_units === "object" ? item.ex_units : {};
+          const detail = `mem ${text(exUnits.memory ?? 0)} / steps ${text(
+            exUnits.steps ?? 0
+          )}`;
+          return witnessRow(
+            item?.purpose || `#${index}`,
+            item?.redeemer_data_hash,
+            witnessPlanPath("redeemers", `#${index}`, "redeemer_data_hash"),
+            item?.redeemer_data_hash,
+            detail
+          );
+        }),
+      },
+      {
+        title: "Datums",
+        empty: "None in the witness set.",
+        rows: datums.map((item, index) =>
+          witnessRow(
+            sourceDetail(item) || `#${index}`,
+            item?.hash,
+            witnessPlanPath("datums", `#${index}`, "hash"),
+            item?.hash,
+            item?.computed_hash ? `computed ${shortHex(item.computed_hash)}` : sourceDetail(item)
+          )
+        ),
+      },
+      {
+        title: "Reference inputs",
+        empty: "None referenced.",
+        rows: referenceInputs.map((item, index) =>
+          witnessRow(
+            `#${index}`,
+            `${shortHex(item?.tx_id)}#${text(item?.index)}`,
+            witnessPlanPath("reference_inputs", `#${index}`, "tx_id"),
+            item?.tx_id,
+            `index ${text(item?.index)}`
+          )
+        ),
+      },
     ],
   };
 };
@@ -364,5 +540,14 @@ export const operationIdentificationImpl = (raw) => {
       "Transaction identity",
       "Ledger operation response was not JSON."
     );
+  }
+};
+
+export const operationWitnessPlanImpl = (raw) => {
+  try {
+    const parsed = JSON.parse(raw);
+    return normalizeWitnessPlan(operationResult(parsed)?.witness_plan);
+  } catch (_err) {
+    return invalidWitnessPlan("Witness plan", "Ledger operation response was not JSON.");
   }
 };

--- a/docs/inspector/src/FFI/Json.purs
+++ b/docs/inspector/src/FFI/Json.purs
@@ -8,10 +8,14 @@ module FFI.Json
   , Metric
   , MintRow
   , OutputRow
+  , WitnessPlan
+  , WitnessPlanRow
+  , WitnessPlanSection
   , inspect
   , operationBrowser
   , operationIdentification
   , operationInspection
+  , operationWitnessPlan
   , pretty
   ) where
 
@@ -20,6 +24,7 @@ foreign import inspectImpl :: String -> Inspection
 foreign import operationInspectionImpl :: String -> String
 foreign import operationBrowserImpl :: String -> Browser
 foreign import operationIdentificationImpl :: String -> Identification
+foreign import operationWitnessPlanImpl :: String -> WitnessPlan
 
 type Metric =
   { label :: String
@@ -92,6 +97,29 @@ type Identification =
   , witnesses :: Array IdentificationRow
   }
 
+type WitnessPlanRow =
+  { label :: String
+  , value :: String
+  , copyValue :: String
+  , path :: String
+  , detail :: String
+  }
+
+type WitnessPlanSection =
+  { title :: String
+  , empty :: String
+  , rows :: Array WitnessPlanRow
+  }
+
+type WitnessPlan =
+  { valid :: Boolean
+  , title :: String
+  , subtitle :: String
+  , metrics :: Array Metric
+  , warnings :: Array String
+  , sections :: Array WitnessPlanSection
+  }
+
 pretty :: String -> String
 pretty = prettyImpl
 
@@ -106,3 +134,6 @@ operationBrowser = operationBrowserImpl
 
 operationIdentification :: String -> Identification
 operationIdentification = operationIdentificationImpl
+
+operationWitnessPlan :: String -> WitnessPlan
+operationWitnessPlan = operationWitnessPlanImpl

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -14,7 +14,7 @@ import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runLedgerOperation)
-import FFI.Json (Browser, Identification, inspect, operationBrowser, operationIdentification, operationInspection, pretty) as Json
+import FFI.Json (Browser, Identification, WitnessPlan, inspect, operationBrowser, operationIdentification, operationInspection, operationWitnessPlan, pretty) as Json
 import FFI.Storage as Storage
 import Provider (Provider(..))
 import Provider as Provider
@@ -81,6 +81,7 @@ type State =
   , txCbor :: Maybe String
   , browser :: Maybe Json.Browser
   , identification :: Maybe Json.Identification
+  , witnessPlan :: Maybe Json.WitnessPlan
   , browserNodes :: Array BrowserNode
   , expandedPaths :: Array String
   , running :: Boolean
@@ -136,6 +137,7 @@ inspectorComponent initial =
         , txCbor: Nothing
         , browser: Nothing
         , identification: Nothing
+        , witnessPlan: Nothing
         , browserNodes: []
         , expandedPaths: []
         , running: false
@@ -422,6 +424,7 @@ inspectorComponent initial =
                      else []
                  )
               <> renderIdentificationMaybe state
+              <> renderWitnessPlanMaybe state
               <> renderBrowserMaybe state r.exitOk
               <> [ renderRawJson r.stdout ]
               <> renderStderr r.stderr
@@ -431,6 +434,13 @@ inspectorComponent initial =
     case state.identification of
       Just identification ->
         if identification.valid then [ renderIdentification state identification ]
+        else []
+      Nothing -> []
+
+  renderWitnessPlanMaybe state =
+    case state.witnessPlan of
+      Just witnessPlan ->
+        if witnessPlan.valid then [ renderWitnessPlan state witnessPlan ]
         else []
       Nothing -> []
 
@@ -469,6 +479,77 @@ inspectorComponent initial =
       , HH.div
           [ classNames [ "witness-grid" ] ]
           (map (renderIdentityRow state) identification.witnesses)
+      ]
+
+  renderWitnessPlan state witnessPlan =
+    HH.div
+      [ classNames [ "identity-panel", "witness-plan" ] ]
+      [ HH.div
+          [ classNames [ "identity-heading" ] ]
+          [ HH.div_
+              [ HH.h3_ [ HH.text witnessPlan.title ]
+              , HH.p_ [ HH.text witnessPlan.subtitle ]
+              ]
+          ]
+      , HH.div
+          [ classNames [ "metric-grid" ] ]
+          (map renderMetric witnessPlan.metrics)
+      , renderWitnessWarnings witnessPlan.warnings
+      , HH.div_
+          (map (renderWitnessSection state) witnessPlan.sections)
+      ]
+
+  renderWitnessWarnings warnings =
+    if Array.null warnings then
+      HH.text ""
+    else
+      HH.div
+        [ classNames [ "witness-warnings" ] ]
+        (map (\warning -> HH.p_ [ HH.text warning ]) warnings)
+
+  renderWitnessSection state section =
+    HH.div
+      [ classNames [ "witness-section" ] ]
+      [ HH.div
+          [ classNames [ "identity-section-title" ] ]
+          [ HH.text section.title ]
+      , if Array.null section.rows then
+          HH.div
+            [ classNames [ "witness-empty" ] ]
+            [ HH.text section.empty ]
+        else
+          HH.div
+            [ classNames [ "witness-row-list" ] ]
+            (map (renderWitnessRow state) section.rows)
+      ]
+
+  renderWitnessRow state row =
+    HH.div
+      [ classNames [ "identity-row", "witness-row" ] ]
+      [ HH.div
+          [ classNames [ "identity-copy" ] ]
+          [ HH.span
+              [ classNames [ "identity-label" ] ]
+              [ HH.text row.label ]
+          , HH.button
+              [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
+              , classNames [ "inline-action" ]
+              ]
+              [ HH.text
+                  ( if state.copiedPath == Just row.path then
+                      "Copied"
+                    else
+                      "Copy"
+                  )
+              ]
+          ]
+      , HH.code_ [ HH.text row.value ]
+      , if row.detail == "" then
+          HH.text ""
+        else
+          HH.span
+            [ classNames [ "witness-detail" ] ]
+            [ HH.text row.detail ]
       ]
 
   renderIdentityRow state row =
@@ -696,6 +777,7 @@ inspectorComponent initial =
           , txCbor = Nothing
           , browser = Nothing
           , identification = Nothing
+          , witnessPlan = Nothing
           , browserNodes = []
           , expandedPaths = []
           , copied = false
@@ -733,10 +815,12 @@ inspectorComponent initial =
         Right h -> do
           operationResult <- H.liftAff (runLedgerOperation h "tx.inspect" "[]")
           identifyResult <- H.liftAff (runLedgerOperation h "tx.identify" "[]")
+          witnessPlanResult <- H.liftAff (runLedgerOperation h "tx.witness.plan" "[]")
           let
             inspectionResult = operationResult { stdout = Json.operationInspection operationResult.stdout }
             browser = Json.operationBrowser operationResult.stdout
             identification = Json.operationIdentification identifyResult.stdout
+            witnessPlan = Json.operationWitnessPlan witnessPlanResult.stdout
           H.modify_
             _
               { running = false
@@ -745,6 +829,9 @@ inspectorComponent initial =
               , browser = if operationResult.exitOk && browser.valid then Just browser else Nothing
               , identification =
                   if identifyResult.exitOk && identification.valid then Just identification
+                  else Nothing
+              , witnessPlan =
+                  if witnessPlanResult.exitOk && witnessPlan.valid then Just witnessPlan
                   else Nothing
               , browserNodes =
                   if operationResult.exitOk && browser.valid then rootBrowserNodes browser

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -46,11 +46,33 @@ test("decodes a Conway transaction and exposes copyable identity values", async 
   await expect(page.getByText("Transaction ID", { exact: true })).toBeVisible();
   await expect(page.getByText("Body hash", { exact: true })).toBeVisible();
   await expect(page.getByText("Witnesses", { exact: true })).toBeVisible();
-  await expect(page.getByText("Redeemers", { exact: true })).toBeVisible();
+  await expect(
+    page
+      .locator(".identity-panel:not(.witness-plan)")
+      .getByText("Redeemers", { exact: true }),
+  ).toBeVisible();
 
   const txIdRow = page.locator(".identity-row", { hasText: "Transaction ID" });
   await txIdRow.getByRole("button", { name: "Copy" }).click();
   await expect(txIdRow.getByRole("button", { name: "Copied" })).toBeVisible();
+});
+
+test("shows transaction-derived witness plan values", async ({ page }) => {
+  await decodeFixture(page);
+
+  await expect(page.getByRole("heading", { name: "Witness plan" })).toBeVisible();
+  await expect(page.getByText("Transaction-only witness plan")).toBeVisible();
+  await expect(page.getByText("Present vkey witnesses")).toBeVisible();
+
+  const redeemerRow = page
+    .locator(".witness-plan .witness-row")
+    .filter({ hasText: "ConwayMinting" })
+    .first();
+  await redeemerRow.getByRole("button", { name: "Copy" }).click();
+  await expect(redeemerRow.getByRole("button", { name: "Copied" })).toBeVisible();
+
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copied).toMatch(/^[0-9a-f]{64}$/);
 });
 
 test("opens browser rows in place without losing identity context", async ({
@@ -65,7 +87,7 @@ test("opens browser rows in place without losing identity context", async ({
   await inputsRow.getByRole("button", { name: "Open" }).click();
 
   await expect(page.locator(".browser-children").first()).toBeVisible();
-  await expect(page.locator(".identity-panel")).toBeVisible();
+  await expect(page.locator(".identity-panel:not(.witness-plan)")).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "Conway transaction identity" }),
   ).toBeVisible();

--- a/flake.nix
+++ b/flake.nix
@@ -165,6 +165,41 @@
             ' response.json
             cp request.json response.json $out/
           '';
+
+          tx-witness-plan-smoke = pkgs.runCommand "tx-witness-plan-smoke" { } ''
+            mkdir -p $out
+            export HOME="$PWD"
+            export XDG_CACHE_HOME="$PWD/.cache"
+            mkdir -p "$XDG_CACHE_HOME"
+            ${pkgs.jq}/bin/jq -n \
+              --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: ($tx | gsub("\\s"; "")),
+                op: "tx.witness.plan",
+                args: {}
+              }' > request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < request.json > response.json
+            ${pkgs.jq}/bin/jq -e '
+              .ledger_functional_layer == "cardano-ledger-functional/v1"
+              and .op == "tx.witness.plan"
+              and (.result.witness_plan.required_signers | type == "array")
+              and (.result.witness_plan.present_vkey_witnesses | type == "array")
+              and (.result.witness_plan.present_bootstrap_witnesses | type == "array")
+              and (.result.witness_plan.missing_vkey_witnesses | type == "array")
+              and (.result.witness_plan.scripts | type == "array")
+              and (.result.witness_plan.redeemers | type == "array")
+              and (.result.witness_plan.datums | type == "array")
+              and (.result.witness_plan.reference_inputs | type == "array")
+              and (.result.witness_plan.summary.required_signer_count >= 0)
+              and (.result.witness_plan.summary.present_vkey_witness_count >= 0)
+              and (.result.witness_plan.summary.missing_vkey_witness_count >= 0)
+              and (.result.witness_plan.warnings | length >= 1)
+            ' response.json
+            cp request.json response.json $out/
+          '';
         in
         {
           packages = {
@@ -179,7 +214,7 @@
           };
 
           checks = {
-            inherit ledger-functional-openapi-check tx-identify-smoke;
+            inherit ledger-functional-openapi-check tx-identify-smoke tx-witness-plan-smoke;
             ledger-functional-swagger-check = ledger-functional-openapi-check;
           };
 

--- a/gh-docs/api.md
+++ b/gh-docs/api.md
@@ -38,6 +38,7 @@ Transforming operations must return the new transaction bytes as
 | `tx.inspect` | Decode transaction CBOR with the Haskell ledger and return a compact summary plus the root browser view. |
 | `tx.browse` | Decode transaction CBOR and return a browser view at `args.path`. |
 | `tx.identify` | Return transaction id, body hash, era, byte size, fee, structural counts, and witness counts. |
+| `tx.witness.plan` | Return transaction-derived signer, witness, script, redeemer, datum, and reference-input planning data. |
 
 `tx.browse` request paths are arrays of strings. Object fields use their key
 name and array indexes use `#<index>`, for example:
@@ -59,7 +60,6 @@ wallets, inspectors, and transaction builders:
 
 | Operation | Description |
 | --- | --- |
-| `tx.witness.plan` | Required signatures, scripts, redeemers, datums, and reference inputs. |
 | `tx.validate` | Full ledger validation with explicit UTxO, protocol, epoch, slot, governance, and network context. |
 | `tx.evaluate.scripts` | Phase-2 script evaluation and execution-unit reporting with explicit context. |
 | `tx.patch` | Ledger-aware structural patches that return new transaction CBOR. |
@@ -78,6 +78,7 @@ The detailed contract and schemas are tracked in the repository:
 - [Response schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json)
 - [Browser view schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/browser-view.schema.json)
 - [tx.identify result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json)
+- [tx.witness.plan result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json)
 
 The same OpenAPI bundle is a flake output:
 

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -49,6 +49,12 @@ Transforming operations must return the resulting transaction as
 : Return stable transaction identifiers, byte-level metadata, and witness
   counts from the ledger-decoded transaction.
 
+`tx.witness.plan`
+: Return transaction-derived signer, witness, script, redeemer, datum, and
+  reference-input planning data. The current result warns when UTxO context is
+  not supplied because input address credentials and reference scripts cannot be
+  inferred from transaction CBOR alone.
+
 ## Contract Source
 
 The readable API page and detailed contract are tracked here:

--- a/justfile
+++ b/justfile
@@ -19,11 +19,15 @@ check-swagger:
 check-identify:
     nix build .#checks.x86_64-linux.tx-identify-smoke -o result-identify-smoke
 
+check-witness-plan:
+    nix build .#checks.x86_64-linux.tx-witness-plan-smoke -o result-witness-plan-smoke
+
 test-playwright: build-ui
     nix develop --quiet -c sh -c 'cd docs/inspector && ln -sfn $(dirname $(dirname $(readlink -f $(command -v playwright))))/lib/node_modules node_modules && TX_INSPECTOR_SITE_DIR=../../result playwright test --reporter=list'
 
 test:
     just check-identify
+    just check-witness-plan
     just test-playwright
 
 build-smokes:

--- a/nix/ledger-functional-openapi.nix
+++ b/nix/ledger-functional-openapi.nix
@@ -74,6 +74,15 @@
                     args = { };
                   };
                 };
+                witnessPlan = {
+                  summary = "Plan transaction witnesses";
+                  value = {
+                    ledger_functional_layer = "cardano-ledger-functional/v1";
+                    tx_cbor = "84a4...";
+                    op = "tx.witness.plan";
+                    args = { };
+                  };
+                };
                 balance = {
                   summary = "Target shape for best-effort balancing";
                   value = {
@@ -169,6 +178,52 @@
                       };
                     };
                   };
+                  witnessPlan = {
+                    summary = "Witness plan response envelope";
+                    value = {
+                      ledger_functional_layer = "cardano-ledger-functional/v1";
+                      op = "tx.witness.plan";
+                      result = {
+                        witness_plan = {
+                          required_signers = [ ];
+                          present_vkey_witnesses = [
+                            {
+                              hash = "00000000000000000000000000000000000000000000000000000000";
+                              source = "witness_set.vkey";
+                            }
+                          ];
+                          present_bootstrap_witnesses = [ ];
+                          missing_vkey_witnesses = [ ];
+                          scripts = [ ];
+                          redeemers = [
+                            {
+                              purpose = "ConwayMinting (AsIx {unAsIx = 0})";
+                              redeemer_data_hash = "2222222222222222222222222222222222222222222222222222222222222222";
+                              ex_units = {
+                                memory = 1;
+                                steps = 1;
+                              };
+                            }
+                          ];
+                          datums = [ ];
+                          reference_inputs = [ ];
+                          summary = {
+                            required_signer_count = 0;
+                            present_vkey_witness_count = 1;
+                            present_bootstrap_witness_count = 0;
+                            missing_vkey_witness_count = 0;
+                            script_count = 0;
+                            redeemer_count = 1;
+                            datum_count = 0;
+                            reference_input_count = 0;
+                          };
+                          warnings = [
+                            "Transaction-only witness plan: UTxO context was not supplied, so input address credentials, reference scripts, and datum requirements cannot be inferred."
+                          ];
+                        };
+                      };
+                    };
+                  };
                   patch = {
                     summary = "Target shape for a transforming operation";
                     value = {
@@ -223,6 +278,9 @@
       };
       TxIdentifyResult = {
         "$ref" = "tx-identify-result.schema.json";
+      };
+      TxWitnessPlanResult = {
+        "$ref" = "tx-witness-plan-result.schema.json";
       };
       LedgerOperationError = {
         type = "object";

--- a/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
+++ b/nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs
@@ -29,8 +29,10 @@ import qualified Cardano.Ledger.Conway.Scripts as ConwayScripts
 import Cardano.Ledger.Core (TxLevel (..))
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Hashes as Hashes
+import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.Plutus.Data as PData
+import qualified Cardano.Ledger.Plutus.ExUnits as ExUnits
 import qualified Cardano.Ledger.TxIn as TxIn
 import Control.Monad ((>=>))
 import Data.Aeson ((.=))
@@ -99,6 +101,7 @@ instance Aeson.FromJSON LedgerOperationRequest where
         normalizeOperation "inspect" = "tx.inspect"
         normalizeOperation "browse" = "tx.browse"
         normalizeOperation "identify" = "tx.identify"
+        normalizeOperation "witness.plan" = "tx.witness.plan"
         normalizeOperation op = op
 
 -- | Hex → bytes → Conway tx → JSON.
@@ -148,6 +151,12 @@ runLedgerOperation request = do
                 ledgerOperationResponse
                     (lorOperation request)
                     [ "identification" .= identifyJson txBytes tx
+                    ]
+        "tx.witness.plan" ->
+            pure $
+                ledgerOperationResponse
+                    (lorOperation request)
+                    [ "witness_plan" .= witnessPlanJson tx
                     ]
         other -> Left (UnknownLedgerOperation other)
 
@@ -362,6 +371,143 @@ identifyJson txBytes tx =
                     ]
             ]
 
+witnessPlanJson ::
+    L.Tx TopTx Conway.ConwayEra ->
+    Aeson.Value
+witnessPlanJson tx =
+    let body = tx ^. L.bodyTxL
+        wits = tx ^. Core.witsTxL
+        requiredSignerHexes =
+            keyHashHex <$> toList (body ^. L.reqSignerHashesTxBodyL)
+        presentVKeyHexes =
+            keyHashHex . Keys.witVKeyHash <$> toList (wits ^. Core.addrTxWitsL)
+        presentBootstrapHexes =
+            keyHashHex . Keys.bootstrapWitKeyHash
+                <$> toList (wits ^. Core.bootAddrTxWitsL)
+        presentSignerHexSet =
+            Set.fromList (presentVKeyHexes <> presentBootstrapHexes)
+        missingSignerHexes =
+            filter (`Set.notMember` presentSignerHexSet) requiredSignerHexes
+        scriptWitnesses =
+            Map.toList (wits ^. Core.scriptTxWitsL)
+        redeemers =
+            Map.toList (L.unRedeemers (wits ^. L.rdmrsTxWitsL))
+        datums =
+            Map.toList (L.unTxDats (wits ^. L.datsTxWitsL))
+        referenceInputs =
+            toList (body ^. L.referenceInputsTxBodyL)
+        warnings =
+            transactionOnlyWitnessPlanWarning
+                : if null missingSignerHexes
+                    then []
+                    else
+                        [ "Declared required signer hashes are absent from the witness set." ::
+                            T.Text
+                        ]
+     in Aeson.object
+            [ "required_signers" .= map requiredSignerJson requiredSignerHexes
+            , "present_vkey_witnesses"
+                .= map presentVKeyWitnessJson presentVKeyHexes
+            , "present_bootstrap_witnesses"
+                .= map presentBootstrapWitnessJson presentBootstrapHexes
+            , "missing_vkey_witnesses"
+                .= map missingSignerJson missingSignerHexes
+            , "scripts" .= map scriptWitnessJson scriptWitnesses
+            , "redeemers" .= map redeemerJson redeemers
+            , "datums" .= map datumWitnessJson datums
+            , "reference_inputs" .= map txInJson referenceInputs
+            , "summary"
+                .= Aeson.object
+                    [ "required_signer_count" .= length requiredSignerHexes
+                    , "present_vkey_witness_count" .= length presentVKeyHexes
+                    , "present_bootstrap_witness_count" .= length presentBootstrapHexes
+                    , "missing_vkey_witness_count" .= length missingSignerHexes
+                    , "script_count" .= length scriptWitnesses
+                    , "redeemer_count" .= length redeemers
+                    , "datum_count" .= length datums
+                    , "reference_input_count" .= length referenceInputs
+                    ]
+            , "warnings" .= warnings
+            ]
+
+transactionOnlyWitnessPlanWarning :: T.Text
+transactionOnlyWitnessPlanWarning =
+    "Transaction-only witness plan: UTxO context was not supplied, so input address credentials, reference scripts, and datum requirements cannot be inferred."
+
+requiredSignerJson :: T.Text -> Aeson.Value
+requiredSignerJson signerHash =
+    Aeson.object
+        [ "hash" .= signerHash
+        , "source" .= ("tx_body.required_signers" :: T.Text)
+        ]
+
+presentVKeyWitnessJson :: T.Text -> Aeson.Value
+presentVKeyWitnessJson signerHash =
+    Aeson.object
+        [ "hash" .= signerHash
+        , "source" .= ("witness_set.vkey" :: T.Text)
+        ]
+
+presentBootstrapWitnessJson :: T.Text -> Aeson.Value
+presentBootstrapWitnessJson signerHash =
+    Aeson.object
+        [ "hash" .= signerHash
+        , "source" .= ("witness_set.bootstrap" :: T.Text)
+        ]
+
+missingSignerJson :: T.Text -> Aeson.Value
+missingSignerJson signerHash =
+    Aeson.object
+        [ "hash" .= signerHash
+        , "reason"
+            .= ( "declared required signer not present in vkey or bootstrap witnesses" ::
+                    T.Text
+               )
+        ]
+
+scriptWitnessJson ::
+    (Hashes.ScriptHash, ConwayScripts.AlonzoScript Conway.ConwayEra) ->
+    Aeson.Value
+scriptWitnessJson (scriptHash, script) =
+    Aeson.object
+        [ "hash" .= scriptHashHex scriptHash
+        , "language" .= scriptWitnessLanguage script
+        , "source" .= ("witness_set.scripts" :: T.Text)
+        ]
+
+scriptWitnessLanguage ::
+    ConwayScripts.AlonzoScript Conway.ConwayEra ->
+    T.Text
+scriptWitnessLanguage = \case
+    ConwayScripts.NativeScript _ -> "native_script"
+    ConwayScripts.PlutusScript plutusScript ->
+        case plutusScript of
+            ConwayScripts.ConwayPlutusV1 _ -> "plutus_v1"
+            ConwayScripts.ConwayPlutusV2 _ -> "plutus_v2"
+            ConwayScripts.ConwayPlutusV3 _ -> "plutus_v3"
+
+redeemerJson ::
+    ( L.PlutusPurpose L.AsIx Conway.ConwayEra
+    , (PData.Data Conway.ConwayEra, ExUnits.ExUnits)
+    ) ->
+    Aeson.Value
+redeemerJson (purpose, (redeemerData, exUnits)) =
+    Aeson.object
+        [ "purpose" .= T.pack (show purpose)
+        , "redeemer_data_hash" .= safeHashHex (PData.hashData redeemerData)
+        , "ex_units" .= Aeson.toJSON exUnits
+        ]
+
+datumWitnessJson ::
+    (Hashes.DataHash, PData.Data Conway.ConwayEra) ->
+    Aeson.Value
+datumWitnessJson (dataHash, datumValue) =
+    Aeson.object
+        [ "hash" .= safeHashHex dataHash
+        , "computed_hash" .= safeHashHex (PData.hashData datumValue)
+        , "source" .= ("witness_set.datums" :: T.Text)
+        ]
+
 scriptWitnessCounts ::
     [ConwayScripts.AlonzoScript Conway.ConwayEra] ->
     (Int, Int, Int, Int)
@@ -486,6 +632,18 @@ txInJson (TxIn.TxIn (TxIn.TxId safeHash) (BaseTypes.TxIx ix)) =
 
 txIdHex :: TxIn.TxId -> T.Text
 txIdHex (TxIn.TxId safeHash) =
+    hashHex (Hashes.extractHash safeHash)
+
+keyHashHex :: Hashes.KeyHash r -> T.Text
+keyHashHex (Hashes.KeyHash h) =
+    hashHex h
+
+scriptHashHex :: Hashes.ScriptHash -> T.Text
+scriptHashHex (Hashes.ScriptHash h) =
+    hashHex h
+
+safeHashHex :: Hashes.SafeHash i -> T.Text
+safeHashHex safeHash =
     hashHex (Hashes.extractHash safeHash)
 
 hashHex :: Crypto.Hash h a -> T.Text

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -203,7 +203,7 @@ and null it is compact JSON.
 | `tx.inspect` | implemented | Decode transaction CBOR and return a compact summary plus root browser view. |
 | `tx.browse` | implemented | Decode transaction CBOR and return a browser view at a path. |
 | `tx.identify` | implemented | Return stable identifiers and metadata such as transaction id, body hash, era, size, and witness counts. |
-| `tx.witness.plan` | 0.1 target | Explain required signatures, scripts, redeemers, datums, and reference inputs. |
+| `tx.witness.plan` | implemented | Explain body-declared signer hashes, present witnesses, scripts, redeemers, datums, and reference inputs that are visible from the transaction alone. |
 | `tx.validate` | 0.1 target | Run ledger validation with explicit UTxO, protocol, epoch, slot, and network context. |
 | `tx.evaluate.scripts` | 0.1 target | Evaluate phase-2 scripts and report execution units or failures with explicit context. |
 | `tx.patch` | 0.1 target | Apply a controlled structural patch and return new transaction CBOR. |
@@ -289,37 +289,52 @@ identifiers plus byte-level metadata:
 
 Arguments: none.
 
+### `tx.witness.plan`
+
+Decode the supplied transaction CBOR with the Haskell ledger and return the
+transaction-derived witness plan:
+
+```json
+{
+  "witness_plan": {
+    "required_signers": [],
+    "present_vkey_witnesses": [],
+    "present_bootstrap_witnesses": [],
+    "missing_vkey_witnesses": [],
+    "scripts": [],
+    "redeemers": [],
+    "datums": [],
+    "reference_inputs": [],
+    "summary": {
+      "required_signer_count": 0,
+      "present_vkey_witness_count": 0,
+      "present_bootstrap_witness_count": 0,
+      "missing_vkey_witness_count": 0,
+      "script_count": 0,
+      "redeemer_count": 0,
+      "datum_count": 0,
+      "reference_input_count": 0
+    },
+    "warnings": []
+  }
+}
+```
+
+Arguments: none in the current implementation.
+
+The first implementation is intentionally transaction-only. It can compare
+`required_signers` from the transaction body with vkey/bootstrap witnesses
+already present in the witness set, and it can report script witnesses,
+redeemers, witness datums, and reference inputs. It cannot infer input address
+credentials, datum hashes needed by consumed UTxOs, or reference scripts without
+an explicit UTxO context, so it returns a warning when the plan is derived from
+the transaction alone.
+
 ## 0.1 Target Operations
 
 These operations define the next API surface. They are intentionally explicit
 about context because a transaction alone is not enough for full ledger checks
 or balancing.
-
-### `tx.witness.plan`
-
-Explain what witnesses are required or present. This is a planning operation,
-not signing.
-
-Arguments:
-
-`utxo`
-: Optional explicit UTxO set for referenced inputs when the plan needs output
-  addresses, scripts, datum hashes, or reference scripts.
-
-Result:
-
-```json
-{
-  "required_signers": [],
-  "present_vkey_witnesses": [],
-  "missing_vkey_witnesses": [],
-  "scripts": [],
-  "redeemers": [],
-  "datums": [],
-  "reference_inputs": [],
-  "warnings": []
-}
-```
 
 ### `tx.validate`
 
@@ -466,6 +481,7 @@ Machine-readable draft schemas are tracked next to this contract:
 - `../schemas/ledger-operation-response.schema.json`
 - `../schemas/browser-view.schema.json`
 - `../schemas/tx-identify-result.schema.json`
+- `../schemas/tx-witness-plan-result.schema.json`
 
 The OpenAPI document is packaged as the `ledger-functional-openapi` flake
 output and rendered by the published Swagger UI. The schemas describe the draft
@@ -485,3 +501,4 @@ Legacy operation names are normalized:
 | `inspect` | `tx.inspect` |
 | `browse` | `tx.browse` |
 | `identify` | `tx.identify` |
+| `witness.plan` | `tx.witness.plan` |

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -45,6 +45,9 @@
       },
       "TxIdentifyResult": {
         "$ref": "tx-identify-result.schema.json"
+      },
+      "TxWitnessPlanResult": {
+        "$ref": "tx-witness-plan-result.schema.json"
       }
     }
   },
@@ -125,6 +128,15 @@
                     "args": {},
                     "ledger_functional_layer": "cardano-ledger-functional/v1",
                     "op": "tx.inspect",
+                    "tx_cbor": "84a4..."
+                  }
+                },
+                "witnessPlan": {
+                  "summary": "Plan transaction witnesses",
+                  "value": {
+                    "args": {},
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "op": "tx.witness.plan",
                     "tx_cbor": "84a4..."
                   }
                 }
@@ -209,6 +221,52 @@
                         "changes": [],
                         "tx_cbor": "84a4...",
                         "warnings": []
+                      }
+                    }
+                  },
+                  "witnessPlan": {
+                    "summary": "Witness plan response envelope",
+                    "value": {
+                      "ledger_functional_layer": "cardano-ledger-functional/v1",
+                      "op": "tx.witness.plan",
+                      "result": {
+                        "witness_plan": {
+                          "datums": [],
+                          "missing_vkey_witnesses": [],
+                          "present_bootstrap_witnesses": [],
+                          "present_vkey_witnesses": [
+                            {
+                              "hash": "00000000000000000000000000000000000000000000000000000000",
+                              "source": "witness_set.vkey"
+                            }
+                          ],
+                          "redeemers": [
+                            {
+                              "ex_units": {
+                                "memory": 1,
+                                "steps": 1
+                              },
+                              "purpose": "ConwayMinting (AsIx {unAsIx = 0})",
+                              "redeemer_data_hash": "2222222222222222222222222222222222222222222222222222222222222222"
+                            }
+                          ],
+                          "reference_inputs": [],
+                          "required_signers": [],
+                          "scripts": [],
+                          "summary": {
+                            "datum_count": 0,
+                            "missing_vkey_witness_count": 0,
+                            "present_bootstrap_witness_count": 0,
+                            "present_vkey_witness_count": 1,
+                            "redeemer_count": 1,
+                            "reference_input_count": 0,
+                            "required_signer_count": 0,
+                            "script_count": 0
+                          },
+                          "warnings": [
+                            "Transaction-only witness plan: UTxO context was not supplied, so input address credentials, reference scripts, and datum requirements cannot be inferred."
+                          ]
+                        }
                       }
                     }
                   }

--- a/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-witness-plan-result.schema.json",
+  "title": "Cardano Ledger WASI tx.witness.plan Result",
+  "type": "object",
+  "required": [
+    "required_signers",
+    "present_vkey_witnesses",
+    "present_bootstrap_witnesses",
+    "missing_vkey_witnesses",
+    "scripts",
+    "redeemers",
+    "datums",
+    "reference_inputs",
+    "summary",
+    "warnings"
+  ],
+  "properties": {
+    "required_signers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/signer"
+      }
+    },
+    "present_vkey_witnesses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/signer"
+      }
+    },
+    "present_bootstrap_witnesses": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/signer"
+      }
+    },
+    "missing_vkey_witnesses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["hash", "reason"],
+        "properties": {
+          "hash": {
+            "$ref": "#/$defs/keyHash"
+          },
+          "reason": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "scripts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["hash", "language", "source"],
+        "properties": {
+          "hash": {
+            "$ref": "#/$defs/scriptHash"
+          },
+          "language": {
+            "type": "string",
+            "enum": ["native_script", "plutus_v1", "plutus_v2", "plutus_v3"]
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "redeemers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["purpose", "redeemer_data_hash", "ex_units"],
+        "properties": {
+          "purpose": {
+            "type": "string"
+          },
+          "redeemer_data_hash": {
+            "$ref": "#/$defs/hash32"
+          },
+          "ex_units": {
+            "type": "object",
+            "required": ["memory", "steps"],
+            "properties": {
+              "memory": {
+                "$ref": "#/$defs/count"
+              },
+              "steps": {
+                "$ref": "#/$defs/count"
+              }
+            },
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "datums": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["hash", "computed_hash", "source"],
+        "properties": {
+          "hash": {
+            "$ref": "#/$defs/hash32"
+          },
+          "computed_hash": {
+            "$ref": "#/$defs/hash32"
+          },
+          "source": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "reference_inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tx_id", "index"],
+        "properties": {
+          "tx_id": {
+            "$ref": "#/$defs/hash32"
+          },
+          "index": {
+            "$ref": "#/$defs/count"
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "summary": {
+      "type": "object",
+      "required": [
+        "required_signer_count",
+        "present_vkey_witness_count",
+        "present_bootstrap_witness_count",
+        "missing_vkey_witness_count",
+        "script_count",
+        "redeemer_count",
+        "datum_count",
+        "reference_input_count"
+      ],
+      "properties": {
+        "required_signer_count": {
+          "$ref": "#/$defs/count"
+        },
+        "present_vkey_witness_count": {
+          "$ref": "#/$defs/count"
+        },
+        "present_bootstrap_witness_count": {
+          "$ref": "#/$defs/count"
+        },
+        "missing_vkey_witness_count": {
+          "$ref": "#/$defs/count"
+        },
+        "script_count": {
+          "$ref": "#/$defs/count"
+        },
+        "redeemer_count": {
+          "$ref": "#/$defs/count"
+        },
+        "datum_count": {
+          "$ref": "#/$defs/count"
+        },
+        "reference_input_count": {
+          "$ref": "#/$defs/count"
+        }
+      },
+      "additionalProperties": true
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "signer": {
+      "type": "object",
+      "required": ["hash", "source"],
+      "properties": {
+        "hash": {
+          "$ref": "#/$defs/keyHash"
+        },
+        "source": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "keyHash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{56}$"
+    },
+    "scriptHash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{56}$"
+    },
+    "hash32": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the `tx.witness.plan` vertical slice for the functional ledger layer.

The operation is exposed by the WASI tx inspector as `tx.witness.plan` and keeps the same boundary discipline as the existing operations: the caller passes `tx_cbor` on every invocation, Haskell decodes the Conway transaction through the ledger packages, and the result is explicit JSON. The first slice is intentionally transaction-derived only. It reports what the transaction body and witness set already contain, and it returns a warning where UTxO context would be required to infer more.

## What Changed

- Added `tx.witness.plan` to the Haskell ledger operation dispatcher.
- Added witness-plan JSON for:
  - body-declared required signer hashes;
  - present vkey and bootstrap witness hashes;
  - declared signer hashes missing from the present witness set;
  - script witnesses and script languages;
  - redeemers with purpose, redeemer data hash, and execution units;
  - witness datums with hashes;
  - reference inputs;
  - summary counts and context warnings.
- Added the legacy compatibility normalization `witness.plan -> tx.witness.plan`.
- Added a Nix flake check and `just check-witness-plan` smoke test against the committed Conway fixture.
- Added the CI smoke step so the witness-plan response shape is checked in pull requests.
- Updated the functional API contract, GitHub Pages docs, OpenAPI examples, generated OpenAPI JSON, and added `tx-witness-plan-result.schema.json`.
- Added the witness-plan panel in the browser inspector, with non-copyable summary metrics and copy actions only on concrete row values such as hashes and reference tx ids.
- Added Playwright coverage for the new panel and its copy behavior.

## Current Boundary

This PR does not claim full witness inference. Without explicit UTxO context, the ledger layer cannot infer input address credentials, reference scripts, or datum requirements for consumed outputs. The response therefore includes the warning:

`Transaction-only witness plan: UTxO context was not supplied, so input address credentials, reference scripts, and datum requirements cannot be inferred.`

That limitation is part of the 0.1 API contract for this slice. Later `tx.validate`, `tx.evaluate.scripts`, and richer witness planning should receive UTxO/protocol context explicitly in `args`.

## Preview

Surge preview: https://cardano-tx-inspector.surge.sh

I decoded the committed Conway fixture against the deployed Surge preview and verified that the `Witness plan` panel renders, the transaction-only warning is visible, the redeemer row is visible, and the page has no horizontal overflow in the tested viewport.

## Verification

- `just check-swagger`
- `just check-witness-plan`
- `just test`
- `just build-pages-site`
- `nix develop --quiet -c fourmolu -m check nix/wasm/tx-inspector/wasm-tx-inspector/src/Conway/Inspector.hs`
- `git diff --check`

Known unrelated check status: full `just format-check` still fails on pre-existing formatting drift in `nix/wasm/smoke` and `nix/wasm/ledger-smoke`; this PR's touched Haskell file passes Fourmolu directly.
