### PR TITLE
chore: pin release-please initial-version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
   "packages": {
     ".": {
       "package-name": "cardano-ledger-wasi",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "initial-version": "0.1.0"
     }
   },
   "include-v-in-tag": true,


### PR DESCRIPTION
Earlier override (PR #25) used `Release-As:` in an empty commit; rebase merge dropped it. Switching to the documented config-level mechanism: `initial-version: "0.1.0"` in `release-please-config.json` so release-please picks 0.1.0 as the first tag.

Non-empty diff this time, so the commit will actually land on main.