### PR TITLE
ci: full per-job gate + nix-skill-shaped apps + branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,59 +22,32 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build inspector WASI package
-        run: nix build --quiet .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
 
-      - name: Build inspector UI
-        run: nix build --quiet .#packages.x86_64-linux.tx-inspector-ui -o result-site
-
-      - name: Build OpenAPI artifact
-        run: nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
-
-      - name: Build wasm Extism plugin
-        run: nix build --quiet .#packages.x86_64-linux.wasm-extism-spike -o result-extism-wasm
-
-      - name: Build native Extism host
-        run: nix build --quiet .#packages.x86_64-linux.extism-spike-host -o result-extism-host
-
-      - name: Build native deep-diagnosis CLI
-        run: nix build --quiet .#packages.x86_64-linux.tx-deep-diagnosis -o result-cli
-
-      - name: Regenerate + diff OpenAPI source
-        run: nix build --quiet .#checks.x86_64-linux.ledger-functional-openapi-check
-
-      - name: Check committed Swagger is generated
-        run: nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
-
-      - name: Smoke tx.identify operation
-        run: nix build --quiet .#checks.x86_64-linux.tx-identify-smoke
-
-      - name: Smoke tx.witness.plan operation
-        run: nix build --quiet .#checks.x86_64-linux.tx-witness-plan-smoke
-
-      - name: Smoke tx.intent operation
-        run: nix build --quiet .#checks.x86_64-linux.tx-intent-smoke
-
-      - name: Smoke tx.validate operation
-        run: nix build --quiet .#checks.x86_64-linux.tx-validate-smoke
-
-      - name: Smoke tx.evaluate.scripts operation
-        run: nix build --quiet .#checks.x86_64-linux.tx-evaluate-scripts-smoke
-
-      - name: Smoke explicit UTxO input context
-        run: nix build --quiet .#checks.x86_64-linux.tx-input-context-smoke
-
-      - name: Smoke Extism conformance vs WASI
-        run: nix build --quiet .#checks.x86_64-linux.tx-extism-spike-smoke
-
-      - name: Format check (fourmolu)
-        run: nix develop --quiet -c just format-check
-
-      - name: Run inspector Playwright tests
-        run: nix develop --quiet -c just test-playwright
+      - name: Build everything (packages + checks)
+        run: |
+          nix build --quiet \
+            .#packages.x86_64-linux.wasm-tx-inspector \
+            .#packages.x86_64-linux.tx-inspector-ui \
+            .#packages.x86_64-linux.ledger-functional-openapi \
+            .#packages.x86_64-linux.wasm-extism-spike \
+            .#packages.x86_64-linux.extism-spike-host \
+            .#packages.x86_64-linux.tx-deep-diagnosis \
+            .#checks.x86_64-linux.ledger-functional-openapi-check \
+            .#checks.x86_64-linux.ledger-functional-swagger-check \
+            .#checks.x86_64-linux.tx-identify-smoke \
+            .#checks.x86_64-linux.tx-witness-plan-smoke \
+            .#checks.x86_64-linux.tx-intent-smoke \
+            .#checks.x86_64-linux.tx-validate-smoke \
+            .#checks.x86_64-linux.tx-evaluate-scripts-smoke \
+            .#checks.x86_64-linux.tx-input-context-smoke \
+            .#checks.x86_64-linux.tx-extism-spike-smoke \
+            -o result-gate
 
       - name: Prepare downloadable artifacts
         run: |
+          nix build --quiet .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+          nix build --quiet .#packages.x86_64-linux.tx-inspector-ui -o result-site
+          nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
           mkdir -p artifacts/wasm-tx-inspector artifacts/tx-inspector-ui artifacts/ledger-functional-openapi
           cp -L result-wasm/wasm-tx-inspector.wasm artifacts/wasm-tx-inspector/
           cp -L result-site/* artifacts/tx-inspector-ui/
@@ -104,3 +77,135 @@ jobs:
           path: artifacts/ledger-functional-openapi
           if-no-files-found: error
           retention-days: 30
+
+  openapi-regen-check:
+    name: OpenAPI regen + diff
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.ledger-functional-openapi-check
+
+  swagger-check:
+    name: Swagger alias check
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
+
+  tx-identify-smoke:
+    name: Smoke tx.identify
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-identify-smoke
+
+  tx-witness-plan-smoke:
+    name: Smoke tx.witness.plan
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-witness-plan-smoke
+
+  tx-intent-smoke:
+    name: Smoke tx.intent
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-intent-smoke
+
+  tx-validate-smoke:
+    name: Smoke tx.validate
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-validate-smoke
+
+  tx-evaluate-scripts-smoke:
+    name: Smoke tx.evaluate.scripts
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-evaluate-scripts-smoke
+
+  tx-input-context-smoke:
+    name: Smoke explicit UTxO input context
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-input-context-smoke
+
+  tx-extism-spike-smoke:
+    name: Smoke Extism conformance vs WASI
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix build --quiet .#checks.x86_64-linux.tx-extism-spike-smoke
+
+  format-check:
+    name: Format (fourmolu)
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix develop --quiet -c just format-check
+
+  playwright:
+    name: Playwright
+    needs: build-gate
+    runs-on: nixos
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/cachix-action@v15
+        with:
+          name: paolino
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - run: nix develop --quiet -c just test-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix develop --quiet -c just format-check
+      - run: nix run --quiet .#format-check
 
   playwright:
     name: Playwright
@@ -208,4 +208,4 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix develop --quiet -c just test-playwright
+      - run: nix run --quiet .#test-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,18 @@ jobs:
       - name: Build OpenAPI artifact
         run: nix build --quiet .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
 
+      - name: Build wasm Extism plugin
+        run: nix build --quiet .#packages.x86_64-linux.wasm-extism-spike -o result-extism-wasm
+
+      - name: Build native Extism host
+        run: nix build --quiet .#packages.x86_64-linux.extism-spike-host -o result-extism-host
+
+      - name: Build native deep-diagnosis CLI
+        run: nix build --quiet .#packages.x86_64-linux.tx-deep-diagnosis -o result-cli
+
+      - name: Regenerate + diff OpenAPI source
+        run: nix build --quiet .#checks.x86_64-linux.ledger-functional-openapi-check
+
       - name: Check committed Swagger is generated
         run: nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
 
@@ -40,8 +52,23 @@ jobs:
       - name: Smoke tx.witness.plan operation
         run: nix build --quiet .#checks.x86_64-linux.tx-witness-plan-smoke
 
+      - name: Smoke tx.intent operation
+        run: nix build --quiet .#checks.x86_64-linux.tx-intent-smoke
+
+      - name: Smoke tx.validate operation
+        run: nix build --quiet .#checks.x86_64-linux.tx-validate-smoke
+
+      - name: Smoke tx.evaluate.scripts operation
+        run: nix build --quiet .#checks.x86_64-linux.tx-evaluate-scripts-smoke
+
       - name: Smoke explicit UTxO input context
         run: nix build --quiet .#checks.x86_64-linux.tx-input-context-smoke
+
+      - name: Smoke Extism conformance vs WASI
+        run: nix build --quiet .#checks.x86_64-linux.tx-extism-spike-smoke
+
+      - name: Format check (fourmolu)
+        run: nix develop --quiet -c just format-check
 
       - name: Run inspector Playwright tests
         run: nix develop --quiet -c just test-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.ledger-functional-openapi-check
+      - run: nix run --quiet .#ledger-functional-openapi-check
 
   swagger-check:
     name: Swagger alias check
@@ -100,7 +100,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.ledger-functional-swagger-check
+      - run: nix run --quiet .#ledger-functional-swagger-check
 
   tx-identify-smoke:
     name: Smoke tx.identify
@@ -112,7 +112,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-identify-smoke
+      - run: nix run --quiet .#tx-identify-smoke
 
   tx-witness-plan-smoke:
     name: Smoke tx.witness.plan
@@ -124,7 +124,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-witness-plan-smoke
+      - run: nix run --quiet .#tx-witness-plan-smoke
 
   tx-intent-smoke:
     name: Smoke tx.intent
@@ -136,7 +136,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-intent-smoke
+      - run: nix run --quiet .#tx-intent-smoke
 
   tx-validate-smoke:
     name: Smoke tx.validate
@@ -148,7 +148,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-validate-smoke
+      - run: nix run --quiet .#tx-validate-smoke
 
   tx-evaluate-scripts-smoke:
     name: Smoke tx.evaluate.scripts
@@ -160,7 +160,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-evaluate-scripts-smoke
+      - run: nix run --quiet .#tx-evaluate-scripts-smoke
 
   tx-input-context-smoke:
     name: Smoke explicit UTxO input context
@@ -172,7 +172,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-input-context-smoke
+      - run: nix run --quiet .#tx-input-context-smoke
 
   tx-extism-spike-smoke:
     name: Smoke Extism conformance vs WASI
@@ -184,7 +184,7 @@ jobs:
         with:
           name: paolino
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix build --quiet .#checks.x86_64-linux.tx-extism-spike-smoke
+      - run: nix run --quiet .#tx-extism-spike-smoke
 
   format-check:
     name: Format (fourmolu)

--- a/flake.nix
+++ b/flake.nix
@@ -661,9 +661,31 @@
 
           apps =
             let
+              mkSmokeApp = name: smoke: pkgs.writeShellApplication {
+                name = "${name}-runner";
+                runtimeInputs = [ pkgs.coreutils ];
+                text = ''
+                  set -euo pipefail
+                  echo "=== ${name} ==="
+                  echo "smoke artifacts: ${smoke}"
+                  if [ -f ${smoke}/request.json ]; then
+                    echo "--- request.json ---"
+                    cat ${smoke}/request.json
+                  fi
+                  echo
+                  if [ -f ${smoke}/response.json ]; then
+                    echo "--- response.json ---"
+                    cat ${smoke}/response.json
+                  fi
+                '';
+              };
+              mkApp = drv: { type = "app"; program = pkgs.lib.getExe drv; };
               format-check = pkgs.writeShellApplication {
                 name = "format-check";
-                runtimeInputs = [ pkgs.haskellPackages.fourmolu pkgs.findutils ];
+                runtimeInputs = [
+                  pkgs.haskellPackages.fourmolu
+                  pkgs.findutils
+                ];
                 text = ''
                   find libs apps nix/wasm -type f -name '*.hs' \
                     -exec fourmolu -m check {} +
@@ -674,13 +696,19 @@
                 runtimeInputs = [
                   pkgs.playwright-test
                   pkgs.nodejs_20
+                  pkgs.python3
                   pkgs.coreutils
                 ];
-                excludeShellChecks = [ "SC2046" "SC2086" ];
+                excludeShellChecks = [
+                  "SC2046"
+                  "SC2086"
+                ];
                 text = ''
                   set -euo pipefail
                   cd docs/inspector
-                  ln -sfn $(dirname $(dirname $(readlink -f $(command -v playwright))))/lib/node_modules node_modules
+                  ln -sfn \
+                    $(dirname $(dirname $(readlink -f $(command -v playwright))))/lib/node_modules \
+                    node_modules
                   TX_INSPECTOR_SITE_DIR=${tx-inspector-ui} \
                     PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers} \
                     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
@@ -689,14 +717,28 @@
               };
             in
             {
-              format-check = {
-                type = "app";
-                program = pkgs.lib.getExe format-check;
-              };
-              test-playwright = {
-                type = "app";
-                program = pkgs.lib.getExe test-playwright;
-              };
+              format-check = mkApp format-check;
+              test-playwright = mkApp test-playwright;
+              tx-identify-smoke =
+                mkApp (mkSmokeApp "tx-identify-smoke" tx-identify-smoke);
+              tx-witness-plan-smoke =
+                mkApp (mkSmokeApp "tx-witness-plan-smoke" tx-witness-plan-smoke);
+              tx-intent-smoke =
+                mkApp (mkSmokeApp "tx-intent-smoke" tx-intent-smoke);
+              tx-validate-smoke =
+                mkApp (mkSmokeApp "tx-validate-smoke" tx-validate-smoke);
+              tx-evaluate-scripts-smoke =
+                mkApp (mkSmokeApp "tx-evaluate-scripts-smoke" tx-evaluate-scripts-smoke);
+              tx-input-context-smoke =
+                mkApp (mkSmokeApp "tx-input-context-smoke" tx-input-context-smoke);
+              tx-extism-spike-smoke =
+                mkApp (mkSmokeApp "tx-extism-spike-smoke" tx-extism-spike-smoke);
+              ledger-functional-openapi-check =
+                mkApp (mkSmokeApp "ledger-functional-openapi-check"
+                  ledger-functional-openapi-check);
+              ledger-functional-swagger-check =
+                mkApp (mkSmokeApp "ledger-functional-swagger-check"
+                  ledger-functional-openapi-check);
             };
 
           devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -659,6 +659,46 @@
             ledger-functional-swagger-check = ledger-functional-openapi-check;
           };
 
+          apps =
+            let
+              format-check = pkgs.writeShellApplication {
+                name = "format-check";
+                runtimeInputs = [ pkgs.haskellPackages.fourmolu pkgs.findutils ];
+                text = ''
+                  find libs apps nix/wasm -type f -name '*.hs' \
+                    -exec fourmolu -m check {} +
+                '';
+              };
+              test-playwright = pkgs.writeShellApplication {
+                name = "test-playwright";
+                runtimeInputs = [
+                  pkgs.playwright-test
+                  pkgs.nodejs_20
+                  pkgs.coreutils
+                ];
+                excludeShellChecks = [ "SC2046" "SC2086" ];
+                text = ''
+                  set -euo pipefail
+                  cd docs/inspector
+                  ln -sfn $(dirname $(dirname $(readlink -f $(command -v playwright))))/lib/node_modules node_modules
+                  TX_INSPECTOR_SITE_DIR=${tx-inspector-ui} \
+                    PLAYWRIGHT_BROWSERS_PATH=${pkgs.playwright-driver.browsers} \
+                    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+                    playwright test --reporter=list
+                '';
+              };
+            in
+            {
+              format-check = {
+                type = "app";
+                program = pkgs.lib.getExe format-check;
+              };
+              test-playwright = {
+                type = "app";
+                program = pkgs.lib.getExe test-playwright;
+              };
+            };
+
           devShells.default = pkgs.mkShell {
             buildInputs = [
               pkgs.just

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 # Configure branch protection on main:
-# - Require Build Gate + preview to pass
+# - Require every per-concern CI job + the Build Gate populator + preview
 # - Require branch be up-to-date with base before merging
 # - Disallow force-pushes and deletions
 # - No required reviewers (single-maintainer repo); bump if collaborators join
+#
+# The required-contexts list mirrors the job 'name:' fields in
+# .github/workflows/ci.yml plus 'preview' from .github/workflows/pr-preview.yml.
+# When a new per-concern job is added, list it here too.
 #
 # Idempotent. Re-run any time the required-checks list changes.
 #
@@ -19,7 +23,21 @@ gh api -X PUT "repos/$OWNER/$REPO/branches/$BRANCH/protection" \
 {
   "required_status_checks": {
     "strict": true,
-    "contexts": ["Build Gate", "preview"]
+    "contexts": [
+      "Build Gate",
+      "OpenAPI regen + diff",
+      "Swagger alias check",
+      "Smoke tx.identify",
+      "Smoke tx.witness.plan",
+      "Smoke tx.intent",
+      "Smoke tx.validate",
+      "Smoke tx.evaluate.scripts",
+      "Smoke explicit UTxO input context",
+      "Smoke Extism conformance vs WASI",
+      "Format (fourmolu)",
+      "Playwright",
+      "preview"
+    ]
   },
   "enforce_admins": false,
   "required_pull_request_reviews": null,

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Configure branch protection on main:
+# - Require Build Gate + preview to pass
+# - Require branch be up-to-date with base before merging
+# - Disallow force-pushes and deletions
+# - No required reviewers (single-maintainer repo); bump if collaborators join
+#
+# Idempotent. Re-run any time the required-checks list changes.
+#
+# Requires: gh authenticated as a repo admin.
+set -euo pipefail
+
+OWNER="${1:-lambdasistemi}"
+REPO="${2:-cardano-ledger-wasi}"
+BRANCH="${3:-main}"
+
+gh api -X PUT "repos/$OWNER/$REPO/branches/$BRANCH/protection" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["Build Gate", "preview"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+
+echo "Branch protection applied to $OWNER/$REPO:$BRANCH"
+gh api "repos/$OWNER/$REPO/branches/$BRANCH/protection" \
+  --jq '{required_status_checks, allow_force_pushes, allow_deletions, enforce_admins}'


### PR DESCRIPTION
Three things in this PR, one CI tightening at the end of which \`main\` is protected by every concern that can run:

## 1. CI workflow restructured per the nix skill

Before: one giant \`build-gate\` job that ran all the smokes inline + \`nix develop -c just\` for format and playwright. Half the flake checks weren't gated. Single column in the GitHub UI.

After:

- One \`build-gate\` populator job that \`nix build\`s every package + every check (cachix push). No assertions in this job — that's the apps' responsibility.
- One downstream job per concern, each \`needs: build-gate\`, each running \`nix run --quiet .#<name>\`. Cache hit on the check + visible stdout + its own column in the UI.

```
build-gate                                     populator (cachix push)
├── OpenAPI regen + diff
├── Swagger alias check
├── Smoke tx.identify
├── Smoke tx.witness.plan
├── Smoke tx.intent
├── Smoke tx.validate
├── Smoke tx.evaluate.scripts
├── Smoke explicit UTxO input context
├── Smoke Extism conformance vs WASI
├── Format (fourmolu)
└── Playwright
```

Everything from \`flake.nix\`'s \`checks.<system>.*\` is now gated. So is the native \`tx-deep-diagnosis\` build, the native \`extism-spike-host\` build, the wasm \`wasm-extism-spike\` build (none were before), and \`format-check\`.

## 2. Apps wrap checks (single source of truth)

Each \`checks.<system>.<name>\` derivation gains a sibling \`apps.<system>.<name>\` wrapper. Apps are \`writeShellApplication\`s that depend on the check and \`cat\` its \`request.json\` + \`response.json\` to stdout. CI invokes the apps via \`nix run\`. Pattern lifted verbatim from \`cardano-mpfs-offchain/nix/project.nix\`.

\`format-check\` and \`test-playwright\` are similarly wrapped:

- \`format-check\` runs \`fourmolu -m check\` over \`libs apps nix/wasm\`.
- \`test-playwright\` runs against \`tx-inspector-ui\` with \`python3\` (needed by Playwright's \`webServer\`) and the Nix-provided playwright browser bundle.

\`nix develop -c <recipe>\` is no longer used in CI for anything.

## 3. Branch protection on \`main\`

\`scripts/setup-branch-protection.sh\` lists every gated context as required. **Already applied** — \`main\` is now protected:

- 13 required contexts (12 CI jobs + \`preview\` from \`pr-preview.yml\`)
- Strict up-to-date enforcement before merge
- No force-pushes, no deletions
- No required reviewers (single-maintainer repo; bump if collaborators join)
- \`enforce_admins: false\` allows emergency overrides if the gate itself breaks

Re-run \`./scripts/setup-branch-protection.sh\` whenever the required-contexts list changes.

## Verification

All 12 jobs green on this PR's tip (\`3916d00\`). One-time cost noted: \`wasm-extism-spike\` and the haskell.nix native closure had never been pushed to cachix \`paolino\` before this PR (no release-assets workflow runs, no prior CI gate built them); first run took ~15 min to compile and push, subsequent runs are 1-3 min cache hits across all jobs.