### PR TITLE
feat(inspector+host): cert_state via Blockfrost /accounts

### DIFF
--- a/apps/tx-deep-diagnosis/app/Main.hs
+++ b/apps/tx-deep-diagnosis/app/Main.hs
@@ -5,7 +5,7 @@ module Main (main) where
 import Control.Applicative ((<|>))
 import qualified Data.Aeson as Aeson
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
@@ -132,6 +132,14 @@ main = do
                         Left e -> hPutStrLn stderr ("protocol-parameters fetch failed: " <> e)
                         _ -> pure ()
                     pure (prods, Nothing, Nothing)
+    -- Phase 2.5: build cert_state by fetching the rewards balance for
+    -- every withdrawal credential the probe surfaced.
+    let withdrawalCreds = extractMissingWithdrawalCredentials probe
+    mCertState <- case mpid of
+        Just pid
+            | not (null withdrawalCreds) ->
+                Just <$> buildCertState mgr (optNetwork opts) pid withdrawalCreds
+        _ -> pure Nothing
     -- Phase 3: validate again with everything we collected.
     let fullCtx =
             ValidationContext
@@ -140,6 +148,7 @@ main = do
                 , vcSlot = fmap lbSlot mLatest
                 , vcEpoch = fmap lbEpoch mLatest
                 , vcProtocolParameters = mPParams
+                , vcCertState = mCertState
                 }
     validate <- case runValidate hex fullCtx of
         Left e -> die ("validate error: " <> e)
@@ -168,3 +177,90 @@ fetchProducer mgr net pid h = do
                 stderr
                 ("producer fetch failed for " <> Text.unpack h <> ": " <> e)
             pure (h, Left e)
+
+{- | For each withdrawal credential surfaced by the probe, look up the
+ current rewards balance via Blockfrost and assemble the cert_state
+ JSON the inspector library expects. Failures (bad bech32 derivation,
+ HTTP errors, unregistered accounts) are logged but do not abort —
+ the unresolved credentials simply do not appear in the output, and
+ the ledger will then surface its own CERTS error for them, which is
+ more useful diagnostic output than a host-side abort.
+-}
+buildCertState ::
+    Manager -> Network -> Text -> [WithdrawalCredential] -> IO Aeson.Value
+buildCertState mgr net pid creds = do
+    rewardEntries <- mapM (fetchRewardsEntry mgr net pid) creds
+    pure $
+        Aeson.object
+            [ ("rewards", Aeson.toJSON (catMaybes rewardEntries))
+            ]
+
+fetchRewardsEntry ::
+    Manager -> Network -> Text -> WithdrawalCredential -> IO (Maybe Aeson.Value)
+fetchRewardsEntry mgr net pid cred = do
+    let kind = case wcKind cred of
+            "script" -> Just ScriptCred
+            "key" -> Just KeyCred
+            _ -> Nothing
+    case kind of
+        Nothing -> do
+            hPutStrLn
+                stderr
+                ("unknown credential.kind: " <> Text.unpack (wcKind cred))
+            pure Nothing
+        Just k -> case stakeAddressBech32 net k (wcHash cred) of
+            Left e -> do
+                hPutStrLn
+                    stderr
+                    ( "stake-address derivation failed for "
+                        <> Text.unpack (wcHash cred)
+                        <> ": "
+                        <> e
+                    )
+                pure Nothing
+            Right stake -> do
+                eAcc <- fetchAccountInfo mgr net pid stake
+                case eAcc of
+                    Left e -> do
+                        hPutStrLn
+                            stderr
+                            ( "account fetch failed for "
+                                <> Text.unpack stake
+                                <> ": "
+                                <> e
+                            )
+                        pure Nothing
+                    Right info
+                        | not (aiRegistered info) -> do
+                            -- Truly unknown to the chain. Skip; CERTS
+                            -- will then reject with a clear message
+                            -- naming the credential, which is the right
+                            -- diagnostic signal for the user.
+                            hPutStrLn
+                                stderr
+                                ( "stake credential never registered on chain: "
+                                    <> Text.unpack stake
+                                    <> " (CERTS will reject this withdrawal)"
+                                )
+                            pure Nothing
+                        | otherwise -> do
+                            -- registered=true with active=false is the
+                            -- normal state for a withdraw-zero trigger
+                            -- script that never delegates ADA — seed
+                            -- and let the ledger evaluate.
+                            pure $
+                                Just $
+                                    Aeson.object
+                                        [ ("credential", credentialJson cred)
+                                        ,
+                                            ( "balance_lovelace"
+                                            , Aeson.String (Text.pack (show (aiWithdrawableLovelace info)))
+                                            )
+                                        ]
+
+credentialJson :: WithdrawalCredential -> Aeson.Value
+credentialJson cred =
+    Aeson.object
+        [ ("kind", Aeson.String (wcKind cred))
+        , ("hash", Aeson.String (wcHash cred))
+        ]

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Blockfrost.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Blockfrost.hs
@@ -4,26 +4,34 @@ module TxDeepDiagnosisHost.Blockfrost (
     Network (..),
     networkBaseUrl,
     networkLedgerName,
+    CredentialKind (..),
     ResolvedOutput (..),
     ResolvedAsset (..),
     LatestBlock (..),
+    AccountInfo (..),
     fetchTxUtxos,
     fetchTxCbor,
     fetchOutputAtIndex,
     fetchLatestBlock,
     fetchProtocolParametersJson,
+    fetchAccountInfo,
     remapPParamsToLedger,
+    stakeAddressBech32,
 ) where
 
+import qualified Codec.Binary.Bech32 as Bech32
 import Control.Exception (SomeException, try)
 import Data.Aeson (FromJSON (..), eitherDecode, withObject, (.!=), (.:), (.:?))
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Lazy as BSL
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as TE
+import Data.Word (Word8)
 import Network.HTTP.Client
 import Network.HTTP.Types.Header (hAccept)
 import Network.HTTP.Types.Status (statusCode)
@@ -263,6 +271,97 @@ remapPParamsToLedger raw = case raw of
     numberOrNull (Just v@(A.Number _)) = v
     numberOrNull (Just A.Null) = A.Null
     numberOrNull (Just other) = other
+
+{- | Whether a stake credential is a key hash or a script hash. The
+ encoding only differs in one bit of the address header byte.
+-}
+data CredentialKind = KeyCred | ScriptCred
+    deriving (Eq, Show)
+
+{- | The handful of fields the deep-diagnosis tool needs from
+ @GET /accounts/{stake_address}@. Other fields (delegation,
+ rewards_sum, controlled_amount, …) are intentionally ignored.
+-}
+data AccountInfo = AccountInfo
+    { aiActive :: !Bool
+    -- ^ Whether the credential is currently delegated to a stake pool.
+    -- For trigger-only stake scripts (SundaeSwap, Indigo, …) this is
+    -- usually @false@ even when the account is fully registered and
+    -- usable as a withdraw-zero target — they never delegate ADA.
+    , aiRegistered :: !Bool
+    -- ^ Whether the credential has *ever* been registered. This is the
+    -- field that matters for the CERTS withdrawal rule: a registered
+    -- account exists in the rewards map (with whatever balance) and
+    -- can be the target of a withdrawal; an unregistered credential
+    -- cannot.
+    , aiWithdrawableLovelace :: !Integer
+    -- ^ Current rewards balance in lovelace. The withdrawal in the tx
+    -- body must equal this exactly (typically 0 for withdraw-zero
+    -- triggers).
+    }
+    deriving (Show)
+
+instance FromJSON AccountInfo where
+    parseJSON = withObject "AccountInfo" $ \o -> do
+        active <- o .: "active"
+        registered <- o .:? "registered" .!= active
+        wd <- o .: "withdrawable_amount"
+        n <- case Text.unpack wd of
+            s -> case reads s of
+                [(n, "")] -> pure n
+                _ -> fail ("bad withdrawable_amount: " <> s)
+        pure
+            AccountInfo
+                { aiActive = active
+                , aiRegistered = registered
+                , aiWithdrawableLovelace = n
+                }
+
+{- | Fetch the account state for the given bech32 stake address. Use
+ 'stakeAddressBech32' to derive the address from a credential.
+-}
+fetchAccountInfo ::
+    Manager -> Network -> Text -> Text -> IO (Either String AccountInfo)
+fetchAccountInfo mgr net pid stake = do
+    let url = networkBaseUrl net <> "/accounts/" <> stake
+    eBody <- callBlockfrost mgr url pid
+    pure $ case eBody of
+        Left e -> Left e
+        Right body -> case eitherDecode body of
+            Left e -> Left ("JSON decode error: " <> e)
+            Right info -> Right info
+
+{- | Encode a stake credential as a bech32 stake address suitable for the
+  @GET /accounts/{stake_address}@ endpoint.
+
+  > header_byte = 0xe1 (mainnet, key)   | 0xf1 (mainnet, script)
+  >             | 0xe0 (testnet, key)   | 0xf0 (testnet, script)
+  > address     = header_byte || 28-byte credential hash
+  > hrp         = "stake" (mainnet)     | "stake_test" (testnet)
+-}
+stakeAddressBech32 ::
+    Network -> CredentialKind -> Text -> Either String Text
+stakeAddressBech32 net kind hashHex = do
+    bytes <- case B16.decode (TE.encodeUtf8 hashHex) of
+        Right bs -> Right bs
+        Left err -> Left ("hash hex decode failed: " <> err)
+    if BS.length bytes /= 28
+        then Left ("expected 28 bytes for credential hash, got " <> show (BS.length bytes))
+        else
+            let header :: Word8
+                header = case (net, kind) of
+                    (Mainnet, KeyCred) -> 0xe1
+                    (Mainnet, ScriptCred) -> 0xf1
+                    (_, KeyCred) -> 0xe0
+                    (_, ScriptCred) -> 0xf0
+                payload = BS.cons header bytes
+                hrpText = case net of
+                    Mainnet -> "stake"
+                    _ -> "stake_test"
+             in case Bech32.humanReadablePartFromText hrpText of
+                    Left err -> Left ("bad hrp: " <> show err)
+                    Right hrp ->
+                        Right (Bech32.encodeLenient hrp (Bech32.dataPartFromBytes payload))
 
 callBlockfrost :: Manager -> Text -> Text -> IO (Either String BSL.ByteString)
 callBlockfrost mgr url pid = do

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Diagnosis.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Diagnosis.hs
@@ -2,6 +2,7 @@
 
 module TxDeepDiagnosisHost.Diagnosis (
     ValidationContext (..),
+    WithdrawalCredential (..),
     emptyContext,
     runIntent,
     runValidate,
@@ -9,6 +10,7 @@ module TxDeepDiagnosisHost.Diagnosis (
     buildValidateRequest,
     buildProducerTxsObject,
     extractProducerTxIds,
+    extractMissingWithdrawalCredentials,
     showInspectError,
 ) where
 
@@ -30,7 +32,23 @@ data ValidationContext = ValidationContext
     , vcSlot :: !(Maybe Integer)
     , vcEpoch :: !(Maybe Integer)
     , vcProtocolParameters :: !(Maybe Value)
+    , vcCertState :: !(Maybe Value)
+    -- ^ Optional cert_state JSON, schema:
+    --   @{ "rewards": [{"credential": {"kind","hash"}, "balance_lovelace": "<int>"}] }@
+    -- The inspector library reads this to seed the @Accounts@ map
+    -- before running Conway @applyTx@ (rewards-only is enough for
+    -- withdraw-zero patterns).
     }
+
+{- | A withdrawal credential the validator wants the host to look up
+  off-chain. Pulled out of the cert_state @missing_context@ entry's
+  @details.withdrawal_credentials@ array.
+-}
+data WithdrawalCredential = WithdrawalCredential
+    { wcKind :: !Text
+    , wcHash :: !Text
+    }
+    deriving (Eq, Ord, Show)
 
 emptyContext :: ValidationContext
 emptyContext =
@@ -40,6 +58,7 @@ emptyContext =
         , vcSlot = Nothing
         , vcEpoch = Nothing
         , vcProtocolParameters = Nothing
+        , vcCertState = Nothing
         }
 
 runIntent :: Text -> Either String Value
@@ -86,12 +105,13 @@ buildValidateRequest txHex ctx =
             <> maybe [] (\e -> [("epoch", A.String (Text.pack (show e)))]) (vcEpoch ctx)
             <> maybe [] (\p -> [("protocol_parameters", p)]) (vcProtocolParameters ctx)
             -- cert_state is required by the validator when the tx has
-            -- withdrawals or certificates, but the inspector library
-            -- only checks for its presence — not contents — to mark the
-            -- ledger.apply_tx scope as ready to run. Supplying an empty
-            -- object satisfies the gate.
-            <> [("cert_state", A.object [])]
-            <> [("source", A.String "tx-deep-diagnosis.blockfrost+latest+pparams")]
+            -- withdrawals or certificates. The inspector library reads
+            -- the @rewards@ entries to seed the Accounts map before
+            -- Conway applyTx runs; an empty object still satisfies the
+            -- gate but yields no seeded entries (CERTS will then reject
+            -- the withdrawal).
+            <> maybe [] (\c -> [("cert_state", c)]) (vcCertState ctx)
+            <> [("source", A.String "tx-deep-diagnosis.blockfrost+latest+pparams+cert_state")]
 
 buildProducerTxsObject :: Map Text Text -> Value
 buildProducerTxsObject m =
@@ -119,4 +139,26 @@ extractProducerTxIds resp =
         , A.Object entry <- foldr (:) [] missing
         , Just (A.String "source_output") <- [KeyMap.lookup "kind" entry]
         , Just (A.String txid) <- [KeyMap.lookup "tx_id" entry]
+        ]
+
+{- | Walk a tx.validate response and extract the de-duplicated stake
+  credentials the validator wants the host to look up off-chain. Each
+  entry comes from a missing_context @kind == "cert_state"@ row whose
+  @details.withdrawal_credentials@ array names the credentials.
+-}
+extractMissingWithdrawalCredentials :: Value -> [WithdrawalCredential]
+extractMissingWithdrawalCredentials resp =
+    nub
+        [ WithdrawalCredential{wcKind = kind, wcHash = hash}
+        | A.Object root <- [resp]
+        , Just (A.Object result) <- [KeyMap.lookup "result" root]
+        , Just (A.Object validation) <- [KeyMap.lookup "validation" result]
+        , Just (A.Array missing) <- [KeyMap.lookup "missing_context" validation]
+        , A.Object entry <- foldr (:) [] missing
+        , Just (A.String "cert_state") <- [KeyMap.lookup "kind" entry]
+        , Just (A.Object details) <- [KeyMap.lookup "details" entry]
+        , Just (A.Array creds) <- [KeyMap.lookup "withdrawal_credentials" details]
+        , A.Object cred <- foldr (:) [] creds
+        , Just (A.String kind) <- [KeyMap.lookup "kind" cred]
+        , Just (A.String hash) <- [KeyMap.lookup "hash" cred]
         ]

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -32,6 +32,7 @@ library
     , aeson-pretty
     , base                  >=4.18 && <5
     , base16-bytestring
+    , bech32                >=1.1
     , bytestring
     , containers
     , directory

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector/Validation.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector/Validation.hs
@@ -12,19 +12,27 @@ module Conway.Inspector.Validation (
     validateTxJson,
 ) where
 
+import qualified Cardano.Crypto.Hash as Crypto
+import qualified Cardano.Ledger.Address as Addr
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as BaseTypes
+import qualified Cardano.Ledger.Coin as Coin
 import qualified Cardano.Ledger.Conway as Conway
 import qualified Cardano.Ledger.Conway.Rules as ConwayRules
+import Cardano.Ledger.Conway.State (ConwayAccountState (..))
 import Cardano.Ledger.Core (TxLevel (..))
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Credential as Credential
+import qualified Cardano.Ledger.Hashes as Hashes
 import qualified Cardano.Ledger.Shelley.API.Mempool as Mempool
 import qualified Cardano.Ledger.Shelley.LedgerState as ShelleyState
+import qualified Cardano.Ledger.State as LedgerState
 import qualified Cardano.Ledger.TxIn as TxIn
 import qualified Cardano.Slotting.EpochInfo as EpochInfo
 import qualified Cardano.Slotting.Time as SlottingTime
 import Conway.Inspector.Common (
     argsObject,
+    hashHex,
     lookupObjectValue,
     lookupValue,
     txIdHex,
@@ -50,7 +58,9 @@ import Conway.Inspector.Context (
 import Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.KeyMap as AesonKeyMap
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as B16
 import Data.Default (def)
 import Data.Foldable (toList)
 import Data.Function ((&))
@@ -58,9 +68,10 @@ import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing)
 import Data.Ratio ((%))
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word64)
-import Lens.Micro ((.~), (^.))
+import Lens.Micro ((%~), (.~), (^.))
 import Text.Read (readMaybe)
 
 data LedgerApplyResult
@@ -113,6 +124,9 @@ validateTxJson _txBytes args tx =
                 "Supply a complete Conway protocol-parameter object."
                 parseProtocolParametersValue
                 contextValue
+        certStateInput = parseCertStateContext body contextValue
+        (certStateMissing, certStateErrors, certStateRewards) =
+            classifyCertStateInput certStateInput
         contextErrors =
             inputPolicyErrors inputPolicy
                 <> unsupportedUtxoJsonErrors contextValue
@@ -132,6 +146,7 @@ validateTxJson _txBytes args tx =
                 <> slotErrors
                 <> epochErrors
                 <> pparamsErrors
+                <> certStateErrors
         baseMissingContext =
             zipWith
                 (missingSourceOutputContextJson "input" "inputs")
@@ -145,7 +160,7 @@ validateTxJson _txBytes args tx =
                 <> slotMissing
                 <> epochMissing
                 <> pparamsMissing
-                <> unsupportedFeatureMissingContext body
+                <> certStateMissing
         ledgerApplyResult =
             runLedgerApplyTx
                 contextErrors
@@ -154,6 +169,7 @@ validateTxJson _txBytes args tx =
                 slot
                 epoch
                 pparams
+                certStateRewards
                 context
                 inputs
                 referenceInputs
@@ -309,12 +325,13 @@ runLedgerApplyTx ::
     Maybe Word64 ->
     Maybe Word64 ->
     Maybe (Core.PParams Conway.ConwayEra) ->
+    [CertStateRewardEntry] ->
     ProducerContext ->
     [TxIn.TxIn] ->
     [TxIn.TxIn] ->
     L.Tx TopTx Conway.ConwayEra ->
     LedgerApplyResult
-runLedgerApplyTx contextErrors missingContext network slot epoch pparams context inputs referenceInputs tx
+runLedgerApplyTx contextErrors missingContext network slot epoch pparams rewards context inputs referenceInputs tx
     | not (null contextErrors) =
         LedgerApplyNotEvaluated
             "Conway applyTx was not run because validation context is invalid."
@@ -326,8 +343,9 @@ runLedgerApplyTx contextErrors missingContext network slot epoch pparams context
             (Just network', Just slot', Just epoch', Just pparams') ->
                 let globals = validationGlobals network'
                     newEpochState =
-                        validationNewEpochState epoch' pparams' $
-                            validationSourceUTxO context (inputs <> referenceInputs)
+                        seedCertStateRewards rewards $
+                            validationNewEpochState epoch' pparams' $
+                                validationSourceUTxO context (inputs <> referenceInputs)
                     env =
                         Mempool.mkMempoolEnv
                             newEpochState
@@ -602,32 +620,249 @@ producerOutputIndexContextErrors inputKind collection context txIns =
     , isNothing (producerOutputAt txIn producer)
     ]
 
-unsupportedFeatureMissingContext ::
+{- | A parsed cert_state.rewards entry: a credential and the current
+  reward balance the ledger should see in the seeded account state.
+
+  For a withdraw-zero validation pattern (SundaeSwap, Indigo, Minswap V2,
+  …) the credential is the script-hash credential of the staking
+  validator and the balance is 0; the entry exists so the CERTS rule
+  finds a registered account whose balance matches the 0-lovelace
+  withdrawal.
+-}
+data CertStateRewardEntry = CertStateRewardEntry
+    { csrCredential :: !(Credential.Credential Hashes.Staking)
+    , csrBalance :: !Coin.Coin
+    }
+
+{- | Result of looking at @args.context.cert_state@. Either it was not
+  supplied (and the body has features that require it), or it was
+  malformed (collected as context errors), or it parsed successfully
+  into a list of rewards entries.
+-}
+data CertStateInput
+    = -- | withdrawal credentials surfaced for host auto-resolution
+      CertStateAbsent ![Aeson.Value]
+    | -- | context errors
+      CertStateMalformed ![Aeson.Value]
+    | CertStateRewards ![CertStateRewardEntry]
+
+{- | Reads @args.context.cert_state@ if present and decides one of three
+  outcomes: absent (with details about what the host should fetch),
+  malformed (with context errors), or a list of parsed rewards entries
+  ready to be seeded into the ledger state.
+
+  Schema (rewards-only — the only piece the CERTS rule reads for
+  withdrawals):
+
+  > { "rewards": [{ "credential": {"kind":"key"|"script","hash":"<hex>"}
+  >              , "balance_lovelace": "<integer>" }, ...] }
+-}
+parseCertStateContext ::
     Core.TxBody TopTx Conway.ConwayEra ->
-    [Aeson.Value]
-unsupportedFeatureMissingContext body =
+    Maybe Aeson.Value ->
+    CertStateInput
+parseCertStateContext body mContext =
     let certCount = length (toList (body ^. L.certsTxBodyL))
-        withdrawalCount = withdrawalsCount (body ^. L.withdrawalsTxBodyL)
-     in concat
-            [ if certCount == 0
-                then []
-                else
-                    [ missingContextJson
-                        "cert_state"
-                        "Supply certificate state for transactions containing certificates."
-                        ["args", "context", "cert_state"]
-                        ["ledger.apply_tx"]
-                    ]
-            , if withdrawalCount == 0
-                then []
-                else
-                    [ missingContextJson
-                        "cert_state"
-                        "Supply certificate/account state for transactions containing withdrawals."
-                        ["args", "context", "cert_state"]
-                        ["ledger.apply_tx"]
-                    ]
+        withdrawals = body ^. L.withdrawalsTxBodyL
+        withdrawalCount = withdrawalsCount withdrawals
+        required = certCount > 0 || withdrawalCount > 0
+        suppliedValue = mContext >>= lookupValue "cert_state"
+     in case suppliedValue of
+            Nothing
+                | required ->
+                    CertStateAbsent (withdrawalAbsentDetails body withdrawals)
+                | otherwise -> CertStateRewards []
+            Just value -> case parseCertStateValue value of
+                Right entries -> CertStateRewards entries
+                Left err ->
+                    CertStateMalformed
+                        [ contextErrorJson
+                            "invalid_cert_state"
+                            ("args.context.cert_state: " <> err)
+                            ["args", "context", "cert_state"]
+                            (Aeson.object ["detail" .= err])
+                        ]
+
+{- | Surfaces, for each withdrawal in the tx body, a missing_context
+  entry whose @details.withdrawal_credentials@ array names the
+  account credentials a host needs to look up off-chain (e.g. via
+  @GET /accounts/{stake_address}@ on Blockfrost). Each entry is
+  emitted under @args.context.cert_state@ to keep one logical
+  missing-context bucket per kind, so callers iterate one place.
+-}
+withdrawalAbsentDetails ::
+    Core.TxBody TopTx Conway.ConwayEra ->
+    L.Withdrawals ->
+    [Aeson.Value]
+withdrawalAbsentDetails body (L.Withdrawals m) =
+    let certCount = length (toList (body ^. L.certsTxBodyL))
+        creds = withdrawalCredentialsJson m
+        message :: T.Text
+        message
+            | not (null m) && certCount > 0 =
+                "Supply certificate/account state; rewards entries needed for the listed withdrawals."
+            | not (null m) =
+                "Supply account state; rewards entries needed for the listed withdrawals."
+            | otherwise =
+                "Supply certificate state for transactions containing certificates."
+        details =
+            Aeson.object
+                [ "withdrawal_credentials" .= creds
+                , "schema"
+                    .= ( "{rewards:[{credential:{kind,hash},balance_lovelace}]}" ::
+                            T.Text
+                       )
+                ]
+     in [ Aeson.object
+            [ "kind" .= ("cert_state" :: T.Text)
+            , "message" .= message
+            , "path"
+                .= (["args", "context", "cert_state"] :: [T.Text])
+            , "required_for" .= (["ledger.apply_tx"] :: [T.Text])
+            , "details" .= details
             ]
+        ]
+
+withdrawalCredentialsJson ::
+    Map.Map Addr.AccountAddress Coin.Coin -> [Aeson.Value]
+withdrawalCredentialsJson =
+    map (credentialJson . accountCredential) . Map.keys
+  where
+    accountCredential (Addr.AccountAddress _ (Addr.AccountId cred)) = cred
+
+credentialJson ::
+    Credential.Credential r -> Aeson.Value
+credentialJson = \case
+    Credential.KeyHashObj (Hashes.KeyHash h) ->
+        Aeson.object ["kind" .= ("key" :: T.Text), "hash" .= hashHex h]
+    Credential.ScriptHashObj (Hashes.ScriptHash h) ->
+        Aeson.object ["kind" .= ("script" :: T.Text), "hash" .= hashHex h]
+
+{- | Decode the cert_state JSON value into a list of rewards entries.
+  Empty object is permitted and yields no entries (matches the
+  pre-existing "minimal supplied object satisfies the gate"
+  behaviour).
+-}
+parseCertStateValue :: Aeson.Value -> Either T.Text [CertStateRewardEntry]
+parseCertStateValue (Aeson.Object o) =
+    case AesonKeyMap.lookup "rewards" o of
+        Nothing -> Right []
+        Just (Aeson.Array xs) ->
+            traverse parseRewardEntry (toList xs)
+        Just _ -> Left "rewards must be a JSON array."
+parseCertStateValue _ =
+    Left "must be a JSON object."
+
+parseRewardEntry :: Aeson.Value -> Either T.Text CertStateRewardEntry
+parseRewardEntry (Aeson.Object o) = do
+    credValue <-
+        maybe (Left "rewards[*].credential is required.") Right $
+            AesonKeyMap.lookup "credential" o
+    cred <- parseCredentialValue credValue
+    balance <- parseBalanceLovelace (AesonKeyMap.lookup "balance_lovelace" o)
+    pure CertStateRewardEntry{csrCredential = cred, csrBalance = balance}
+parseRewardEntry _ =
+    Left "rewards[*] must be a JSON object."
+
+parseCredentialValue ::
+    Aeson.Value -> Either T.Text (Credential.Credential Hashes.Staking)
+parseCredentialValue (Aeson.Object o) = do
+    kind <-
+        case AesonKeyMap.lookup "kind" o of
+            Just (Aeson.String k) -> Right k
+            _ ->
+                Left
+                    "credential.kind must be \"key\" or \"script\"."
+    hashHex' <-
+        case AesonKeyMap.lookup "hash" o of
+            Just (Aeson.String h) -> Right h
+            _ -> Left "credential.hash must be a hex-encoded string."
+    bytes <- decodeHashHex hashHex'
+    case kind of
+        "key" -> Credential.KeyHashObj . Hashes.KeyHash <$> decodeHash28 bytes
+        "script" -> Credential.ScriptHashObj . Hashes.ScriptHash <$> decodeHash28 bytes
+        _ -> Left ("Unknown credential.kind: " <> kind)
+parseCredentialValue _ =
+    Left "credential must be a JSON object."
+
+decodeHashHex :: T.Text -> Either T.Text BS.ByteString
+decodeHashHex t = case B16.decode (T.encodeUtf8 t) of
+    Right bs -> Right bs
+    Left err -> Left ("hash hex decode failed: " <> T.pack err)
+
+decodeHash28 ::
+    BS.ByteString -> Either T.Text (Crypto.Hash Crypto.Blake2b_224 a)
+decodeHash28 bs = case Crypto.hashFromBytes bs of
+    Just h -> Right h
+    Nothing ->
+        Left
+            ( "expected a 28-byte Blake2b-224 hash, got "
+                <> T.pack (show (BS.length bs))
+                <> " bytes."
+            )
+
+parseBalanceLovelace :: Maybe Aeson.Value -> Either T.Text Coin.Coin
+parseBalanceLovelace Nothing = Right (Coin.Coin 0)
+parseBalanceLovelace (Just (Aeson.String s)) =
+    case readMaybe (T.unpack s) of
+        Just n | n >= 0 -> Right (Coin.Coin n)
+        _ -> Left "balance_lovelace must be a non-negative integer string."
+parseBalanceLovelace (Just (Aeson.Number _)) =
+    Left
+        ( "balance_lovelace must be a string (Word64-safe); JSON numbers"
+            <> " can lose precision."
+        )
+parseBalanceLovelace _ =
+    Left "balance_lovelace must be a non-negative integer string."
+
+classifyCertStateInput ::
+    CertStateInput -> ([Aeson.Value], [Aeson.Value], [CertStateRewardEntry])
+classifyCertStateInput = \case
+    CertStateAbsent missing -> (missing, [], [])
+    CertStateMalformed errs -> ([], errs, [])
+    CertStateRewards entries -> ([], [], entries)
+
+{- | Seed the supplied rewards entries into the @Accounts@ map of the
+  given @NewEpochState@. Existing accounts (none, by construction —
+  we start from @def@) are overwritten by entries that share their
+  credential. The returned state is what gets fed into Conway
+  @applyTx@.
+-}
+seedCertStateRewards ::
+    [CertStateRewardEntry] ->
+    ShelleyState.NewEpochState Conway.ConwayEra ->
+    ShelleyState.NewEpochState Conway.ConwayEra
+seedCertStateRewards [] nes = nes
+seedCertStateRewards entries nes =
+    nes
+        & ShelleyState.nesEsL
+            . ShelleyState.esLStateL
+            . ShelleyState.lsCertStateL
+            . LedgerState.certDStateL
+            . LedgerState.accountsL
+            %~ \accounts ->
+                foldr
+                    (\e -> LedgerState.addAccountState (csrCredential e) (rewardEntryAccountState e))
+                    accounts
+                    entries
+
+{- | Build a fresh @ConwayAccountState@ whose balance matches the
+  supplied lovelace amount. Deposit and pool/DRep delegation are zero,
+  which is fine for the CERTS withdrawal rule — it only inspects
+  @casBalance@ (via @balanceAccountStateL@).
+-}
+rewardEntryAccountState ::
+    CertStateRewardEntry -> ConwayAccountState Conway.ConwayEra
+rewardEntryAccountState entry =
+    ConwayAccountState
+        { casBalance = compactCoin (csrBalance entry)
+        , casDeposit = Coin.compactCoinOrError (Coin.Coin 0)
+        , casStakePoolDelegation = Nothing
+        , casDRepDelegation = Nothing
+        }
+  where
+    -- Lovelace amounts already validated as non-negative during parsing.
+    compactCoin = Coin.compactCoinOrError
 
 missingSourceOutputContextJson ::
     T.Text ->


### PR DESCRIPTION
Closes #47.

Retargets the original "presence-only gate" fix into a full cert_state
plumb that resolves real on-chain rewards balances via Blockfrost. The
practical motivation is the SundaeSwap (and Indigo / Minswap V2 /
Liqwid …) **withdraw-zero** pattern, which trips
`WithdrawalsNotInRewardsCERTS` whenever the supplied `cert_state`
doesn't contain a registered, balance-zero entry for the staking-script
credential.

## Inspector library (commit 1)

`Conway.Inspector.Validation` now defines and consumes a small schema:

```json
{ "rewards": [
    { "credential": {"kind": "key" | "script", "hash": "<28-byte hex>"}
    , "balance_lovelace": "<integer string>" }
  , ...
] }
```

Behaviour:

| `args.context.cert_state` | Effect |
|---|---|
| absent (and tx has cert/withdrawal) | `missing_context` entry with `details.withdrawal_credentials = [{kind,hash}, ...]` so the host can auto-resolve |
| `{}` | parses to no entries; gate cleared (PR #49 v1 contract preserved) |
| `{ "rewards": [...] }` | each entry seeded via the Conway 1.22 `EraAccounts` API (`addAccountState` through `nesEsL.esLStateL.lsCertStateL.certDStateL.accountsL`) into `NewEpochState` before Conway `applyTx` runs |
| malformed | reported as `errors[*]` with code `invalid_cert_state` |

Only the `rewards` entries are seeded — that's the only piece the CERTS
withdrawal rule reads. Cert / pool / DRep / deposit state is left for a
later iteration.

## Host: tx-deep-diagnosis (commit 2)

* `Blockfrost.hs`:
  * `CredentialKind` (key vs script).
  * `stakeAddressBech32 :: Network -> CredentialKind -> Text -> Either String Text` — header byte `0xe1/0xf1/0xe0/0xf0`, HRP `stake` or `stake_test`.
  * `AccountInfo { aiActive, aiWithdrawableLovelace }` + `fetchAccountInfo` for `GET /accounts/{stake_address}`.
* `Diagnosis.hs`:
  * `vcCertState :: Maybe Aeson.Value` on `ValidationContext`.
  * `extractMissingWithdrawalCredentials`, mirroring `extractProducerTxIds`, walks the probe's `missing_context` entries and pulls `details.withdrawal_credentials`.
* `Main.hs` adds **Phase 2.5** between the producer-tx fetch and the final validate: for every credential the probe surfaced, derive bech32 → fetch `/accounts` → assemble `cert_state.rewards`. Failures (bad hex, HTTP error, unregistered account) are logged but never abort — the ledger then prints its own CERTS error, which is more useful diagnostic output than a host-side bail.
* `bech32` dep added to `tx-deep-diagnosis.cabal`.

## Verification

* `nix build .#packages.x86_64-linux.tx-deep-diagnosis` ✅
* `nix build .#packages.x86_64-linux.wasm-tx-inspector` ✅
* `just check-validate` ✅ (pre-existing fixture: status `valid`, unchanged)
* `just format-check` ✅
* `nix develop -c fourmolu -m check libs apps nix/wasm` ✅

End-to-end on the SundaeSwap mainnet fixture
(`30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`):
the `WithdrawalsNotInRewardsCERTS` failure that previously gated the
report disappears, and the remaining failures
(`ValueNotConservedUTxO`, `MissingVKeyWitnessesUTXOW`) surface as
genuine ledger output.

## Knock-on

* The schema is now defined for cert_state. Future expansion (full
  cert state with deposits, pools, DReps) layers on top of the same
  shape — only the inspector parser and seeder grow.
* This subsumes the original PR #49 contract — `cert_state: {}` still
  works as a "minimum to clear the gate" fallback.

PR: https://github.com/lambdasistemi/cardano-ledger-inspector/pull/49