### PR TITLE
feat: narrow provider interface to tx cbor

### DIFF
--- a/docs/inspector/src/FFI/Blockfrost.js
+++ b/docs/inspector/src/FFI/Blockfrost.js
@@ -8,10 +8,6 @@ const BASES = {
 };
 
 export const fetchTxCborImpl = (network) => (projectId) => (txHash) => async () => {
-  return fetchTxCborRaw(network, projectId, txHash);
-};
-
-const fetchTxCborRaw = async (network, projectId, txHash) => {
   const base = BASES[network] || BASES.mainnet;
   const resp = await fetch(`${base}/txs/${txHash}/cbor`, {
     headers: { project_id: projectId },
@@ -23,84 +19,3 @@ const fetchTxCborRaw = async (network, projectId, txHash) => {
   const json = await resp.json();
   return json.cbor;
 };
-
-const operationResult = (parsed) => parsed?.result ?? parsed;
-
-const inputKey = (input) => `${input.tx_id}#${input.index}`;
-
-const isTxIn = (input) =>
-  input &&
-  typeof input === "object" &&
-  /^[0-9a-fA-F]{64}$/.test(String(input.tx_id || "")) &&
-  Number.isInteger(Number(input.index));
-
-const uniqueTxIns = (inputs) => {
-  const seen = new Set();
-  const txIns = [];
-  for (const input of inputs.filter(isTxIn)) {
-    const txIn = {
-      tx_id: String(input.tx_id).toLowerCase(),
-      index: Number(input.index),
-    };
-    const key = inputKey(txIn);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    txIns.push({ ...txIn, key });
-  }
-  return txIns;
-};
-
-const extractInspectionInputs = (inspectionResponse) => {
-  const parsed = JSON.parse(inspectionResponse);
-  const inspection = operationResult(parsed)?.inspection ?? operationResult(parsed);
-  const inputs = Array.isArray(inspection?.inputs) ? inspection.inputs : [];
-  const referenceInputs = Array.isArray(inspection?.reference_inputs)
-    ? inspection.reference_inputs
-    : [];
-  return {
-    inputs: uniqueTxIns(inputs),
-    referenceInputs: uniqueTxIns(referenceInputs),
-  };
-};
-
-export const resolveInputContextImpl =
-  (network) => (projectId) => (inspectionResponse) => async () => {
-    const { inputs, referenceInputs } = extractInspectionInputs(inspectionResponse);
-    const requestedTxIds = [
-      ...new Set([...inputs, ...referenceInputs].map((input) => input.tx_id)),
-    ];
-    const producerTxs = {};
-    const missing = [];
-    const errors = [];
-
-    for (const txId of requestedTxIds) {
-      try {
-        const cbor = await fetchTxCborRaw(network, projectId, txId);
-        producerTxs[txId] = {
-          tx_cbor: cbor,
-          source: "blockfrost.txs.cbor",
-        };
-      } catch (err) {
-        missing.push(txId);
-        errors.push(`${txId}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-
-    return JSON.stringify({
-      input_policy: "preserve",
-      context: {
-        producer_txs: producerTxs,
-        resolution: {
-          provider: "blockfrost",
-          source: "tx-cbor",
-          requested_input_count: inputs.length,
-          requested_reference_input_count: referenceInputs.length,
-          requested_tx_count: requestedTxIds.length,
-          resolved_count: Object.keys(producerTxs).length,
-          missing,
-          errors,
-          unspent_status: "not_checked",
-        },
-      },
-    });
-  };

--- a/docs/inspector/src/FFI/Blockfrost.purs
+++ b/docs/inspector/src/FFI/Blockfrost.purs
@@ -2,7 +2,7 @@ module FFI.Blockfrost
   ( Network(..)
   , networkName
   , fetchTxCbor
-  , resolveInputContext
+  , fetchTxCborEffect
   ) where
 
 import Prelude
@@ -27,16 +27,10 @@ foreign import fetchTxCborImpl
   -> String -- tx hash
   -> Effect (Promise String)
 
-foreign import resolveInputContextImpl
-  :: String -- network
-  -> String -- projectId
-  -> String -- tx.inspect response
-  -> Effect (Promise String)
-
 fetchTxCbor :: Network -> String -> String -> Aff String
 fetchTxCbor net projectId hash =
-  toAffE (fetchTxCborImpl (networkName net) projectId hash)
+  toAffE (fetchTxCborEffect net projectId hash)
 
-resolveInputContext :: Network -> String -> String -> Aff String
-resolveInputContext net projectId inspectionResponse =
-  toAffE (resolveInputContextImpl (networkName net) projectId inspectionResponse)
+fetchTxCborEffect :: Network -> String -> String -> Effect (Promise String)
+fetchTxCborEffect net projectId hash =
+  fetchTxCborImpl (networkName net) projectId hash

--- a/docs/inspector/src/FFI/Koios.purs
+++ b/docs/inspector/src/FFI/Koios.purs
@@ -1,8 +1,7 @@
 module FFI.Koios
   ( fetchTxCbor
+  , fetchTxCborEffect
   ) where
-
-import Prelude
 
 import Control.Promise (Promise, toAffE)
 import Effect (Effect)
@@ -17,4 +16,8 @@ foreign import fetchTxCborImpl
 
 fetchTxCbor :: Network -> String -> String -> Aff String
 fetchTxCbor net bearer hash =
-  toAffE (fetchTxCborImpl (networkName net) bearer hash)
+  toAffE (fetchTxCborEffect net bearer hash)
+
+fetchTxCborEffect :: Network -> String -> String -> Effect (Promise String)
+fetchTxCborEffect net bearer hash =
+  fetchTxCborImpl (networkName net) bearer hash

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -12,7 +12,6 @@ import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Effect.Exception (message)
 import FFI.Blockfrost (Network(..))
-import FFI.Blockfrost as BF
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runLedgerOperation)
 import FFI.Json (Browser, Identification, WitnessPlan, inspect, operationArgsWithPath, operationBrowser, operationIdentification, operationInspection, operationWitnessPlan, pretty) as Json
@@ -822,14 +821,21 @@ inspectorComponent initial =
         Left err -> H.modify_ _ { running = false, fetchError = Just err, browserPath = "[]" }
         Right h -> do
           operationResult <- H.liftAff (runLedgerOperation h "tx.inspect" "{}")
-          inputContextArgs <- case st.provider of
-            Blockfrost | operationResult.exitOk && String.trim st.blockfrostKey /= "" -> do
+          let
+            providerKeyValue = case st.provider of
+              Blockfrost -> String.trim st.blockfrostKey
+              Koios      -> String.trim st.koiosBearer
+            canResolveContext =
+              operationResult.exitOk
+                && (not (Provider.needsKey st.provider) || providerKeyValue /= "")
+          inputContextArgs <-
+            if canResolveContext then do
               ctx <- H.liftAff
-                (attempt (BF.resolveInputContext st.network (String.trim st.blockfrostKey) operationResult.stdout))
+                (attempt (Provider.resolveProducerTxContext st.provider st.network providerKeyValue operationResult.stdout))
               case ctx of
                 Right args -> pure args
                 Left _     -> pure "{}"
-            _ -> pure "{}"
+            else pure "{}"
           identifyResult <- H.liftAff (runLedgerOperation h "tx.identify" inputContextArgs)
           witnessPlanResult <- H.liftAff (runLedgerOperation h "tx.witness.plan" inputContextArgs)
           let

--- a/docs/inspector/src/Provider.js
+++ b/docs/inspector/src/Provider.js
@@ -1,0 +1,80 @@
+const operationResult = (parsed) => parsed?.result ?? parsed;
+
+const inputKey = (input) => `${input.tx_id}#${input.index}`;
+
+const isTxIn = (input) =>
+  input &&
+  typeof input === "object" &&
+  /^[0-9a-fA-F]{64}$/.test(String(input.tx_id || "")) &&
+  Number.isInteger(Number(input.index));
+
+const uniqueTxIns = (inputs) => {
+  const seen = new Set();
+  const txIns = [];
+  for (const input of inputs.filter(isTxIn)) {
+    const txIn = {
+      tx_id: String(input.tx_id).toLowerCase(),
+      index: Number(input.index),
+    };
+    const key = inputKey(txIn);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    txIns.push({ ...txIn, key });
+  }
+  return txIns;
+};
+
+const extractInspectionInputs = (inspectionResponse) => {
+  const parsed = JSON.parse(inspectionResponse);
+  const inspection = operationResult(parsed)?.inspection ?? operationResult(parsed);
+  const inputs = Array.isArray(inspection?.inputs) ? inspection.inputs : [];
+  const referenceInputs = Array.isArray(inspection?.reference_inputs)
+    ? inspection.reference_inputs
+    : [];
+  return {
+    inputs: uniqueTxIns(inputs),
+    referenceInputs: uniqueTxIns(referenceInputs),
+  };
+};
+
+export const resolveProducerTxContextImpl =
+  (provider) => (source) => (inspectionResponse) => (fetchTxCbor) => async () => {
+    const { inputs, referenceInputs } = extractInspectionInputs(inspectionResponse);
+    const requestedTxIds = [
+      ...new Set([...inputs, ...referenceInputs].map((input) => input.tx_id)),
+    ];
+    const producerTxs = {};
+    const missing = [];
+    const errors = [];
+
+    for (const txId of requestedTxIds) {
+      try {
+        const cbor = await fetchTxCbor(txId)();
+        producerTxs[txId] = {
+          tx_cbor: cbor,
+          source,
+        };
+      } catch (err) {
+        missing.push(txId);
+        errors.push(`${txId}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    return JSON.stringify({
+      input_policy: "preserve",
+      context: {
+        producer_txs: producerTxs,
+        resolution: {
+          provider,
+          source: "tx-cbor",
+          requested_input_count: inputs.length,
+          requested_reference_input_count: referenceInputs.length,
+          requested_tx_count: requestedTxIds.length,
+          resolved_count: Object.keys(producerTxs).length,
+          missing,
+          errors,
+          unspent_status: "not_checked",
+        },
+      },
+    });
+  };

--- a/docs/inspector/src/Provider.purs
+++ b/docs/inspector/src/Provider.purs
@@ -3,10 +3,13 @@ module Provider
   , providerName
   , needsKey
   , fetchTxCbor
+  , resolveProducerTxContext
   ) where
 
 import Prelude
 
+import Control.Promise (Promise, toAffE)
+import Effect (Effect)
 import Effect.Aff (Aff)
 import FFI.Blockfrost (Network)
 import FFI.Blockfrost as Blockfrost
@@ -32,6 +35,37 @@ needsKey = case _ of
 -- | Unified fetch. `key` is the project ID for Blockfrost or an optional
 -- bearer token for Koios (empty string = no auth).
 fetchTxCbor :: Provider -> Network -> String -> String -> Aff String
-fetchTxCbor = case _ of
-  Blockfrost -> Blockfrost.fetchTxCbor
-  Koios      -> Koios.fetchTxCbor
+fetchTxCbor provider network key txId =
+  toAffE (fetchTxCborEffect provider network key txId)
+
+resolveProducerTxContext :: Provider -> Network -> String -> String -> Aff String
+resolveProducerTxContext provider network key inspectionResponse =
+  toAffE
+    ( resolveProducerTxContextImpl
+        (resolutionProvider provider)
+        (producerTxSource provider)
+        inspectionResponse
+        (\txId -> fetchTxCborEffect provider network key txId)
+    )
+
+fetchTxCborEffect :: Provider -> Network -> String -> String -> Effect (Promise String)
+fetchTxCborEffect = case _ of
+  Blockfrost -> Blockfrost.fetchTxCborEffect
+  Koios      -> Koios.fetchTxCborEffect
+
+resolutionProvider :: Provider -> String
+resolutionProvider = case _ of
+  Blockfrost -> "blockfrost"
+  Koios      -> "koios"
+
+producerTxSource :: Provider -> String
+producerTxSource = case _ of
+  Blockfrost -> "blockfrost.txs.cbor"
+  Koios      -> "koios.tx_cbor"
+
+foreign import resolveProducerTxContextImpl
+  :: String -- provider
+  -> String -- producer tx source
+  -> String -- tx.inspect response
+  -> (String -> Effect (Promise String)) -- fetchTxCbor by tx id
+  -> Effect (Promise String)

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -144,6 +144,36 @@ test("passes producer transaction CBOR into witness planning", async ({
   expect(copied).toMatch(/^[0-9a-f]{64}#[0-9]+$/);
 });
 
+test("uses the same tx CBOR provider boundary for Koios", async ({ page }) => {
+  const txCbor = (await readFile(fixturePath, "utf8")).trim();
+  let koiosCborRequests = 0;
+
+  await installClipboardMock(page);
+  await page.route("https://api.koios.rest/api/v1/tx_cbor", async (route) => {
+    koiosCborRequests += 1;
+    const requestBody = route.request().postDataJSON();
+    expect(requestBody._tx_hashes).toHaveLength(1);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ cbor: txCbor }]),
+    });
+  });
+
+  await page.goto("/");
+  await page.getByRole("radio", { name: "Koios" }).check();
+  await page.getByPlaceholder("eyJhbGciOi...").fill("koios-test-token");
+  await page.getByRole("radio", { name: "CBOR hex" }).check();
+  await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
+  await page.getByRole("button", { name: "Decode" }).click();
+
+  await expect(
+    page.getByText("Producer transaction CBOR resolved every visible transaction input"),
+  ).toBeVisible();
+  await expect(page.getByText("Producer txs")).toBeVisible();
+  expect(koiosCborRequests).toBeGreaterThan(0);
+});
+
 test("opens browser rows in place without losing identity context", async ({
   page,
 }) => {

--- a/gh-docs/api.md
+++ b/gh-docs/api.md
@@ -51,6 +51,19 @@ decodes those producer transactions and derives referenced outputs by
 Producer transaction bytes are immutable. Live unspent status is mutable and
 must be checked again before submission or live-chain validation.
 
+## Provider Boundary
+
+Provider adapters expose the same byte-level function for opening a transaction
+and resolving producer context:
+
+```text
+fetchTxCbor(network, credentials, tx_id) -> tx_cbor
+```
+
+Provider-specific UTxO JSON is not part of the ledger functional interface.
+The host builds `context.producer_txs` from fetched transaction CBOR, and the
+Haskell ledger layer derives referenced outputs.
+
 ## Implemented Operations
 
 | Operation | Description |

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -51,6 +51,20 @@ Producer transaction CBOR is stable because transaction bytes are immutable.
 The ledger layer derives referenced outputs by `tx_id#index`. Current unspent
 status is not stable and belongs to live-chain validation or submission checks.
 
+## Provider Boundary
+
+Browser provider adapters expose one capability for the current 0.1 inspection
+path:
+
+```text
+fetchTxCbor(network, credentials, tx_id) -> tx_cbor
+```
+
+The same capability opens the user-selected transaction and fetches producer
+transactions needed for input context. Provider modules do not expose UTxO JSON
+projection or ledger reconstruction helpers; producer-context arguments are
+built by the host and interpreted by the Haskell ledger layer.
+
 ## Current Operations
 
 `tx.inspect`

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -69,6 +69,22 @@ Producer transaction data and live chain status are intentionally separate:
 - Live unspent status is mutable and must be checked again before submission or
   live-chain validation.
 
+## Provider Boundary
+
+Provider adapters are byte fetchers, not ledger interpreters. The current
+required provider capability is:
+
+```text
+fetchTxCbor(network, credentials, tx_id) -> tx_cbor
+```
+
+The same function opens the transaction selected by hash and fetches producer
+transactions for `context.producer_txs`. Provider modules MUST NOT expose
+provider-specific UTxO JSON as the core ledger interface. If later operations
+need additional mutable chain state, that capability must be added explicitly
+with a ledger-facing schema and must not replace transaction CBOR as the byte
+data plane.
+
 `input_policy` has three draft values:
 
 `preserve`


### PR DESCRIPTION
## Summary

Closes #14.

This PR narrows the browser provider boundary to the one capability the current ledger-functional flow actually needs:

```text
fetchTxCbor(network, credentials, tx_id) -> tx_cbor
```

It is stacked on #12, which changes input context to `args.context.producer_txs` and lets Haskell derive referenced `TxOut`s from producer transaction CBOR.

## What Changed

- Removed the Blockfrost-specific `resolveInputContext` FFI export.
- Kept provider modules byte-oriented: `FFI.Blockfrost` and `FFI.Koios` now expose tx-CBOR fetch effects only.
- Added generic provider-context construction in `Provider`, which extracts visible input producer tx ids from the `tx.inspect` result and calls the selected provider's `fetchTxCbor` for each one.
- Let both Blockfrost and Koios use the same producer-context path for witness planning.
- Documented the provider boundary in the API docs, functional-layer docs, and contract.
- Added Playwright coverage proving Koios also feeds producer transaction CBOR through the same boundary.

## Boundary

This deliberately does not add a provider SDK, live UTxO lookup, submission API, or coin-selection provider abstraction. Future mutable chain-state capabilities should be added only when a concrete ledger operation needs them and with an explicit ledger-facing schema.

## Verification

- `just ui-check`
- `just test-playwright`
- `just test`
- `just build-pages-site`
- `just check-openapi`
- `just check-swagger`
- `git diff --check`