### PR TITLE
chore: rename to cardano-ledger-inspector + constitution v2.0.0

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,57 +1,91 @@
-# Cardano Ledger WASI Constitution
+# Cardano Ledger Inspector Constitution
 
 ## Core Principles
 
 ### I. Ledger Code Is Authoritative
-This repository exposes Cardano ledger semantics by compiling Haskell ledger
-code to WASI. Transaction decoding, inspection, checking, patching, and future
-balancing operations MUST go through the upstream ledger types and functions
-wherever they exist. Reimplementing ledger CBOR or era rules in JavaScript,
-PureScript, Rust, or ad hoc JSON logic is out of scope unless it is explicitly
-documented as a temporary compatibility shim.
+This repository exposes Cardano ledger semantics through a single Haskell
+library (`libs/cardano-ledger-inspector`) compiled to multiple targets:
+wasm32-wasi (loaded by the browser workbench), wasm32-wasi as an Extism
+plugin (for cross-implementation conformance), and natively (linked into
+host applications such as `apps/tx-deep-diagnosis`). Transaction decoding,
+inspection, validation, evaluation, and any future operations MUST go
+through the upstream Cardano ledger packages (`cardano-ledger-conway`,
+`cardano-ledger-api`, `plutus-ledger-api`, etc.) wherever they exist.
+Reimplementing ledger CBOR decoding, era rules, or `applyTx` semantics in
+JavaScript, PureScript, Rust, or ad hoc JSON logic — in any consumer — is
+out of scope unless it is explicitly documented as a temporary
+compatibility shim.
 
 ### II. Transaction Documents Own State
 Applications built here model user-visible work as explicit transaction
 documents. The canonical transaction state is CBOR bytes owned by the
-application/workspace. Haskell/WASI code MAY cache decoded values or handles for
-performance, but cached state MUST NOT become authoritative and MUST NOT make
-operation results depend on unobserved prior calls.
+application/workspace. The inspector library MAY cache decoded values or
+handles for performance, but cached state MUST NOT become authoritative
+and MUST NOT make operation results depend on unobserved prior calls.
 
 ### III. JSON Control Plane, CBOR Data Plane
 Ledger operation requests and responses use JSON for operation names, paths,
-diagnostics, summaries, and simple arguments. CBOR remains the canonical format
-for transactions and fidelity-sensitive ledger values. Structural JSON is a view
-over ledger data, not a round-trippable ledger serialization.
+diagnostics, summaries, and simple arguments. CBOR remains the canonical
+format for transactions and fidelity-sensitive ledger values. Structural
+JSON is a view over ledger data, not a round-trippable ledger serialization.
+The same JSON envelope works regardless of the consumer (browser via WASI,
+Extism plugin host, native CLI), so a tx that decodes in one consumer
+decodes byte-identically in the others.
 
 ### IV. Explicit Context Only
 Every ledger operation receives the current transaction CBOR, explicit
-operation arguments, and any external ledger context required for
-reproducibility. Provider or chain state MAY enter an operation only through an
-explicit request context or an explicitly named provider fetch.
+operation arguments, and any external ledger context (producer txs, protocol
+parameters, slot, epoch, network) required for reproducibility. Provider or
+chain state MAY enter an operation only through an explicit request context
+or an explicitly named provider fetch.
 
-### V. WASI Artifacts Are First-Class
-The repository's primary deliverables are WASI artifacts, the Nix builder that
-produces them, and small browser/CLI references that prove the artifacts work.
-The browser workbench exists to exercise the WASI ledger layer and demonstrate
-the operation API. It is not allowed to become the authority for ledger
-semantics.
+### V. The Library Is the Canonical Artifact
+The repository's primary deliverable is the `cardano-ledger-inspector`
+Haskell library. The per-target builds (WASI binary loaded in the browser,
+Extism plugin, native executables, Nix derivations) are packaging of the
+library, not implementations of the ledger semantics. A consumer is free
+to add a new target — another wasm runtime, a direct library link, a
+different host language via Extism — provided it consumes the inspector
+library's typed entry points (`runLedgerOperationInput` and friends)
+rather than reimplementing them.
 
 ## Quality Gates
 
-- WASI packages build reproducibly through Nix.
-- Haskell sources are Fourmolu-formatted.
-- PureScript browser sources compile.
-- Ledger operation contracts are documented before UI or provider behavior
-  depends on them.
-- Browser previews are verified with Playwright after UI changes.
+- The wasm32-wasi build is reproducible through Nix (`.#wasm-tx-inspector`).
+- The native build is reproducible through Nix via haskell.nix + CHaP
+  (`.#tx-deep-diagnosis`).
+- The Extism plugin build is reproducible through Nix (`.#wasm-extism-spike`)
+  and matches the WASI reactor byte-for-byte on the same input
+  (`.#tx-extism-spike-smoke`).
+- Haskell sources under `libs/`, `apps/`, and `nix/wasm/` are Fourmolu-formatted
+  (`.#format-check`).
+- PureScript browser sources compile and the inspector workbench Playwright
+  suite is green (`.#test-playwright`).
+- Ledger operation contracts are documented before UI, host, or provider
+  behavior depends on them.
+- The OpenAPI source-of-truth in `nix/ledger-functional-openapi.nix` regenerates
+  byte-identical to the committed `specs/001-ledger-functional-layer/openapi/...`
+  JSON (`.#ledger-functional-openapi-check`).
+- Every per-concern check is its own job in CI (`.github/workflows/ci.yml`)
+  with its own GitHub identity, and `main` is branch-protected requiring
+  every per-concern job to pass before merge
+  (`scripts/setup-branch-protection.sh`).
 
 ## Development Workflow
 
-- Nix-first: all local and CI commands run through `nix` or `just` recipes.
-- Pull requests are required after the initial bootstrap commit.
-- Keep commits focused: infrastructure, Haskell ledger operations, browser UI,
-  and documentation changes should be separable.
+- Nix-first: all local and CI commands run through `nix build` or `nix run`.
+  CI does not use `nix develop -c <recipe>`; per-concern jobs invoke
+  `nix run .#<app>` over checks wrapped as apps via
+  `pkgs.writeShellApplication` + `pkgs.lib.getExe`.
+- The build-gate populator `nix build`s every package + check (one cachix
+  push per run); per-concern downstream jobs `nix run` cache hits with
+  stdout visible.
+- Pull requests are required after the initial bootstrap commit. Every PR
+  must pass every required CI check before merging.
+- Keep commits focused: infrastructure, library changes, per-target builds,
+  host applications, browser UI, and documentation changes should be
+  separable.
 - Public artifacts and previews must be linked with HTTP URLs in handover
   messages and PR descriptions.
 
-**Version**: 1.0.0 | **Ratified**: 2026-04-25
+**Version**: 2.0.0 | **Ratified**: 2026-04-25 | **Last amended**: 2026-05-03

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# cardano-ledger-wasi Development Guidelines
+# cardano-ledger-inspector Development Guidelines
 
 Auto-generated from feature plans, then curated for this repository.
 Last updated: 2026-04-26

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cardano-ledger-wasi
+# cardano-ledger-inspector
 
 Cardano ledger operations compiled to WASI, with a browser transaction
 workbench that exercises the same Haskell ledger code.
@@ -48,8 +48,8 @@ walkthrough on the SundaeSwap fixture.
 You can also build directly from GitHub:
 
 ```bash
-nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.wasm-tx-inspector
-nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.tx-inspector-ui
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.wasm-tx-inspector
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.tx-inspector-ui
 ```
 
 ## Development
@@ -97,13 +97,13 @@ data, and complete-context execution-unit reporting.
 
 ## Published Site
 
-Repository docs: <https://lambdasistemi.github.io/cardano-ledger-wasi/>
+Repository docs: <https://lambdasistemi.github.io/cardano-ledger-inspector/>
 
-Functional API definition: <https://lambdasistemi.github.io/cardano-ledger-wasi/api/>
+Functional API definition: <https://lambdasistemi.github.io/cardano-ledger-inspector/api/>
 
-Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-wasi/swagger/>
+Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-inspector/swagger/>
 
-Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-wasi/inspector/>
+Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>
 
 Pull-request previews are published to Surge by the `PR preview` workflow.
 
@@ -128,7 +128,7 @@ conventional-commit history. Each release attaches:
   JSON envelope.
 - `SHA256SUMS-<tag>.txt` — checksums.
 
-Releases: <https://github.com/lambdasistemi/cardano-ledger-wasi/releases>
+Releases: <https://github.com/lambdasistemi/cardano-ledger-inspector/releases>
 
 ## CI Artifacts (per-run, ephemeral)
 
@@ -142,7 +142,7 @@ anything you depend on.
   `SHA256SUMS`.
 
 Open a workflow run under
-<https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml>
+<https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml>
 and download them from the run's **Artifacts** section.
 
 ## License

--- a/docs/inspector/protocols/README.md
+++ b/docs/inspector/protocols/README.md
@@ -6,9 +6,9 @@ typed schemas.
 
 This directory is **data only** at this stage. The decoder primitive that
 consumes it is tracked in
-[issue #35](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/35);
+[issue #35](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/35);
 the SundaeSwap V3 wiring in
-[issue #36](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/36).
+[issue #36](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/36).
 
 ## Layout
 

--- a/docs/inspector/protocols/WORKED-EXAMPLE.md
+++ b/docs/inspector/protocols/WORKED-EXAMPLE.md
@@ -1,15 +1,15 @@
 # Issue #31 fixture, fully decoded by hand
 
 Reference for what the inspector should produce once issues
-[#32](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/32),
-[#33](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/33),
-[#34](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/34),
-[#35](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/35),
-[#36](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/36) and
-[#37](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/37) ship.
+[#32](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/32),
+[#33](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/33),
+[#34](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/34),
+[#35](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/35),
+[#36](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/36) and
+[#37](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/37) ship.
 
 Fixture: `specs/001-ledger-functional-layer/fixtures/sundae-swap-usdm-disbursement.hex`
-(the tx from [issue #31](https://github.com/lambdasistemi/cardano-ledger-wasi/issues/31)).
+(the tx from [issue #31](https://github.com/lambdasistemi/cardano-ledger-inspector/issues/31)).
 
 ## Sources used
 

--- a/docs/inspector/protocols/registry.json
+++ b/docs/inspector/protocols/registry.json
@@ -1,5 +1,5 @@
 {
-  "$schema_note": "Draft shape for the inspector's protocol registry. Spec under iteration in https://github.com/lambdasistemi/cardano-ledger-wasi/issues/35.",
+  "$schema_note": "Draft shape for the inspector's protocol registry. Spec under iteration in https://github.com/lambdasistemi/cardano-ledger-inspector/issues/35.",
   "blueprints": [
     {
       "id": "sundaeswap-v3",

--- a/gh-docs/api.md
+++ b/gh-docs/api.md
@@ -106,17 +106,17 @@ workspace management stay outside the ledger WASI layer.
 
 The detailed contract and schemas are tracked in the repository:
 
-- [Functional API contract](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
-- [OpenAPI document](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json)
-- [Request schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json)
-- [Response schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json)
-- [Producer transaction context schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/producer-tx-context.schema.json)
-- [Browser view schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/browser-view.schema.json)
-- [tx.identify result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json)
-- [tx.intent result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json)
-- [tx.witness.plan result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json)
-- [tx.validate result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-validate-result.schema.json)
-- [tx.evaluate.scripts result schema](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/schemas/tx-evaluate-scripts-result.schema.json)
+- [Functional API contract](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+- [OpenAPI document](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json)
+- [Request schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json)
+- [Response schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json)
+- [Producer transaction context schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/producer-tx-context.schema.json)
+- [Browser view schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/browser-view.schema.json)
+- [tx.identify result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json)
+- [tx.intent result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json)
+- [tx.witness.plan result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json)
+- [tx.validate result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-validate-result.schema.json)
+- [tx.evaluate.scripts result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-evaluate-scripts-result.schema.json)
 
 The same OpenAPI bundle is a flake output:
 

--- a/gh-docs/build.md
+++ b/gh-docs/build.md
@@ -117,8 +117,8 @@ Amaru Network Compliance treasury", not just the bare hex.
 ## Build From GitHub
 
 ```bash
-nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.wasm-tx-inspector
-nix build github:lambdasistemi/cardano-ledger-wasi#packages.x86_64-linux.tx-inspector-ui
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.wasm-tx-inspector
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.tx-inspector-ui
 ```
 
 ## Download CI Artifacts
@@ -133,11 +133,11 @@ Every `CI` workflow run uploads downloadable artifacts:
 
 Download them from the artifact section of a CI run:
 
-[CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml)
+[CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml)
 
 ## Published Documentation Site
 
 GitHub Pages publishes this documentation site and mounts the transaction
 inspector at:
 
-<https://lambdasistemi.github.io/cardano-ledger-wasi/inspector/>
+<https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -129,7 +129,7 @@ validation diagnostics rather than being guessed by the UI.
 browser panel can be added separately once its UI flow is selected.
 
 A complete positive request is committed at
-[`specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json).
+[`specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json`](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json).
 It validates the current mainnet fixture with producer transaction CBOR,
 network, slot, epoch, and protocol parameters, and the smoke check asserts
 `status: "valid"` and `valid_for_supplied_context: true`.
@@ -139,7 +139,7 @@ network, slot, epoch, and protocol parameters, and the smoke check asserts
 The readable API page and detailed contract are tracked here:
 
 - [API definition](api.md)
-- [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+- [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
 
 ## Direction
 

--- a/gh-docs/index.md
+++ b/gh-docs/index.md
@@ -24,13 +24,13 @@ and a browsable transaction result.
 
 ## Important Links
 
-- Repository: [lambdasistemi/cardano-ledger-wasi](https://github.com/lambdasistemi/cardano-ledger-wasi)
+- Repository: [lambdasistemi/cardano-ledger-inspector](https://github.com/lambdasistemi/cardano-ledger-inspector)
 - Inspector page: [GitHub Pages inspector](inspector/)
 - API definition: [Functional API](api.md)
 - Swagger UI: [OpenAPI reference](swagger.md)
-- CI artifacts: [CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-wasi/actions/workflows/ci.yml)
-- Constitution: [`.specify/memory/constitution.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/.specify/memory/constitution.md)
-- Functional API contract: [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
+- CI artifacts: [CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml)
+- Constitution: [`.specify/memory/constitution.md`](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/.specify/memory/constitution.md)
+- Functional API contract: [`specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md)
 
 ## Design Commitments
 

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ build-pages-site:
 
 deploy-surge-preview:
     nix build .#packages.x86_64-linux.tx-inspector-ui
-    rm -rf /tmp/cardano-ledger-wasi-surge
-    mkdir -p /tmp/cardano-ledger-wasi-surge
-    cp -rL result/* /tmp/cardano-ledger-wasi-surge/
-    nix shell 'nixpkgs#nodejs_20' -c npx --yes surge /tmp/cardano-ledger-wasi-surge cardano-tx-inspector.surge.sh
+    rm -rf /tmp/cardano-ledger-inspector-surge
+    mkdir -p /tmp/cardano-ledger-inspector-surge
+    cp -rL result/* /tmp/cardano-ledger-inspector-surge/
+    nix shell 'nixpkgs#nodejs_20' -c npx --yes surge /tmp/cardano-ledger-inspector-surge cardano-tx-inspector.surge.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Cardano Ledger WASI
-site_url: https://lambdasistemi.github.io/cardano-ledger-wasi/
+site_url: https://lambdasistemi.github.io/cardano-ledger-inspector/
 docs_dir: gh-docs
 
 theme:
@@ -33,7 +33,7 @@ nav:
   - API Definition: api.md
   - Swagger UI: swagger.md
   - Build and Artifacts: build.md
-  - Repository: https://github.com/lambdasistemi/cardano-ledger-wasi
+  - Repository: https://github.com/lambdasistemi/cardano-ledger-inspector
 
 plugins:
   - search

--- a/nix/ledger-functional-openapi.nix
+++ b/nix/ledger-functional-openapi.nix
@@ -7,12 +7,12 @@
     version = "0.1.0-draft";
     license = {
       name = "Apache-2.0";
-      url = "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE";
+      url = "https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/LICENSE";
     };
   };
   externalDocs = {
     description = "Functional API contract";
-    url = "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md";
+    url = "https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md";
   };
   servers = [
     {

--- a/nix/wasm/default.nix
+++ b/nix/wasm/default.nix
@@ -1,4 +1,4 @@
-# Public API surface for cardano-ledger-wasi.lib.wasm.
+# Public API surface for cardano-ledger-inspector.lib.wasm.
 #
 # Module is system-agnostic: only nixpkgs `lib` is needed to build strings.
 # Per-system `pkgs` and `ghcWasmMeta` flow through `mkCardanoLedgerWasm`'s own

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "release-type": "simple",
   "packages": {
     ".": {
-      "package-name": "cardano-ledger-wasi",
+      "package-name": "cardano-ledger-inspector",
       "include-component-in-tag": false,
       "initial-version": "0.1.0"
     }

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -65,13 +65,13 @@
   },
   "externalDocs": {
     "description": "Functional API contract",
-    "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md"
+    "url": "https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md"
   },
   "info": {
     "description": "This OpenAPI document describes the JSON control envelope used by host adapters around the Cardano Ledger WASI functional layer. The repository does not publish a stateful hosted service. WASI callers use the same request and response schemas through stdin/stdout; HTTP adapters can expose the POST shape documented here.",
     "license": {
       "name": "Apache-2.0",
-      "url": "https://github.com/lambdasistemi/cardano-ledger-wasi/blob/main/LICENSE"
+      "url": "https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/LICENSE"
     },
     "summary": "Functional ledger-operation boundary for Cardano transaction tooling.",
     "title": "Cardano Ledger WASI Functional API",

--- a/specs/001-ledger-functional-layer/schemas/browser-view.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/browser-view.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/browser-view.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/browser-view.schema.json",
   "title": "Cardano Ledger WASI Browser View",
   "type": "object",
   "required": [

--- a/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/ledger-operation-request.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/ledger-operation-request.schema.json",
   "title": "Cardano Ledger WASI Ledger Operation Request",
   "type": "object",
   "required": ["tx_cbor", "op"],

--- a/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/ledger-operation-response.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/ledger-operation-response.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/ledger-operation-response.schema.json",
   "title": "Cardano Ledger WASI Ledger Operation Response",
   "type": "object",
   "required": ["ledger_functional_layer", "op", "result"],

--- a/specs/001-ledger-functional-layer/schemas/producer-tx-context.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/producer-tx-context.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/producer-tx-context.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/producer-tx-context.schema.json",
   "title": "Cardano Ledger WASI Producer Transaction Context",
   "type": "object",
   "properties": {

--- a/specs/001-ledger-functional-layer/schemas/tx-evaluate-scripts-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-evaluate-scripts-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-evaluate-scripts-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-evaluate-scripts-result.schema.json",
   "title": "tx.evaluate.scripts result",
   "type": "object",
   "additionalProperties": false,

--- a/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-identify-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-identify-result.schema.json",
   "title": "Cardano Ledger WASI tx.identify Result",
   "type": "object",
   "required": [

--- a/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-intent-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-intent-result.schema.json",
   "title": "Cardano Ledger WASI Transaction Intent Result",
   "type": "object",
   "required": ["title", "subtitle", "metrics", "claims", "sections", "warnings"],

--- a/specs/001-ledger-functional-layer/schemas/tx-validate-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-validate-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-validate-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-validate-result.schema.json",
   "title": "Cardano Ledger WASI tx.validate Result",
   "type": "object",
   "required": [

--- a/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-witness-plan-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-witness-plan-result.schema.json",
   "title": "Cardano Ledger WASI tx.witness.plan Result",
   "type": "object",
   "required": [

--- a/specs/002-tx-validate/contracts/schemas/tx-validate-args.schema.json
+++ b/specs/002-tx-validate/contracts/schemas/tx-validate-args.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-validate-args.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-validate-args.schema.json",
   "title": "Cardano Ledger WASI tx.validate Args",
   "type": "object",
   "properties": {

--- a/specs/002-tx-validate/contracts/schemas/tx-validate-result.schema.json
+++ b/specs/002-tx-validate/contracts/schemas/tx-validate-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-validate-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-validate-result.schema.json",
   "title": "Cardano Ledger WASI tx.validate Result",
   "type": "object",
   "required": [

--- a/specs/003-tx-evaluate-scripts/contracts/schemas/tx-evaluate-scripts-args.schema.json
+++ b/specs/003-tx-evaluate-scripts/contracts/schemas/tx-evaluate-scripts-args.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-evaluate-scripts-args.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-evaluate-scripts-args.schema.json",
   "title": "tx.evaluate.scripts arguments",
   "type": "object",
   "additionalProperties": false,

--- a/specs/003-tx-evaluate-scripts/contracts/schemas/tx-evaluate-scripts-result.schema.json
+++ b/specs/003-tx-evaluate-scripts/contracts/schemas/tx-evaluate-scripts-result.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://lambdasistemi.github.io/cardano-ledger-wasi/schemas/tx-evaluate-scripts-result.schema.json",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-evaluate-scripts-result.schema.json",
   "title": "tx.evaluate.scripts result",
   "type": "object",
   "additionalProperties": false,


### PR DESCRIPTION
Closes part of #43 (the in-repo halves; the GitHub-side `gh api PATCH` to actually rename the repo and the post-rename branch-protection re-apply remain — separate admin actions).

## Constitution rewritten to v2.0.0

Key changes (full diff in `.specify/memory/constitution.md`):

- Title drops "WASI" (now "Cardano Ledger Inspector Constitution").
- **Principle I** broadens "compiling Haskell ledger code to WASI" → "a Haskell library compiled to wasm32-wasi, wasm32-wasi-as-Extism, and native targets."
- **Principle V** replaces "WASI Artifacts Are First-Class" with "The Library Is the Canonical Artifact" (per-target builds are packaging, not implementations).
- **Quality Gates** expanded to mention native + Extism builds, the OpenAPI regen check, and per-concern CI job naming.
- **Development Workflow** drops "`just` recipes" in favour of `nix build` / `nix run`, and adds the build-gate populator + downstream apps pattern (per the nix skill).
- Version bumped 1.0.0 → 2.0.0; "Last amended" stamped 2026-05-03.

## In-repo references swept

29 files updated from `cardano-ledger-wasi` to `cardano-ledger-inspector`:

- README.md, AGENTS.md, mkdocs.yml, gh-docs/{index,build,api,functional-layer}.md
- release-please-config.json, justfile, nix/ledger-functional-openapi.nix, nix/wasm/default.nix
- All committed spec/openapi JSON (`$id` URLs and external doc links)
- docs/inspector/protocols/{README,WORKED-EXAMPLE,registry}.json (the issue-link refs from PR #39)

## Verification

- `nix build .#checks.x86_64-linux.ledger-functional-openapi-check` — clean (the regenerated OpenAPI matches the committed JSON after sweeping the URL references in both)
- `nix run .#format-check` — clean
- `nix build .#wasm-tx-inspector .#tx-deep-diagnosis` — clean
- The 12 per-concern CI jobs are in flight on the new gate and required by branch protection.

## Out of scope (admin follow-ups, listed in #43)

- `gh api -X PATCH repos/lambdasistemi/cardano-ledger-wasi -f name=cardano-ledger-inspector`
- Re-running `./scripts/setup-branch-protection.sh lambdasistemi cardano-ledger-inspector main` (GitHub does not carry branch-protection settings through repo renames)
- GitHub Pages URL transition: `lambdasistemi.github.io/cardano-ledger-wasi/` → `lambdasistemi.github.io/cardano-ledger-inspector/` (auto-redirects work for browser users)