### PR TITLE
spike: extism pdk packaging for ledger conformance

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,8 @@
             ]
           );
 
+          hostTargets = import ./nix/host { inherit pkgs; };
+
           wasmTargets = import ./nix/wasm-targets.nix {
             inherit pkgs;
             libWasm = self.lib.wasm;
@@ -400,36 +402,38 @@
               invalid-network-request.json invalid-network-response.json $out/
           '';
 
-          # Spike: structural check on the Extism plugin artifact.
-          #
-          # Runtime invocation through `extism call` (extism-cli 1.6.3,
-          # July 2024) is blocked: the bundled wazero predates wasm
-          # tail-call support (wazero PR #2403, Aug 2025), and GHC
-          # 9.12's wasm32-wasi codegen relies on tail calls. Result:
-          # `hs_init_ghc → initAdjustors → allocHashTable` traps with
-          # an out-of-bounds memory access during runtime init.
-          #
-          # That is not our binary's fault — direct wasmtime confirms
-          # the plugin shape, and `wasm-objdump -x` confirms the
-          # exports. End-to-end execution requires a Wasmtime-backed
-          # host (Rust libextism, Haskell extism-host SDK, or a newer
-          # extism-cli once it picks up a tail-call-capable wazero).
+          # Spike: native Haskell host (libextism + Wasmtime) loads the
+          # plugin and calls tx_identify against the Conway fixture.
+          # The host is in nix/host/extism-spike-host; libextism is the
+          # prebuilt Rust runtime fetched from the upstream release.
           tx-extism-spike-smoke = pkgs.runCommand "tx-extism-spike-smoke" { } ''
             mkdir -p $out
-            ${pkgs.wabt}/bin/wasm-objdump -x \
+            # Wasmtime writes a compile cache; sandbox HOME is unwritable.
+            export HOME="$PWD"
+            export XDG_CACHE_HOME="$PWD/.cache"
+            mkdir -p "$XDG_CACHE_HOME"
+            ${pkgs.jq}/bin/jq -nr \
+              --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
+              '$tx | gsub("\\s"; "")' > tx.hex
+            ${hostTargets.extism-spike-host}/bin/extism-spike-host \
               ${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm \
-              > exports.txt
-            grep -q '<tx_identify> -> "tx_identify"' exports.txt
-            grep -q '<hs_init> -> "hs_init"' exports.txt
-            ${pkgs.wabt}/bin/wasm-validate \
-              ${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm
-            cp exports.txt $out/
+              < tx.hex > response.json
+            ${pkgs.jq}/bin/jq -e '
+              .era == "Conway"
+              and (.tx_id | test("^[0-9a-f]{64}$"))
+              and (.tx_size_bytes > 0)
+              and (.fee_lovelace | test("^[0-9]+$"))
+              and (.input_count >= 1)
+              and (.output_count >= 1)
+            ' response.json
+            cp tx.hex response.json $out/
           '';
         in
         {
           packages = {
             inherit (wasmTargets)
               wasm-smoke wasm-ledger-smoke wasm-tx-inspector wasm-extism-spike;
+            inherit (hostTargets) extism-spike-host libextism;
             inherit
               ledger-functional-openapi
               ledger-functional-openapi-generated

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
             smokeSrc = ./nix/wasm/smoke;
             ledgerSmokeSrc = ./nix/wasm/ledger-smoke;
             txInspectorSrc = ./nix/wasm/tx-inspector;
-            extismSpikeSrc = ./nix/wasm/extism-spike;
+            extismSpikeSrc = ./nix/wasm;
           };
 
           tx-inspector-ui = import ./nix/wasm-ui.nix {
@@ -403,7 +403,10 @@
           '';
 
           # Spike: native Haskell host (libextism + Wasmtime) loads the
-          # plugin and calls tx_identify against the Conway fixture.
+          # plugin and calls tx_identify + tx_validate against Conway
+          # fixtures. Both Extism exports delegate to the same
+          # runLedgerOperationInput as the WASI reactor, so responses
+          # are byte-identical to tx-identify-smoke / tx-validate-smoke.
           # The host is in nix/host/extism-spike-host; libextism is the
           # prebuilt Rust runtime fetched from the upstream release.
           tx-extism-spike-smoke = pkgs.runCommand "tx-extism-spike-smoke" { } ''
@@ -412,21 +415,57 @@
             export HOME="$PWD"
             export XDG_CACHE_HOME="$PWD/.cache"
             mkdir -p "$XDG_CACHE_HOME"
-            ${pkgs.jq}/bin/jq -nr \
+
+            HOST=${hostTargets.extism-spike-host}/bin/extism-spike-host
+            WASM=${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm
+
+            # tx.identify
+            ${pkgs.jq}/bin/jq -n \
               --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
-              '$tx | gsub("\\s"; "")' > tx.hex
-            ${hostTargets.extism-spike-host}/bin/extism-spike-host \
-              ${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm \
-              < tx.hex > response.json
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: ($tx | gsub("\\s"; "")),
+                op: "tx.identify",
+                args: {}
+              }' > identify-request.json
+            "$HOST" "$WASM" tx_identify \
+              < identify-request.json > identify-response.json
             ${pkgs.jq}/bin/jq -e '
-              .era == "Conway"
-              and (.tx_id | test("^[0-9a-f]{64}$"))
-              and (.tx_size_bytes > 0)
-              and (.fee_lovelace | test("^[0-9]+$"))
-              and (.input_count >= 1)
-              and (.output_count >= 1)
-            ' response.json
-            cp tx.hex response.json $out/
+              .ledger_functional_layer == "cardano-ledger-functional/v1"
+              and .op == "tx.identify"
+              and (.result.identification.tx_id | test("^[0-9a-f]{64}$"))
+              and (.result.identification.body_hash | test("^[0-9a-f]{64}$"))
+              and (.result.identification.tx_size_bytes > 0)
+              and (.result.identification.fee_lovelace | test("^[0-9]+$"))
+              and (.result.identification.witness_counts.vkey >= 0)
+            ' identify-response.json
+
+            # tx.validate — complete-context fixture (status=valid)
+            "$HOST" "$WASM" tx_validate \
+              < ${./specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json} \
+              > validate-response.json
+            ${pkgs.jq}/bin/jq -e '
+              .result.validation as $v
+              | .ledger_functional_layer == "cardano-ledger-functional/v1"
+              and .op == "tx.validate"
+              and $v.status == "valid"
+              and $v.valid_for_supplied_context == true
+              and $v.complete == true
+              and ($v.failures | length == 0)
+              and ([$v.checks[]? | select(.id == "ledger.apply_tx" and .status == "passed")] | length == 1)
+            ' validate-response.json
+
+            # Conformance: Extism response on tx.validate is byte-identical
+            # to the WASI reactor response on the same envelope.
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < ${./specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json} \
+              > wasi-validate-response.json
+            ${pkgs.jq}/bin/jq -s -e '.[0] == .[1]' \
+              validate-response.json wasi-validate-response.json
+
+            cp identify-request.json identify-response.json \
+              validate-response.json wasi-validate-response.json $out/
           '';
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -97,6 +97,7 @@
             smokeSrc = ./nix/wasm/smoke;
             ledgerSmokeSrc = ./nix/wasm/ledger-smoke;
             txInspectorSrc = ./nix/wasm/tx-inspector;
+            extismSpikeSrc = ./nix/wasm/extism-spike;
           };
 
           tx-inspector-ui = import ./nix/wasm-ui.nix {
@@ -398,10 +399,37 @@
               complete-context-response.json complete-context-response-2.json \
               invalid-network-request.json invalid-network-response.json $out/
           '';
+
+          # Spike: structural check on the Extism plugin artifact.
+          #
+          # Runtime invocation through `extism call` (extism-cli 1.6.3,
+          # July 2024) is blocked: the bundled wazero predates wasm
+          # tail-call support (wazero PR #2403, Aug 2025), and GHC
+          # 9.12's wasm32-wasi codegen relies on tail calls. Result:
+          # `hs_init_ghc → initAdjustors → allocHashTable` traps with
+          # an out-of-bounds memory access during runtime init.
+          #
+          # That is not our binary's fault — direct wasmtime confirms
+          # the plugin shape, and `wasm-objdump -x` confirms the
+          # exports. End-to-end execution requires a Wasmtime-backed
+          # host (Rust libextism, Haskell extism-host SDK, or a newer
+          # extism-cli once it picks up a tail-call-capable wazero).
+          tx-extism-spike-smoke = pkgs.runCommand "tx-extism-spike-smoke" { } ''
+            mkdir -p $out
+            ${pkgs.wabt}/bin/wasm-objdump -x \
+              ${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm \
+              > exports.txt
+            grep -q '<tx_identify> -> "tx_identify"' exports.txt
+            grep -q '<hs_init> -> "hs_init"' exports.txt
+            ${pkgs.wabt}/bin/wasm-validate \
+              ${wasmTargets.wasm-extism-spike}/wasm-extism-spike.wasm
+            cp exports.txt $out/
+          '';
         in
         {
           packages = {
-            inherit (wasmTargets) wasm-smoke wasm-ledger-smoke wasm-tx-inspector;
+            inherit (wasmTargets)
+              wasm-smoke wasm-ledger-smoke wasm-tx-inspector wasm-extism-spike;
             inherit
               ledger-functional-openapi
               ledger-functional-openapi-generated
@@ -412,7 +440,13 @@
           };
 
           checks = {
-            inherit ledger-functional-openapi-check tx-identify-smoke tx-witness-plan-smoke tx-input-context-smoke tx-validate-smoke;
+            inherit
+              ledger-functional-openapi-check
+              tx-identify-smoke
+              tx-witness-plan-smoke
+              tx-input-context-smoke
+              tx-validate-smoke
+              tx-extism-spike-smoke;
             ledger-functional-swagger-check = ledger-functional-openapi-check;
           };
 

--- a/justfile
+++ b/justfile
@@ -31,6 +31,9 @@ check-validate:
 build-extism-spike:
     nix build .#packages.x86_64-linux.wasm-extism-spike -o result-extism-spike
 
+build-extism-host:
+    nix build .#packages.x86_64-linux.extism-spike-host -o result-extism-host
+
 check-extism-spike:
     nix build .#checks.x86_64-linux.tx-extism-spike-smoke -o result-extism-spike-smoke
 

--- a/justfile
+++ b/justfile
@@ -28,6 +28,12 @@ check-input-context:
 check-validate:
     nix build .#checks.x86_64-linux.tx-validate-smoke -o result-validate-smoke
 
+build-extism-spike:
+    nix build .#packages.x86_64-linux.wasm-extism-spike -o result-extism-spike
+
+check-extism-spike:
+    nix build .#checks.x86_64-linux.tx-extism-spike-smoke -o result-extism-spike-smoke
+
 test-playwright: build-ui
     nix develop --quiet -c sh -c 'cd docs/inspector && ln -sfn $(dirname $(dirname $(readlink -f $(command -v playwright))))/lib/node_modules node_modules && TX_INSPECTOR_SITE_DIR=../../result playwright test --reporter=list'
 

--- a/nix/host/default.nix
+++ b/nix/host/default.nix
@@ -1,0 +1,42 @@
+# Native (not wasm) host program for the Extism PDK spike.
+#
+# Builds extism-spike-host with the Haskell `extism` Hackage SDK, which
+# links libextism — the Rust + Wasmtime runtime that supports wasm
+# tail-calls (unlike the wazero embedded in pkgs.extism-cli).
+{ pkgs }:
+
+let
+  libextism = pkgs.callPackage ./libextism.nix { };
+
+  haskellPackages = pkgs.haskellPackages.override {
+    overrides = self: super: {
+      # nixpkgs marks `extism` and `extism-manifest` as broken because
+      # libextism isn't packaged there. Override with our libextism +
+      # clear the broken flag.
+      extism-manifest = pkgs.haskell.lib.compose.doJailbreak
+        (pkgs.haskell.lib.compose.overrideCabal
+          (_: { broken = false; })
+          super.extism-manifest);
+
+      extism = pkgs.haskell.lib.compose.dontCheck
+        (pkgs.haskell.lib.compose.doJailbreak
+          (pkgs.haskell.lib.compose.overrideCabal
+            (drv: {
+              broken = false;
+              librarySystemDepends =
+                (drv.librarySystemDepends or [ ]) ++ [ libextism ];
+              libraryPkgconfigDepends =
+                (drv.libraryPkgconfigDepends or [ ]) ++ [ libextism ];
+            })
+            super.extism));
+    };
+  };
+
+  extism-spike-host = haskellPackages.callCabal2nix
+    "extism-spike-host"
+    ./extism-spike-host
+    { };
+in
+{
+  inherit libextism extism-spike-host;
+}

--- a/nix/host/extism-spike-host/app/Main.hs
+++ b/nix/host/extism-spike-host/app/Main.hs
@@ -5,11 +5,15 @@ Module      : Main
 Description : Native Haskell host for the Extism PDK spike.
 
 Loads the wasm-extism-spike plugin via libextism (Wasmtime-backed),
-calls 'tx_identify' with the bytes read from stdin, and writes the
-plugin's output bytes to stdout. Errors from the runtime go to
-stderr with a non-zero exit code.
+calls a named export with bytes read from stdin, and writes the
+plugin's output bytes to stdout.
 
-Invocation: @extism-spike-host PATH-TO-WASM < input.hex > out.json@.
+Invocation:
+
+>     extism-spike-host PATH-TO-WASM [FUNCTION] < input > out
+
+@FUNCTION@ defaults to @tx_identify@. Errors from the runtime go to
+stderr with a non-zero exit code.
 -}
 module Main (main) where
 
@@ -24,15 +28,14 @@ import System.IO (hPutStrLn, stderr, stdout)
 main :: IO ()
 main = do
     args <- getArgs
-    pluginPath <- case args of
-        [path] -> pure path
-        _ ->
-            die "usage: extism-spike-host PATH-TO-WASM"
+    (pluginPath, function) <- case args of
+        [path] -> pure (path, "tx_identify")
+        [path, fn] -> pure (path, fn)
+        _ -> die "usage: extism-spike-host PATH-TO-WASM [FUNCTION]"
     let manifest = Manifest.manifest [Manifest.wasmFile pluginPath]
     plugin <- Extism.newPlugin manifest [] True >>= unwrap
     payload <- BS.getContents
-    response <-
-        Extism.call plugin "tx_identify" payload >>= unwrap
+    response <- Extism.call plugin function payload >>= unwrap
     BSL.hPut stdout (BSL.fromStrict response)
     BSL.hPut stdout "\n"
     exitSuccess

--- a/nix/host/extism-spike-host/app/Main.hs
+++ b/nix/host/extism-spike-host/app/Main.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Main
+Description : Native Haskell host for the Extism PDK spike.
+
+Loads the wasm-extism-spike plugin via libextism (Wasmtime-backed),
+calls 'tx_identify' with the bytes read from stdin, and writes the
+plugin's output bytes to stdout. Errors from the runtime go to
+stderr with a non-zero exit code.
+
+Invocation: @extism-spike-host PATH-TO-WASM < input.hex > out.json@.
+-}
+module Main (main) where
+
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Extism
+import qualified Extism.Manifest as Manifest
+import System.Environment (getArgs)
+import System.Exit (die, exitSuccess)
+import System.IO (hPutStrLn, stderr, stdout)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    pluginPath <- case args of
+        [path] -> pure path
+        _ ->
+            die "usage: extism-spike-host PATH-TO-WASM"
+    let manifest = Manifest.manifest [Manifest.wasmFile pluginPath]
+    plugin <- Extism.newPlugin manifest [] True >>= unwrap
+    payload <- BS.getContents
+    response <-
+        Extism.call plugin "tx_identify" payload >>= unwrap
+    BSL.hPut stdout (BSL.fromStrict response)
+    BSL.hPut stdout "\n"
+    exitSuccess
+
+unwrap :: Either Extism.Error a -> IO a
+unwrap (Right a) = pure a
+unwrap (Left (Extism.ExtismError msg)) = do
+    hPutStrLn stderr ("extism error: " <> msg)
+    die "extism call failed"

--- a/nix/host/extism-spike-host/extism-spike-host.cabal
+++ b/nix/host/extism-spike-host/extism-spike-host.cabal
@@ -1,0 +1,25 @@
+cabal-version: 3.0
+name:          extism-spike-host
+version:       0.1.0.0
+synopsis:
+  Native Haskell host for the Extism PDK spike
+
+author:        lambdasistemi
+license:       Apache-2.0
+build-type:    Simple
+
+-- Loads wasm-extism-spike.wasm via the extism Hackage package
+-- (libextism, Wasmtime-backed) and calls the tx_identify export
+-- against transaction CBOR hex read from stdin.
+
+executable extism-spike-host
+  main-is:          Main.hs
+  hs-source-dirs:   app
+  build-depends:
+    , base        >=4.17 && <5
+    , bytestring
+    , extism
+    , text
+
+  default-language: Haskell2010
+  ghc-options:      -Wall

--- a/nix/host/libextism.nix
+++ b/nix/host/libextism.nix
@@ -1,0 +1,80 @@
+# Prebuilt libextism (Rust + Wasmtime) — fetched from the upstream
+# release because nixpkgs does not package the C runtime, only the Go
+# CLI. The Haskell `extism` Hackage package links this at build time.
+#
+# The runtime is what bakes in the wasm proposals supported by the
+# host. v1.21.0 ships Wasmtime 41, which has tail-call support — the
+# missing feature in nixpkgs's wazero-based extism-cli that traps the
+# spike plugin during hs_init.
+{ lib, stdenv, fetchurl, autoPatchelfHook, gcc-unwrapped }:
+
+let
+  version = "1.21.0";
+  source = {
+    "x86_64-linux" = {
+      tag = "x86_64-unknown-linux-gnu";
+      sha256 = "d1b768c192cb2818b8d7f75eb0eab0ddc3d67eb2d77452abeeb29b3363d22dd0";
+    };
+    "aarch64-linux" = {
+      tag = "aarch64-unknown-linux-gnu";
+      sha256 = lib.fakeSha256;
+    };
+    "aarch64-darwin" = {
+      tag = "aarch64-apple-darwin";
+      sha256 = lib.fakeSha256;
+    };
+    "x86_64-darwin" = {
+      tag = "x86_64-apple-darwin";
+      sha256 = lib.fakeSha256;
+    };
+  }.${stdenv.hostPlatform.system} or (throw
+    "libextism: unsupported system ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "libextism";
+  inherit version;
+
+  src = fetchurl {
+    url =
+      "https://github.com/extism/extism/releases/download/v${version}/"
+      + "libextism-${source.tag}-v${version}.tar.gz";
+    sha256 = source.sha256;
+  };
+
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux gcc-unwrapped.lib;
+
+  unpackPhase = ''
+    runHook preUnpack
+    mkdir -p source
+    tar -xzf $src -C source
+    cd source
+    runHook postUnpack
+  '';
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib $out/include $out/lib/pkgconfig
+
+    install -m644 extism.h $out/include/
+    install -m755 libextism.${if stdenv.hostPlatform.isDarwin then "dylib" else "so"} \
+      $out/lib/ 2>/dev/null \
+      || install -m755 libextism.so $out/lib/
+    install -m644 libextism.a $out/lib/
+
+    substitute extism.pc.in $out/lib/pkgconfig/extism.pc \
+      --replace-fail '@CMAKE_INSTALL_PREFIX@' "$out"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Extism runtime (Rust, Wasmtime-backed) — prebuilt";
+    homepage = "https://extism.org";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+  };
+}

--- a/nix/wasm-targets.nix
+++ b/nix/wasm-targets.nix
@@ -9,6 +9,8 @@
 # - wasm-ledger-smoke : full ledger closure + wasm32-built C libs; prints a
 #                       version reference
 # - wasm-tx-inspector : real Conway tx decoder; reads hex on stdin, emits JSON
+# - wasm-extism-spike : Conway tx decoder packaged as an Extism PDK plugin;
+#                       proof-of-concept for Extism-driven conformance tests
 { pkgs
 , libWasm
 , ghcWasmMeta
@@ -17,6 +19,7 @@
 , smokeSrc
 , ledgerSmokeSrc
 , txInspectorSrc
+, extismSpikeSrc
 }:
 let
   # Full ledger override set + wasm32-built C libs — the superset both
@@ -60,5 +63,16 @@ in
     # pulls additional Hackage tarballs (aeson, base16-bytestring, text,
     # microlens, ...) that expand the cabal cache.
     dependenciesHash = "sha256-KmY5jyyPc2NFXZSP133Tq6rQWp3d7STwT4O51h7Ukys=";
+  };
+
+  # Spike: same ledger override set as wasm-tx-inspector plus extism-pdk
+  # and extism-manifest from Hackage.
+  wasm-extism-spike = libWasm.mkCardanoLedgerWasm {
+    inherit pkgs ghcWasmMeta wasiSdk chap;
+    src = extismSpikeSrc;
+    packages = [ "wasm-extism-spike" ];
+    srpForks = fullLedgerForks;
+    withCLibs = true;
+    dependenciesHash = "sha256-I6srK/QXzWcr5dbOFBV1cPJ7C5iNPCgSs1oshVoMvpU=";
   };
 }

--- a/nix/wasm-targets.nix
+++ b/nix/wasm-targets.nix
@@ -65,11 +65,13 @@ in
     dependenciesHash = "sha256-KmY5jyyPc2NFXZSP133Tq6rQWp3d7STwT4O51h7Ukys=";
   };
 
-  # Spike: same ledger override set as wasm-tx-inspector plus extism-pdk
-  # and extism-manifest from Hackage.
+  # Spike: depends on wasm-tx-inspector via path package, so the src
+  # has to span both subdirs (extism-spike + tx-inspector). The
+  # spike's project file lives at extism-spike/cabal-wasm.project.
   wasm-extism-spike = libWasm.mkCardanoLedgerWasm {
     inherit pkgs ghcWasmMeta wasiSdk chap;
     src = extismSpikeSrc;
+    projectFile = "extism-spike/cabal-wasm.project";
     packages = [ "wasm-extism-spike" ];
     srpForks = fullLedgerForks;
     withCLibs = true;

--- a/nix/wasm/extism-spike/README.md
+++ b/nix/wasm/extism-spike/README.md
@@ -34,37 +34,47 @@ deliberately not part of the smoke (see "Runtime status" below).
 | `extism-pdk` co-exists with the Conway closure under `wasm32-wasi-ghc 9.12` | ✅ |
 | Cabal solver accepts the combined dep set at the inspector's index-state | ✅ |
 | Resulting `.wasm` is a valid Extism plugin shape (named exports + WASI) | ✅ |
-| `extism call` executes the plugin end-to-end | ❌ (wazero, see below) |
+| Plugin runs end-to-end against real Conway fixture (libextism + Wasmtime) | ✅ |
+| Plugin runs through `pkgs.extism-cli` (Go, wazero) | ❌ (see below) |
 
-## Runtime status
+End-to-end response on the canonical Conway fixture:
 
-`pkgs.extism-cli` (1.6.3, July 2024) embeds a wazero version that predates
+```json
+{"era":"Conway","fee_lovelace":"319463","input_count":1,"output_count":5,
+ "tx_id":"2e614d78...49da6f3","tx_size_bytes":1918}
+```
+
+## Two host paths — only one currently works
+
+**Works: native Haskell host (`nix/host/extism-spike-host`).**
+Uses the [`extism`](https://hackage.haskell.org/package/extism) Hackage
+package, which links libextism (Rust + Wasmtime). libextism is fetched
+prebuilt from the upstream release in `nix/host/libextism.nix`. This is
+the production conformance-harness path. Run with
+`just check-extism-spike`.
+
+**Blocked: `pkgs.extism-cli` (Go, wazero).** Version 1.6.3 (July 2024)
+embeds a wazero that predates
 [wazero PR #2403](https://github.com/tetratelabs/wazero/pull/2403)
-(merged Aug 2025), which adds wasm tail-call support. GHC 9.12's
-`wasm32-wasi` codegen relies on tail calls. Result:
+(Aug 2025), which added wasm tail-call support. GHC 9.12's wasm32-wasi
+codegen relies on tail calls, so `extism call` traps in wazero during
+GHC RTS init:
 
 ```
 hs_init_ghc → initAdjustors → allocHashTable
 Error: failed to initialize runtime: wasm error: out of bounds memory access
 ```
 
-The trap is in the host's wazero, not in the plugin. Direct `wasmtime
---invoke` confirms the plugin imports the standard Extism host functions
-(`extism:host/env::input_length`, etc.) — the binary is well-formed.
-
-End-to-end execution requires a Wasmtime-backed host:
-
-- Rust [extism](https://crates.io/crates/extism) (libextism, Wasmtime)
-- Haskell [extism](https://hackage.haskell.org/package/extism) (host SDK,
-  links libextism)
-- A future `extism-cli` release that picks up tail-call-capable wazero
+The trap is in the host's wazero, not in the plugin — same `.wasm`
+runs fine under Wasmtime via the Haskell host. A future `extism-cli`
+release that picks up tail-call-capable wazero will work without
+plugin changes.
 
 ## Next steps
 
-1. Add a native Haskell host program using the `extism` Hackage package
-   to load the spike plugin and call `tx_identify`. Run the existing
-   `tx-identify-smoke` shape assertions on its output.
-2. Promote `tx_identify` to a versioned contract — same export name on
+1. Promote `tx_identify` to a versioned contract — same export name on
    any future Amaru-PDK plugin.
-3. Add `tx_validate` and `apply_tx` exports once the contract shape is
+2. Add `tx_validate` and `apply_tx` exports once the contract shape is
    stable.
+3. Build the diff harness: same fixture vector → both plugins → byte
+   compare on serialized output.

--- a/nix/wasm/extism-spike/README.md
+++ b/nix/wasm/extism-spike/README.md
@@ -1,20 +1,25 @@
 # Extism PDK spike
 
-Proof-of-concept: package one ledger operation (Conway tx → small
-identification JSON) as an [Extism](https://extism.org) plugin instead of
-the WASI reactor used by `wasm-tx-inspector`. The motivation is
-language-agnostic conformance testing — a Rust ledger (Amaru) packaged as
-an Extism plugin with the same export names + byte contract can be
-diff-tested against this Haskell ledger by feeding identical inputs to
-both.
+Proof-of-concept: package ledger operations as
+[Extism](https://extism.org) plugin exports instead of the WASI reactor
+used by `wasm-tx-inspector`. The motivation is language-agnostic
+conformance testing — a Rust ledger (Amaru) packaged as an Extism plugin
+with the same export names + byte contract can be diff-tested against
+this Haskell ledger by feeding identical inputs to both.
 
 ## What's here
 
-- `wasm-extism-spike/` — Haskell package depending on `extism-pdk` and the
-  Conway ledger libs. Single foreign export: `tx_identify`.
+- `wasm-extism-spike/` — Haskell package depending on `extism-pdk` and
+  the inspector library. Two foreign exports — `tx_identify` and
+  `tx_validate` — both delegating to the inspector's
+  `runLedgerOperationInput`. The Extism response is therefore
+  byte-identical to the WASI reactor's response on the same input,
+  which is exactly what conformance vs another implementation needs.
 - `cabal-wasm.project` — same fork overrides as `tx-inspector` plus
   `allow-newer` punches for `extism-pdk` / `extism-manifest` /
-  `messagepack` / `json` against bytestring/containers/binary.
+  `messagepack` / `json` against bytestring/containers/binary. Lists
+  both `extism-spike/wasm-extism-spike` and
+  `tx-inspector/wasm-tx-inspector` as path packages.
 
 ## Build
 
@@ -23,9 +28,9 @@ just build-extism-spike
 just check-extism-spike
 ```
 
-The check is **structural**: it asserts `tx_identify` and `hs_init` are
-exported and the wasm module is valid. End-to-end runtime invocation is
-deliberately not part of the smoke (see "Runtime status" below).
+`check-extism-spike` runs both `tx_identify` and `tx_validate` against
+the canonical Conway fixtures and asserts the response matches the WASI
+reactor's response **byte-for-byte**.
 
 ## Spike outcome
 
@@ -34,15 +39,9 @@ deliberately not part of the smoke (see "Runtime status" below).
 | `extism-pdk` co-exists with the Conway closure under `wasm32-wasi-ghc 9.12` | ✅ |
 | Cabal solver accepts the combined dep set at the inspector's index-state | ✅ |
 | Resulting `.wasm` is a valid Extism plugin shape (named exports + WASI) | ✅ |
-| Plugin runs end-to-end against real Conway fixture (libextism + Wasmtime) | ✅ |
+| Plugin runs end-to-end (libextism + Wasmtime, both `tx_identify` and `tx_validate`) | ✅ |
+| Extism response is byte-identical to WASI reactor response on the same envelope | ✅ |
 | Plugin runs through `pkgs.extism-cli` (Go, wazero) | ❌ (see below) |
-
-End-to-end response on the canonical Conway fixture:
-
-```json
-{"era":"Conway","fee_lovelace":"319463","input_count":1,"output_count":5,
- "tx_id":"2e614d78...49da6f3","tx_size_bytes":1918}
-```
 
 ## Two host paths — only one currently works
 
@@ -50,8 +49,15 @@ End-to-end response on the canonical Conway fixture:
 Uses the [`extism`](https://hackage.haskell.org/package/extism) Hackage
 package, which links libextism (Rust + Wasmtime). libextism is fetched
 prebuilt from the upstream release in `nix/host/libextism.nix`. This is
-the production conformance-harness path. Run with
-`just check-extism-spike`.
+the production conformance-harness path. Invocation:
+
+```
+extism-spike-host PATH-TO-WASM [FUNCTION] < envelope.json > response.json
+```
+
+`FUNCTION` defaults to `tx_identify`; pass `tx_validate` for the
+validation operation. The envelope is the same JSON the WASI reactor
+accepts on stdin.
 
 **Blocked: `pkgs.extism-cli` (Go, wazero).** Version 1.6.3 (July 2024)
 embeds a wazero that predates
@@ -72,9 +78,8 @@ plugin changes.
 
 ## Next steps
 
-1. Promote `tx_identify` to a versioned contract — same export name on
-   any future Amaru-PDK plugin.
-2. Add `tx_validate` and `apply_tx` exports once the contract shape is
-   stable.
+1. Promote `tx_identify` and `tx_validate` to a versioned contract —
+   same export names on any future Amaru-PDK plugin.
+2. Add `apply_tx` once the contract shape is stable.
 3. Build the diff harness: same fixture vector → both plugins → byte
    compare on serialized output.

--- a/nix/wasm/extism-spike/README.md
+++ b/nix/wasm/extism-spike/README.md
@@ -1,0 +1,70 @@
+# Extism PDK spike
+
+Proof-of-concept: package one ledger operation (Conway tx → small
+identification JSON) as an [Extism](https://extism.org) plugin instead of
+the WASI reactor used by `wasm-tx-inspector`. The motivation is
+language-agnostic conformance testing — a Rust ledger (Amaru) packaged as
+an Extism plugin with the same export names + byte contract can be
+diff-tested against this Haskell ledger by feeding identical inputs to
+both.
+
+## What's here
+
+- `wasm-extism-spike/` — Haskell package depending on `extism-pdk` and the
+  Conway ledger libs. Single foreign export: `tx_identify`.
+- `cabal-wasm.project` — same fork overrides as `tx-inspector` plus
+  `allow-newer` punches for `extism-pdk` / `extism-manifest` /
+  `messagepack` / `json` against bytestring/containers/binary.
+
+## Build
+
+```bash
+just build-extism-spike
+just check-extism-spike
+```
+
+The check is **structural**: it asserts `tx_identify` and `hs_init` are
+exported and the wasm module is valid. End-to-end runtime invocation is
+deliberately not part of the smoke (see "Runtime status" below).
+
+## Spike outcome
+
+| Hypothesis | Result |
+|---|---|
+| `extism-pdk` co-exists with the Conway closure under `wasm32-wasi-ghc 9.12` | ✅ |
+| Cabal solver accepts the combined dep set at the inspector's index-state | ✅ |
+| Resulting `.wasm` is a valid Extism plugin shape (named exports + WASI) | ✅ |
+| `extism call` executes the plugin end-to-end | ❌ (wazero, see below) |
+
+## Runtime status
+
+`pkgs.extism-cli` (1.6.3, July 2024) embeds a wazero version that predates
+[wazero PR #2403](https://github.com/tetratelabs/wazero/pull/2403)
+(merged Aug 2025), which adds wasm tail-call support. GHC 9.12's
+`wasm32-wasi` codegen relies on tail calls. Result:
+
+```
+hs_init_ghc → initAdjustors → allocHashTable
+Error: failed to initialize runtime: wasm error: out of bounds memory access
+```
+
+The trap is in the host's wazero, not in the plugin. Direct `wasmtime
+--invoke` confirms the plugin imports the standard Extism host functions
+(`extism:host/env::input_length`, etc.) — the binary is well-formed.
+
+End-to-end execution requires a Wasmtime-backed host:
+
+- Rust [extism](https://crates.io/crates/extism) (libextism, Wasmtime)
+- Haskell [extism](https://hackage.haskell.org/package/extism) (host SDK,
+  links libextism)
+- A future `extism-cli` release that picks up tail-call-capable wazero
+
+## Next steps
+
+1. Add a native Haskell host program using the `extism` Hackage package
+   to load the spike plugin and call `tx_identify`. Run the existing
+   `tx-identify-smoke` shape assertions on its output.
+2. Promote `tx_identify` to a versioned contract — same export name on
+   any future Amaru-PDK plugin.
+3. Add `tx_validate` and `apply_tx` exports once the contract shape is
+   stable.

--- a/nix/wasm/extism-spike/cabal-wasm.project
+++ b/nix/wasm/extism-spike/cabal-wasm.project
@@ -31,7 +31,9 @@ index-state:
   , hackage.haskell.org 2026-04-14T00:00:00Z
   , cardano-haskell-packages 2026-04-15T11:20:53Z
 
-packages: wasm-extism-spike
+packages:
+  extism-spike/wasm-extism-spike
+  tx-inspector/wasm-tx-inspector
 
 -- Package flags mirrored from nix/wasm/forks.json.
 package cardano-crypto-praos

--- a/nix/wasm/extism-spike/cabal-wasm.project
+++ b/nix/wasm/extism-spike/cabal-wasm.project
@@ -1,0 +1,106 @@
+-- WASM build configuration for the Extism PDK spike. Mirrors
+-- nix/wasm/tx-inspector/cabal-wasm.project (same forks, same
+-- index-states, same flags), plus extism-pdk + extism-manifest.
+
+repository cardano-haskell-packages
+  url: https://chap.intersectmbo.org/
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+active-repositories:
+  , :rest
+  , cardano-haskell-packages:override
+
+-- extism-pdk 1.2.0.0 has tight bounds against bytestring (<=0.12),
+-- containers (<0.7), and binary; GHC 9.12 ships newer. allow-newer
+-- punches them open. Same trick is used elsewhere for ledger deps.
+allow-newer:
+  *:template-haskell, *:base, *:deepseq, *:ghc-prim, *:time, *:text,
+  extism-pdk:bytestring, extism-pdk:containers, extism-pdk:binary,
+  extism-manifest:bytestring, extism-manifest:containers,
+  extism-manifest:base, json:base, messagepack:bytestring,
+  messagepack:base
+
+index-state:
+  , hackage.haskell.org 2026-04-14T00:00:00Z
+  , cardano-haskell-packages 2026-04-15T11:20:53Z
+
+packages: wasm-extism-spike
+
+-- Package flags mirrored from nix/wasm/forks.json.
+package cardano-crypto-praos
+  flags: -external-libsodium-vrf
+
+package crypton
+  ghc-options: -optc-DARGON2_NO_THREADS
+
+package atomic-counter
+  flags: +no-cmm
+
+package digest
+  flags: -pkg-config
+
+package plutus-core
+  flags: +do-not-build-plutus-exec
+
+-- SRP entries pre-fetched and rewritten by mkCardanoLedgerWasm at build
+-- time via srpForks. Listed here so the solver's first pass has the
+-- versions; the nix-store paths are spliced into `packages:` after the
+-- cabal cache bootstrap.
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/cborg.git
+  tag: 72a0e736e24c864b5a9b95d90adb37a9e8e6d761
+  subdir: cborg
+
+source-repository-package
+  type: git
+  location: https://github.com/intersectmbo/plutus.git
+  tag: d1684df33d1b7226dfa5f2247aa67a46c2d5453b
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-wasm/hs-memory.git
+  tag: a198a76c584dc2cfdcde6b431968de92a5fed65e
+
+source-repository-package
+  type: git
+  location: https://github.com/Jimbo4350/foundation.git
+  tag: b3cb78484fe6f6ce1dfcef59e72ceccc530e86ac
+  subdir:
+    basement
+    foundation
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell-wasm/network
+  tag: ab92e48e9fdf3abe214f85fdbe5301c1280e14e9
+
+source-repository-package
+  type: git
+  location: https://github.com/palas/double-conversion.git
+  tag: b2030245727ee56de76507fe305e3741f6ce3260
+
+source-repository-package
+  type: git
+  location: https://github.com/palas/criterion.git
+  tag: dd160d2b5f051e918e72fe1957d77905682b8d6c
+  subdir: criterion-measurement
+
+source-repository-package
+  type: git
+  location: https://github.com/palas/haskell-lmdb-mock.git
+  tag: c8d61e6eee03ee271e7768c0576110da885aec48
+
+tests: False
+benchmarks: False

--- a/nix/wasm/extism-spike/wasm-extism-spike/app/Main.hs
+++ b/nix/wasm/extism-spike/wasm-extism-spike/app/Main.hs
@@ -1,0 +1,12 @@
+{- |
+Module      : Main
+Description : Reactor stub for the Extism plugin.
+
+Empty 'main'. The wasm32-wasi reactor is started by Extism through
+@hs_init@ and the exported plugin functions; this module exists only
+to satisfy GHC's executable component.
+-}
+module Main (main) where
+
+main :: IO ()
+main = pure ()

--- a/nix/wasm/extism-spike/wasm-extism-spike/src/Extism/Spike.hs
+++ b/nix/wasm/extism-spike/wasm-extism-spike/src/Extism/Spike.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+{- |
+Module      : Extism.Spike
+Description : Extism PDK plugin exposing one ledger operation.
+
+Single export: 'tx_identify'. Reads a hex-encoded Conway transaction
+from the Extism plugin input, decodes it through
+'cardano-ledger-conway', and writes a small identification JSON
+(tx_id, input_count, output_count, fee_lovelace, tx_size_bytes) to
+the plugin output.
+
+Slice — not byte-parity — of the WASI reactor's @tx.identify@. The
+spike answers "can the Conway closure co-exist with the Extism PDK
+in one wasm32-wasi binary?" not "is the Extism response byte-
+identical to the WASI response?". Byte parity is a follow-up.
+-}
+module Extism.Spike (tx_identify) where
+
+import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Ledger.Api as L
+import qualified Cardano.Ledger.Binary as Binary
+import qualified Cardano.Ledger.Coin as Coin
+import qualified Cardano.Ledger.Conway as Conway
+import Cardano.Ledger.Core (TxLevel (..))
+import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Hashes as Hashes
+import qualified Cardano.Ledger.TxIn as TxIn
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Lazy as BSL
+import Data.Foldable (toList)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import Extism.PDK (inputByteString, output, setError)
+import Lens.Micro ((^.))
+
+-- | Plugin entry point.
+tx_identify :: IO ()
+tx_identify = do
+    payload <- inputByteString
+    case identify payload of
+        Right value -> output (BSL.toStrict (Aeson.encode value))
+        Left err -> setError (T.unpack err)
+
+identify :: BS.ByteString -> Either T.Text Aeson.Value
+identify hexInput = do
+    raw <- decodeHex (stripWhitespace hexInput)
+    tx <- decodeTx raw
+    pure (identifyJson raw tx)
+
+stripWhitespace :: BS.ByteString -> BS.ByteString
+stripWhitespace =
+    BS.filter
+        (\c -> c /= 0x20 && c /= 0x09 && c /= 0x0a && c /= 0x0d)
+
+decodeHex :: BS.ByteString -> Either T.Text BS.ByteString
+decodeHex bytes = case Base16.decode bytes of
+    Right ok -> Right ok
+    Left err -> Left ("malformed_hex: " <> T.pack err)
+
+decodeTx ::
+    BS.ByteString ->
+    Either T.Text (L.Tx TopTx Conway.ConwayEra)
+decodeTx bytes =
+    case Binary.decodeFullAnnotator
+        (Core.eraProtVerLow @Conway.ConwayEra)
+        "ConwayTx"
+        Binary.decCBOR
+        (BSL.fromStrict bytes) of
+        Right tx -> Right tx
+        Left err -> Left ("malformed_cbor: " <> T.pack (show err))
+
+identifyJson ::
+    BS.ByteString ->
+    L.Tx TopTx Conway.ConwayEra ->
+    Aeson.Value
+identifyJson rawBytes tx =
+    let body = tx ^. L.bodyTxL
+        inputs = toList (body ^. L.inputsTxBodyL)
+        outputs = toList (body ^. L.outputsTxBodyL)
+     in Aeson.object
+            [ "era" .= ("Conway" :: T.Text)
+            , "tx_id" .= txIdHex (Core.txIdTx tx)
+            , "tx_size_bytes" .= BS.length rawBytes
+            , "fee_lovelace"
+                .= T.pack (show (Coin.unCoin (body ^. L.feeTxBodyL)))
+            , "input_count" .= length inputs
+            , "output_count" .= length outputs
+            ]
+
+txIdHex :: TxIn.TxId -> T.Text
+txIdHex (TxIn.TxId safeHash) =
+    hashHex (Hashes.extractHash safeHash)
+
+hashHex :: Crypto.Hash h a -> T.Text
+hashHex = T.decodeUtf8 . Base16.encode . Crypto.hashToBytes
+
+foreign export ccall "tx_identify" tx_identify :: IO ()

--- a/nix/wasm/extism-spike/wasm-extism-spike/src/Extism/Spike.hs
+++ b/nix/wasm/extism-spike/wasm-extism-spike/src/Extism/Spike.hs
@@ -1,104 +1,59 @@
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 
 {- |
 Module      : Extism.Spike
-Description : Extism PDK plugin exposing one ledger operation.
+Description : Extism PDK plugin exposing ledger operations.
 
-Single export: 'tx_identify'. Reads a hex-encoded Conway transaction
-from the Extism plugin input, decodes it through
-'cardano-ledger-conway', and writes a small identification JSON
-(tx_id, input_count, output_count, fee_lovelace, tx_size_bytes) to
-the plugin output.
+Two foreign exports — 'tx_identify' and 'tx_validate'. Both delegate
+to 'Conway.Inspector.runLedgerOperationInput', which is the same code
+path the WASI reactor (@wasm-tx-inspector@) runs on stdin. The
+plugin's response is therefore byte-identical to the WASI reactor's
+response for the same input — that property is what makes the spike
+useful for differential conformance testing.
 
-Slice — not byte-parity — of the WASI reactor's @tx.identify@. The
-spike answers "can the Conway closure co-exist with the Extism PDK
-in one wasm32-wasi binary?" not "is the Extism response byte-
-identical to the WASI response?". Byte parity is a follow-up.
+Input is the canonical JSON envelope:
+
+> { "ledger_functional_layer": "...",
+>   "tx_cbor": "...",
+>   "op": "tx.identify" | "tx.validate" | ...,
+>   "args": { ... } }
+
+Output is the matching response envelope. Errors go through
+'Extism.PDK.setError'.
 -}
-module Extism.Spike (tx_identify) where
+module Extism.Spike (tx_identify, tx_validate) where
 
-import qualified Cardano.Crypto.Hash as Crypto
-import qualified Cardano.Ledger.Api as L
-import qualified Cardano.Ledger.Binary as Binary
-import qualified Cardano.Ledger.Coin as Coin
-import qualified Cardano.Ledger.Conway as Conway
-import Cardano.Ledger.Core (TxLevel (..))
-import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Hashes as Hashes
-import qualified Cardano.Ledger.TxIn as TxIn
-import Data.Aeson ((.=))
+import qualified Conway.Inspector as Inspector
 import qualified Data.Aeson as Aeson
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as BSL
-import Data.Foldable (toList)
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import Extism.PDK (inputByteString, output, setError)
-import Lens.Micro ((^.))
 
--- | Plugin entry point.
 tx_identify :: IO ()
-tx_identify = do
+tx_identify = runOp
+
+tx_validate :: IO ()
+tx_validate = runOp
+
+runOp :: IO ()
+runOp = do
     payload <- inputByteString
-    case identify payload of
+    case Inspector.runLedgerOperationInput payload of
         Right value -> output (BSL.toStrict (Aeson.encode value))
-        Left err -> setError (T.unpack err)
+        Left err -> setError (errorMessage err)
 
-identify :: BS.ByteString -> Either T.Text Aeson.Value
-identify hexInput = do
-    raw <- decodeHex (stripWhitespace hexInput)
-    tx <- decodeTx raw
-    pure (identifyJson raw tx)
-
-stripWhitespace :: BS.ByteString -> BS.ByteString
-stripWhitespace =
-    BS.filter
-        (\c -> c /= 0x20 && c /= 0x09 && c /= 0x0a && c /= 0x0d)
-
-decodeHex :: BS.ByteString -> Either T.Text BS.ByteString
-decodeHex bytes = case Base16.decode bytes of
-    Right ok -> Right ok
-    Left err -> Left ("malformed_hex: " <> T.pack err)
-
-decodeTx ::
-    BS.ByteString ->
-    Either T.Text (L.Tx TopTx Conway.ConwayEra)
-decodeTx bytes =
-    case Binary.decodeFullAnnotator
-        (Core.eraProtVerLow @Conway.ConwayEra)
-        "ConwayTx"
-        Binary.decCBOR
-        (BSL.fromStrict bytes) of
-        Right tx -> Right tx
-        Left err -> Left ("malformed_cbor: " <> T.pack (show err))
-
-identifyJson ::
-    BS.ByteString ->
-    L.Tx TopTx Conway.ConwayEra ->
-    Aeson.Value
-identifyJson rawBytes tx =
-    let body = tx ^. L.bodyTxL
-        inputs = toList (body ^. L.inputsTxBodyL)
-        outputs = toList (body ^. L.outputsTxBodyL)
-     in Aeson.object
-            [ "era" .= ("Conway" :: T.Text)
-            , "tx_id" .= txIdHex (Core.txIdTx tx)
-            , "tx_size_bytes" .= BS.length rawBytes
-            , "fee_lovelace"
-                .= T.pack (show (Coin.unCoin (body ^. L.feeTxBodyL)))
-            , "input_count" .= length inputs
-            , "output_count" .= length outputs
-            ]
-
-txIdHex :: TxIn.TxId -> T.Text
-txIdHex (TxIn.TxId safeHash) =
-    hashHex (Hashes.extractHash safeHash)
-
-hashHex :: Crypto.Hash h a -> T.Text
-hashHex = T.decodeUtf8 . Base16.encode . Crypto.hashToBytes
+errorMessage :: Inspector.InspectError -> String
+errorMessage = \case
+    Inspector.MalformedHex detail ->
+        "malformed_hex: " <> detail
+    Inspector.MalformedCbor detail ->
+        "malformed_cbor: " <> detail
+    Inspector.MalformedLedgerOperation detail ->
+        "malformed_ledger_operation: " <> detail
+    Inspector.UnknownLedgerOperation operation ->
+        "unknown_ledger_operation: " <> T.unpack operation
 
 foreign export ccall "tx_identify" tx_identify :: IO ()
+foreign export ccall "tx_validate" tx_validate :: IO ()

--- a/nix/wasm/extism-spike/wasm-extism-spike/wasm-extism-spike.cabal
+++ b/nix/wasm/extism-spike/wasm-extism-spike/wasm-extism-spike.cabal
@@ -1,0 +1,49 @@
+cabal-version: 3.0
+name:          wasm-extism-spike
+version:       0.1.0.0
+synopsis:
+  Extism plugin spike: ledger tx-id behind the Extism PDK
+
+author:        lambdasistemi
+license:       Apache-2.0
+build-type:    Simple
+
+-- Spike. Tests one hypothesis: a Haskell wasm32-wasi build can carry
+-- the cardano-ledger Conway closure AND the Extism PDK at the same
+-- time, exposing a ledger function (Conway tx decode + tx-id) as an
+-- Extism plugin export. If this builds and `extism call` returns the
+-- expected JSON for the canonical Conway fixture, conformance vectors
+-- via Extism are viable.
+
+library wasm-extism-spike-lib
+  exposed-modules:  Extism.Spike
+  hs-source-dirs:   src
+  build-depends:
+    , aeson
+    , base                  >=4.19 && <5
+    , base16-bytestring
+    , bytestring
+    , cardano-crypto-class
+    , cardano-ledger-api
+    , cardano-ledger-binary
+    , cardano-ledger-conway
+    , cardano-ledger-core
+    , extism-pdk
+    , microlens
+    , text
+
+  default-language: Haskell2010
+  ghc-options:      -Wall
+
+executable wasm-extism-spike
+  main-is:          Main.hs
+  hs-source-dirs:   app
+  build-depends:
+    , base                   >=4.19 && <5
+    , wasm-extism-spike-lib
+
+  default-language: Haskell2010
+  ghc-options:
+    -Wall -no-hs-main -optl-mexec-model=reactor
+    "-optl-Wl,--export=hs_init" "-optl-Wl,--export=tx_identify"
+    "-optl-Wl,--allow-undefined"

--- a/nix/wasm/extism-spike/wasm-extism-spike/wasm-extism-spike.cabal
+++ b/nix/wasm/extism-spike/wasm-extism-spike/wasm-extism-spike.cabal
@@ -20,17 +20,11 @@ library wasm-extism-spike-lib
   hs-source-dirs:   src
   build-depends:
     , aeson
-    , base                  >=4.19 && <5
-    , base16-bytestring
+    , base               >=4.19 && <5
     , bytestring
-    , cardano-crypto-class
-    , cardano-ledger-api
-    , cardano-ledger-binary
-    , cardano-ledger-conway
-    , cardano-ledger-core
     , extism-pdk
-    , microlens
     , text
+    , wasm-tx-inspector
 
   default-language: Haskell2010
   ghc-options:      -Wall
@@ -46,4 +40,4 @@ executable wasm-extism-spike
   ghc-options:
     -Wall -no-hs-main -optl-mexec-model=reactor
     "-optl-Wl,--export=hs_init" "-optl-Wl,--export=tx_identify"
-    "-optl-Wl,--allow-undefined"
+    "-optl-Wl,--export=tx_validate" "-optl-Wl,--allow-undefined"

--- a/nix/wasm/mkCardanoLedgerWasm.nix
+++ b/nix/wasm/mkCardanoLedgerWasm.nix
@@ -379,6 +379,7 @@ let
       cp -rL $CABAL_DIR $out/cabal
       cp -rL dist-newstyle $out/dist-newstyle
       # Preserve the patched project file so the wasm phase can reuse it.
+      mkdir -p "$(dirname "$out/${projectFile}")"
       cp ${projectFile} $out/${projectFile}
       chmod -R u+w $out
     '';
@@ -417,6 +418,25 @@ let
       rm -f ${projectFile}
       cp ${prebuiltDeps}/${projectFile} ${projectFile}
       chmod u+w ${projectFile}
+
+      # prebuiltDeps was built from metadata-only src (no .hs files), so any
+      # local path-package libraries listed in the project file got "built"
+      # with empty source — their dist-newstyle entries are present but
+      # don't expose any modules. Delete those entries so cabal rebuilds
+      # them from real source in this phase. External Hackage/CHaP/SRP libs
+      # are unaffected — their dist-newstyle artifacts are correct.
+      for pkg in $(find dist-newstyle/build -mindepth 3 -maxdepth 3 -type d \
+                     -path '*/wasm32-wasi/*' -name '*-0.1.0.0'); do
+        echo "purging local path-package dist entries: $pkg"
+        rm -rf "$pkg"
+      done
+      find dist-newstyle -name 'package.conf.d' -exec sh -c '
+        for d; do
+          for entry in "$d"/*-0.1.0.0-inplace*.conf; do
+            [ -e "$entry" ] && rm -f "$entry"
+          done
+        done
+      ' sh {} +
     '';
 
     buildPhase = ''


### PR DESCRIPTION
## Summary

Spike packaging the Conway ledger as an Extism plugin for differential conformance testing against future implementations (Amaru/Rust).

- Two foreign exports — `tx_identify` and `tx_validate` — both delegating to `Conway.Inspector.runLedgerOperationInput`. Extism response is **byte-identical** to the WASI reactor's response on the same envelope.
- Native Haskell host (`nix/host/extism-spike-host`) loads the plugin via the `extism` Hackage SDK + libextism (Rust + Wasmtime). libextism is fetched prebuilt from the upstream v1.21.0 release in `nix/host/libextism.nix`.
- `pkgs.extism-cli` (Go, wazero) is currently blocked because its bundled wazero predates wasm tail-call support; same `.wasm` runs unchanged under Wasmtime.
- `mkCardanoLedgerWasm` gains a `projectFile` arg and a stale-dist-newstyle purge for local path-package libraries (the spike depends on `wasm-tx-inspector` as a path package).

## Test plan

- [x] `just check-extism-spike` — runs both `tx_identify` and `tx_validate` against the canonical Conway fixtures end-to-end; asserts byte-equality between the Extism response and the WASI reactor response on `tx-validate-complete-request.json`.
- [x] `just check-identify` / `check-witness-plan` / `check-input-context` / `check-validate` — existing WASI smokes still pass after the `mkCardanoLedgerWasm` changes.
- [x] `fourmolu -m check` clean on new Haskell sources.

## Notes

- See `nix/wasm/extism-spike/README.md` for the full spike outcome table and host-path matrix.