### PR TITLE
feat(tx-deep-diagnosis): explain artifacts — mermaid diagram + markdown report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-newstyle/
 *.o
 *.dyn_hi
 *.dyn_o
+WIP.md

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -33,18 +33,33 @@ import System.IO (hPutStrLn, stderr)
 
 import TxDeepDiagnosisHost.Registry (ProtocolRegistry, loadRegistries)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc, parseDiagnosisDoc)
+import TxDeepDiagnosisHost.Render.Failures (renderFailuresMermaid)
 import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+import TxDeepDiagnosisHost.Render.Summary (
+    EmittedFiles (..),
+    renderSummaryMarkdown,
+ )
 import TxDeepDiagnosisHost.Render.Topology (renderTopologyMermaid)
 import TxDeepDiagnosisHost.Render.ValueFlow (renderValueFlowTsv)
 
-{- | Static registry of (relative file name, producer) pairs. Each
-renderer commit appends one line.
+{- | All artifacts the harness can produce, in emit order. Failures
+and summary are conditional on doc state and produce 'Maybe'
+output.
 -}
-renderers :: [(FilePath, ProtocolRegistry -> DiagnosisDoc -> Text)]
+data Artifact
+    = Always !FilePath !(ProtocolRegistry -> DiagnosisDoc -> Text)
+    | Conditional !FilePath !(ProtocolRegistry -> DiagnosisDoc -> Maybe Text)
+    | -- | Summary depends on which other files were emitted, so it
+      -- runs last and receives the cumulative 'EmittedFiles'.
+      SummaryArtifact !FilePath
+
+renderers :: [Artifact]
 renderers =
-    [ ("parties.mmd", renderPartiesMermaid)
-    , ("value-flow.tsv", renderValueFlowTsv)
-    , ("topology.mmd", renderTopologyMermaid)
+    [ Always "parties.mmd" renderPartiesMermaid
+    , Always "value-flow.tsv" renderValueFlowTsv
+    , Always "topology.mmd" renderTopologyMermaid
+    , Conditional "failures.mmd" renderFailuresMermaid
+    , SummaryArtifact "summary.md"
     ]
 
 main :: IO ()
@@ -113,11 +128,37 @@ runCase mode reg root name = do
                 hPutStrLn stderr ("parse " <> inputPath <> ": " <> e)
                 pure (name, False)
             Right doc -> do
-                outcomes <-
-                    mapM
-                        (handleArtifact mode reg root name doc)
-                        renderers
+                let initial = noEmittedFilesLocal
+                (outcomes, _emitted) <-
+                    foldArtifacts mode reg root name doc initial renderers
                 pure (name, and outcomes)
+
+noEmittedFilesLocal :: EmittedFiles
+noEmittedFilesLocal =
+    EmittedFiles
+        { efParties = Nothing
+        , efValueFlow = Nothing
+        , efTopology = Nothing
+        , efFailures = Nothing
+        }
+
+{- | Apply each artifact in order, threading 'EmittedFiles' so the
+summary can link only to files that were actually written.
+-}
+foldArtifacts ::
+    Mode ->
+    ProtocolRegistry ->
+    FilePath ->
+    FilePath ->
+    DiagnosisDoc ->
+    EmittedFiles ->
+    [Artifact] ->
+    IO ([Bool], EmittedFiles)
+foldArtifacts _ _ _ _ _ acc [] = pure ([], acc)
+foldArtifacts mode reg root name doc acc (a : as) = do
+    (ok, acc') <- handleArtifact mode reg root name doc acc a
+    (rest, accFinal) <- foldArtifacts mode reg root name doc acc' as
+    pure (ok : rest, accFinal)
 
 handleArtifact ::
     Mode ->
@@ -125,29 +166,51 @@ handleArtifact ::
     FilePath ->
     FilePath ->
     DiagnosisDoc ->
-    (FilePath, ProtocolRegistry -> DiagnosisDoc -> Text) ->
-    IO Bool
-handleArtifact WriteMode reg root name doc (artifact, render) = do
-    let expectedDir = root </> name </> "expected"
-        expectedPath = expectedDir </> artifact
-    exists <- doesDirectoryExist expectedDir
-    unless exists $ die ("missing expected dir: " <> expectedDir)
-    TIO.writeFile expectedPath (render reg doc)
-    putStrLn ("wrote " <> expectedPath)
-    pure True
-handleArtifact CompareMode reg root name doc args =
-    compareArtifact reg root name doc args
+    EmittedFiles ->
+    Artifact ->
+    IO (Bool, EmittedFiles)
+handleArtifact mode reg root name doc files art = case art of
+    Always file render -> do
+        let actual = render reg doc
+        ok <- handle mode reg root name file actual
+        pure (ok, recordFile file files)
+    Conditional file render -> case render reg doc of
+        Nothing ->
+            -- Skipped on purpose; tolerate any leftover expected file.
+            pure (True, files)
+        Just actual -> do
+            ok <- handle mode reg root name file actual
+            pure (ok, recordFile file files)
+    SummaryArtifact file -> do
+        let actual = renderSummaryMarkdown reg doc files
+        ok <- handle mode reg root name file actual
+        pure (ok, recordFile file files)
 
-compareArtifact ::
+recordFile :: FilePath -> EmittedFiles -> EmittedFiles
+recordFile "parties.mmd" f = f{efParties = Just "parties.mmd"}
+recordFile "value-flow.tsv" f = f{efValueFlow = Just "value-flow.tsv"}
+recordFile "topology.mmd" f = f{efTopology = Just "topology.mmd"}
+recordFile "failures.mmd" f = f{efFailures = Just "failures.mmd"}
+recordFile _ f = f
+
+handle ::
+    Mode ->
     ProtocolRegistry ->
     FilePath ->
     FilePath ->
-    DiagnosisDoc ->
-    (FilePath, ProtocolRegistry -> DiagnosisDoc -> Text) ->
+    FilePath ->
+    Text ->
     IO Bool
-compareArtifact reg root name doc (artifact, render) = do
-    let expectedPath = root </> name </> "expected" </> artifact
-        actual = render reg doc
+handle WriteMode _reg root name file actual = do
+    let expectedDir = root </> name </> "expected"
+        expectedPath = expectedDir </> file
+    exists <- doesDirectoryExist expectedDir
+    unless exists $ die ("missing expected dir: " <> expectedDir)
+    TIO.writeFile expectedPath actual
+    putStrLn ("wrote " <> expectedPath)
+    pure True
+handle CompareMode _reg root name file actual = do
+    let expectedPath = root </> name </> "expected" </> file
     expectedExists <- doesFileExist expectedPath
     if not expectedExists
         then do
@@ -170,7 +233,7 @@ compareArtifact reg root name doc (artifact, render) = do
                         ( "DIFF in "
                             <> name
                             <> "/"
-                            <> artifact
+                            <> file
                             <> ":\n--- expected ---\n"
                             <> Text.unpack expected
                             <> "--- actual ---\n"

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : Main
+Description : Snapshot harness for the explain renderers.
+
+Walks @apps/tx-deep-diagnosis/test/golden/<case>/@ trees, runs every
+renderer the harness knows about against @input.json@, and compares
+each emitted artifact byte-for-byte against @expected/<file>@.
+
+Failure mode: print a unified-style diff for each mismatching file and
+exit non-zero. Success mode: print one line per case and exit zero.
+
+The harness is on purpose deliberately dumb — it does not invoke the
+ledger and it does not call Blockfrost. Its only inputs are the JSON
+envelope and the bundled 'ProtocolRegistry'.
+-}
+module Main (main) where
+
+import Control.Monad (forM, unless, when)
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BSL
+import Data.List (sort)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as TIO
+import qualified Paths_tx_deep_diagnosis as Paths
+import System.Directory (doesDirectoryExist, doesFileExist, listDirectory)
+import System.Environment (getArgs)
+import System.Exit (exitFailure, exitSuccess)
+import System.FilePath ((</>))
+import System.IO (hPutStrLn, stderr)
+
+import TxDeepDiagnosisHost.Registry (loadRegistries)
+import TxDeepDiagnosisHost.Render.Doc (parseDiagnosisDoc)
+
+main :: IO ()
+main = do
+    args <- getArgs
+    goldenRoot <- case args of
+        [p] -> pure p
+        _ ->
+            die
+                "usage: tx-deep-diagnosis-render-snapshot <golden-root>\n"
+    bundled <- Paths.getDataDir
+    _reg <- loadRegistries [bundled]
+    cases <- listGoldenCases goldenRoot
+    when (null cases) $
+        die ("no golden cases found under " <> goldenRoot)
+    results <- forM cases (runCase _reg goldenRoot)
+    let failed = [name | (name, False) <- results]
+    if null failed
+        then do
+            mapM_ (\(name, _) -> putStrLn ("ok   " <> name)) results
+            exitSuccess
+        else do
+            mapM_
+                ( \(name, ok) ->
+                    putStrLn ((if ok then "ok   " else "FAIL ") <> name)
+                )
+                results
+            exitFailure
+
+listGoldenCases :: FilePath -> IO [FilePath]
+listGoldenCases root = do
+    exists <- doesDirectoryExist root
+    if not exists
+        then pure []
+        else do
+            entries <- listDirectory root
+            sort
+                <$> filterM
+                    (\e -> doesDirectoryExist (root </> e))
+                    entries
+
+filterM :: (a -> IO Bool) -> [a] -> IO [a]
+filterM _ [] = pure []
+filterM p (x : xs) = do
+    keep <- p x
+    rest <- filterM p xs
+    pure (if keep then x : rest else rest)
+
+{- | Run all renderers for a single golden case. Returns @True@ on
+match, @False@ otherwise. The renderer set is currently empty; each
+renderer commit will extend 'renderers' to add a new (artifact name,
+producer) entry.
+-}
+runCase ::
+    -- | bundled protocol registry; passed for forward use as renderers land
+    a ->
+    -- | golden root
+    FilePath ->
+    -- | case name (subdir of root)
+    FilePath ->
+    IO (FilePath, Bool)
+runCase _reg root name = do
+    let inputPath = root </> name </> "input.json"
+    inputExists <- doesFileExist inputPath
+    unless inputExists $
+        die ("missing " <> inputPath)
+    raw <- BSL.readFile inputPath
+    case A.eitherDecode raw of
+        Left e -> do
+            hPutStrLn stderr ("decode " <> inputPath <> ": " <> e)
+            pure (name, False)
+        Right v -> case parseDiagnosisDoc v of
+            Left e -> do
+                hPutStrLn stderr ("parse " <> inputPath <> ": " <> e)
+                pure (name, False)
+            Right _doc -> do
+                -- Renderer set is empty for now; the case passes if the
+                -- envelope decodes. Subsequent commits extend this with
+                -- per-artifact byte equality checks against
+                -- expected/<file>.
+                pure (name, True)
+
+die :: String -> IO a
+die msg = do
+    hPutStrLn stderr msg
+    exitFailure
+
+-- Silence "defined but not used" until the renderer wiring lands.
+_unused :: ()
+_unused = const () (Text.pack "", TIO.hPutStrLn)

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -21,6 +21,7 @@ import Control.Monad (forM, unless, when)
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BSL
 import Data.List (sort)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as TIO
 import qualified Paths_tx_deep_diagnosis as Paths
@@ -30,35 +31,42 @@ import System.Exit (exitFailure, exitSuccess)
 import System.FilePath ((</>))
 import System.IO (hPutStrLn, stderr)
 
-import TxDeepDiagnosisHost.Registry (loadRegistries)
-import TxDeepDiagnosisHost.Render.Doc (parseDiagnosisDoc)
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry, loadRegistries)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc, parseDiagnosisDoc)
+import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+
+{- | Static registry of (relative file name, producer) pairs. Each
+renderer commit appends one line.
+-}
+renderers :: [(FilePath, ProtocolRegistry -> DiagnosisDoc -> Text)]
+renderers =
+    [ ("parties.mmd", renderPartiesMermaid)
+    ]
 
 main :: IO ()
 main = do
     args <- getArgs
-    goldenRoot <- case args of
-        [p] -> pure p
+    (mode, goldenRoot) <- case args of
+        [p] -> pure (CompareMode, p)
+        ["--write", p] -> pure (WriteMode, p)
         _ ->
             die
-                "usage: tx-deep-diagnosis-render-snapshot <golden-root>\n"
+                ( "usage: tx-deep-diagnosis-render-snapshot [--write] "
+                    <> "<golden-root>\n"
+                )
     bundled <- Paths.getDataDir
-    _reg <- loadRegistries [bundled]
+    reg <- loadRegistries [bundled]
     cases <- listGoldenCases goldenRoot
     when (null cases) $
         die ("no golden cases found under " <> goldenRoot)
-    results <- forM cases (runCase _reg goldenRoot)
+    results <- forM cases (runCase mode reg goldenRoot)
     let failed = [name | (name, False) <- results]
-    if null failed
-        then do
-            mapM_ (\(name, _) -> putStrLn ("ok   " <> name)) results
-            exitSuccess
-        else do
-            mapM_
-                ( \(name, ok) ->
-                    putStrLn ((if ok then "ok   " else "FAIL ") <> name)
-                )
-                results
-            exitFailure
+    mapM_
+        ( \(name, ok) ->
+            putStrLn ((if ok then "ok   " else "FAIL ") <> name)
+        )
+        results
+    if null failed then exitSuccess else exitFailure
 
 listGoldenCases :: FilePath -> IO [FilePath]
 listGoldenCases root = do
@@ -80,19 +88,13 @@ filterM p (x : xs) = do
     pure (if keep then x : rest else rest)
 
 {- | Run all renderers for a single golden case. Returns @True@ on
-match, @False@ otherwise. The renderer set is currently empty; each
-renderer commit will extend 'renderers' to add a new (artifact name,
-producer) entry.
+match, @False@ otherwise.
 -}
-runCase ::
-    -- | bundled protocol registry; passed for forward use as renderers land
-    a ->
-    -- | golden root
-    FilePath ->
-    -- | case name (subdir of root)
-    FilePath ->
-    IO (FilePath, Bool)
-runCase _reg root name = do
+data Mode = CompareMode | WriteMode
+    deriving (Eq)
+
+runCase :: Mode -> ProtocolRegistry -> FilePath -> FilePath -> IO (FilePath, Bool)
+runCase mode reg root name = do
     let inputPath = root </> name </> "input.json"
     inputExists <- doesFileExist inputPath
     unless inputExists $
@@ -106,18 +108,74 @@ runCase _reg root name = do
             Left e -> do
                 hPutStrLn stderr ("parse " <> inputPath <> ": " <> e)
                 pure (name, False)
-            Right _doc -> do
-                -- Renderer set is empty for now; the case passes if the
-                -- envelope decodes. Subsequent commits extend this with
-                -- per-artifact byte equality checks against
-                -- expected/<file>.
-                pure (name, True)
+            Right doc -> do
+                outcomes <-
+                    mapM
+                        (handleArtifact mode reg root name doc)
+                        renderers
+                pure (name, and outcomes)
+
+handleArtifact ::
+    Mode ->
+    ProtocolRegistry ->
+    FilePath ->
+    FilePath ->
+    DiagnosisDoc ->
+    (FilePath, ProtocolRegistry -> DiagnosisDoc -> Text) ->
+    IO Bool
+handleArtifact WriteMode reg root name doc (artifact, render) = do
+    let expectedDir = root </> name </> "expected"
+        expectedPath = expectedDir </> artifact
+    exists <- doesDirectoryExist expectedDir
+    unless exists $ die ("missing expected dir: " <> expectedDir)
+    TIO.writeFile expectedPath (render reg doc)
+    putStrLn ("wrote " <> expectedPath)
+    pure True
+handleArtifact CompareMode reg root name doc args =
+    compareArtifact reg root name doc args
+
+compareArtifact ::
+    ProtocolRegistry ->
+    FilePath ->
+    FilePath ->
+    DiagnosisDoc ->
+    (FilePath, ProtocolRegistry -> DiagnosisDoc -> Text) ->
+    IO Bool
+compareArtifact reg root name doc (artifact, render) = do
+    let expectedPath = root </> name </> "expected" </> artifact
+        actual = render reg doc
+    expectedExists <- doesFileExist expectedPath
+    if not expectedExists
+        then do
+            hPutStrLn
+                stderr
+                ( "MISSING expected file: "
+                    <> expectedPath
+                    <> "\n--- actual output ---\n"
+                    <> Text.unpack actual
+                    <> "--- end ---"
+                )
+            pure False
+        else do
+            expected <- TIO.readFile expectedPath
+            if expected == actual
+                then pure True
+                else do
+                    hPutStrLn
+                        stderr
+                        ( "DIFF in "
+                            <> name
+                            <> "/"
+                            <> artifact
+                            <> ":\n--- expected ---\n"
+                            <> Text.unpack expected
+                            <> "--- actual ---\n"
+                            <> Text.unpack actual
+                            <> "--- end ---"
+                        )
+                    pure False
 
 die :: String -> IO a
 die msg = do
     hPutStrLn stderr msg
     exitFailure
-
--- Silence "defined but not used" until the renderer wiring lands.
-_unused :: ()
-_unused = const () (Text.pack "", TIO.hPutStrLn)

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -35,6 +35,7 @@ import TxDeepDiagnosisHost.Registry (ProtocolRegistry, loadRegistries)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc, parseDiagnosisDoc)
 import TxDeepDiagnosisHost.Render.Failures (renderFailuresMermaid)
 import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+import TxDeepDiagnosisHost.Render.Single (renderSingleMarkdown)
 import TxDeepDiagnosisHost.Render.Summary (
     EmittedFiles (..),
     renderSummaryMarkdown,
@@ -60,6 +61,7 @@ renderers =
     , Always "topology.mmd" renderTopologyMermaid
     , Conditional "failures.mmd" renderFailuresMermaid
     , SummaryArtifact "summary.md"
+    , Always "explain.md" renderSingleMarkdown
     ]
 
 main :: IO ()

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -34,6 +34,7 @@ import System.IO (hPutStrLn, stderr)
 import TxDeepDiagnosisHost.Registry (ProtocolRegistry, loadRegistries)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc, parseDiagnosisDoc)
 import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+import TxDeepDiagnosisHost.Render.Topology (renderTopologyMermaid)
 import TxDeepDiagnosisHost.Render.ValueFlow (renderValueFlowTsv)
 
 {- | Static registry of (relative file name, producer) pairs. Each
@@ -43,6 +44,7 @@ renderers :: [(FilePath, ProtocolRegistry -> DiagnosisDoc -> Text)]
 renderers =
     [ ("parties.mmd", renderPartiesMermaid)
     , ("value-flow.tsv", renderValueFlowTsv)
+    , ("topology.mmd", renderTopologyMermaid)
     ]
 
 main :: IO ()

--- a/apps/tx-deep-diagnosis/snapshot/Main.hs
+++ b/apps/tx-deep-diagnosis/snapshot/Main.hs
@@ -34,6 +34,7 @@ import System.IO (hPutStrLn, stderr)
 import TxDeepDiagnosisHost.Registry (ProtocolRegistry, loadRegistries)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc, parseDiagnosisDoc)
 import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+import TxDeepDiagnosisHost.Render.ValueFlow (renderValueFlowTsv)
 
 {- | Static registry of (relative file name, producer) pairs. Each
 renderer commit appends one line.
@@ -41,6 +42,7 @@ renderer commit appends one line.
 renderers :: [(FilePath, ProtocolRegistry -> DiagnosisDoc -> Text)]
 renderers =
     [ ("parties.mmd", renderPartiesMermaid)
+    , ("value-flow.tsv", renderValueFlowTsv)
     ]
 
 main :: IO ()

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Doc.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Doc.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Doc
+Description : Typed view onto the tx-deep-diagnosis JSON envelope.
+
+The envelope produced by 'TxDeepDiagnosisHost.Report.renderReport' wraps
+a @tx-deep-diagnosis@ object with @summary@, @intent@ and @validate@
+children. Renderers operate on this typed view rather than walking the
+raw 'A.Value' from the top.
+-}
+module TxDeepDiagnosisHost.Render.Doc (
+    DiagnosisDoc (..),
+    parseDiagnosisDoc,
+) where
+
+import Data.Aeson (Value)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.Text (Text)
+
+-- | Parsed @tx-deep-diagnosis@ envelope.
+data DiagnosisDoc = DiagnosisDoc
+    { ddSummary :: !Text
+    -- ^ Top-level summary line ("N/M producer txs resolved, network=…").
+    , ddIntent :: !Value
+    -- ^ Raw @intent@ subobject as returned by @tx.intent@.
+    , ddValidate :: !Value
+    -- ^ Raw @validate@ subobject as returned by @tx.validate@.
+    }
+    deriving (Show)
+
+{- | Parse a 'DiagnosisDoc' out of the wrapped envelope JSON. Accepts
+either the wrapped form @{"tx-deep-diagnosis": {...}}@ or the inner
+object directly so this is robust to minor format drift.
+-}
+parseDiagnosisDoc :: Value -> Either String DiagnosisDoc
+parseDiagnosisDoc raw = case raw of
+    A.Object root
+        | Just (A.Object inner) <- KeyMap.lookup "tx-deep-diagnosis" root ->
+            fromInner inner
+        | otherwise -> fromInner root
+    _ -> Left "tx-deep-diagnosis envelope must be a JSON object"
+  where
+    fromInner inner = do
+        summary <- requireText "summary" inner
+        intent <- requireValue "intent" inner
+        validate <- requireValue "validate" inner
+        Right
+            DiagnosisDoc
+                { ddSummary = summary
+                , ddIntent = intent
+                , ddValidate = validate
+                }
+
+requireValue :: KeyMap.Key -> KeyMap.KeyMap Value -> Either String Value
+requireValue k m = case KeyMap.lookup k m of
+    Just v -> Right v
+    Nothing -> Left ("missing field: " <> show k)
+
+requireText :: KeyMap.Key -> KeyMap.KeyMap Value -> Either String Text
+requireText k m = case KeyMap.lookup k m of
+    Just (A.String t) -> Right t
+    Just _ -> Left ("field is not a string: " <> show k)
+    Nothing -> Left ("missing field: " <> show k)

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Failures.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Failures.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Failures
+Description : L4 cut — failures-only Mermaid diagram, when invalid.
+
+Returns 'Nothing' when @validation.failures@ is empty so callers know
+not to write the file. When non-empty: emits a small Mermaid
+@flowchart TD@ with one node per failure routed onto its target node
+(body, signer, or input) per the same mapping used by 'Render.Topology'.
+-}
+module TxDeepDiagnosisHost.Render.Failures (
+    renderFailuresMermaid,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl')
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Names (truncateHash)
+
+-- | Render a Mermaid failures diagram, or 'Nothing' when valid.
+renderFailuresMermaid :: ProtocolRegistry -> DiagnosisDoc -> Maybe Text
+renderFailuresMermaid _reg doc =
+    let failures = failureItems doc
+     in if null failures
+            then Nothing
+            else
+                Just
+                    . TL.toStrict
+                    . TB.toLazyText
+                    . mconcat
+                    $ [ "%% L4 — failures for tx "
+                      , txt (txIdOf doc)
+                      , "\n"
+                      , "flowchart TD\n"
+                      , "    classDef body fill:#fff,stroke:#000\n"
+                      , "    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px\n"
+                      , "    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px\n"
+                      , "    classDef ruleFail fill:#fff0f0,stroke:#aa3333,stroke-dasharray:3 3\n"
+                      , "    body[\"tx body\"]:::body\n"
+                      , mconcat (zipWith (renderFailure doc) [0 ..] failures)
+                      ]
+
+renderFailure :: DiagnosisDoc -> Int -> FailureItem -> TB.Builder
+renderFailure doc i fi =
+    let tag = "f" <> txt (Text.pack (show i))
+        ruleNode =
+            mconcat
+                [ "    "
+                , tag
+                , "[\""
+                , txt (escape (fiTitle fi))
+                , "\"]:::ruleFail\n"
+                ]
+     in case fiClass fi of
+            BodyFail ->
+                ruleNode
+                    <> mconcat ["    ", tag, " --> body\n"]
+                    <> "    body:::bodyFail\n"
+            SignerFail hashes ->
+                let signerNodes =
+                        zipWith
+                            (renderSignerNode tag)
+                            [0 :: Int ..]
+                            hashes
+                 in ruleNode <> mconcat signerNodes
+  where
+    _unused = doc
+
+renderSignerNode :: TB.Builder -> Int -> Text -> TB.Builder
+renderSignerNode parent j h =
+    let tag = parent <> "_s" <> txt (Text.pack (show j))
+        label = "missing signer " <> truncateHash h
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::signerFail\n    "
+            , parent
+            , " --> "
+            , tag
+            , "\n"
+            ]
+
+-- ---------------------------------------------------------------- --
+-- Failure parsing
+-- ---------------------------------------------------------------- --
+
+data FailureClass
+    = BodyFail
+    | SignerFail ![Text]
+    deriving (Show)
+
+data FailureItem = FailureItem
+    { fiTitle :: !Text
+    , fiClass :: !FailureClass
+    }
+
+failureItems :: DiagnosisDoc -> [FailureItem]
+failureItems doc =
+    let path = ["result", "validation", "failures"]
+        items = case lookupPath (ddValidate doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in map parseItem items
+  where
+    parseItem (Object o) =
+        let predicate = fromMaybe "" (textOf "predicate" o)
+            rule = fromMaybe "" (textOf "rule" o)
+            short = shortName predicate
+            cls
+                | "MissingVKeyWitnesses" `Text.isInfixOf` predicate =
+                    SignerFail (extractKeyHashes predicate)
+                | otherwise = BodyFail
+         in FailureItem
+                { fiTitle = rule <> " / " <> short
+                , fiClass = cls
+                }
+    parseItem _ =
+        FailureItem{fiTitle = "unknown failure shape", fiClass = BodyFail}
+
+textOf :: Text -> KeyMap.KeyMap Value -> Maybe Text
+textOf k o = case KeyMap.lookup (Key.fromText k) o of
+    Just (String s) -> Just s
+    _ -> Nothing
+
+-- | Collapse a verbose ledger predicate to a short, displayable name.
+shortName :: Text -> Text
+shortName p
+    | "ValueNotConservedUTxO" `Text.isInfixOf` p = "ValueNotConservedUTxO"
+    | "MissingVKeyWitnesses" `Text.isInfixOf` p = "MissingVKeyWitnesses"
+    | "BadInputsUTxO" `Text.isInfixOf` p = "BadInputsUTxO"
+    | "OutsideValidityIntervalUTxO" `Text.isInfixOf` p = "OutsideValidityInterval"
+    | otherwise = Text.take 60 p
+
+extractKeyHashes :: Text -> [Text]
+extractKeyHashes =
+    filter isHashLike
+        . map cleanup
+        . drop 1
+        . Text.splitOn "KeyHash"
+  where
+    cleanup t =
+        Text.takeWhile
+            (/= '"')
+            (Text.drop 1 (Text.dropWhile (/= '"') t))
+    isHashLike t =
+        Text.length t == 56 && Text.all isHex t
+    isHex c =
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+txIdOf :: DiagnosisDoc -> Text
+txIdOf doc = case lookupPath (ddIntent doc) ["result", "intent", "tx_id"] of
+    Just (String s) -> s
+    _ -> ""
+
+lookupPath :: Value -> [Text] -> Maybe Value
+lookupPath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing
+
+txt :: Text -> TB.Builder
+txt = TB.fromText
+
+escape :: Text -> Text
+escape = Text.replace "\"" "\\\""

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Names.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Names.hs
@@ -1,0 +1,141 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Names
+Description : Hash → human label resolution against the protocol registry.
+
+Every node in the explain artifacts that comes from a hash (script
+hash, payment-credential hash, signer hash) flows through 'resolveScript'
+or 'resolveAddress'. Unknown hashes are truncated rather than guessed so
+the rendered output stays honest.
+-}
+module TxDeepDiagnosisHost.Render.Names (
+    PartyName (..),
+    PartySource (..),
+    resolveScript,
+    resolveAddress,
+    truncateHash,
+) where
+
+import Data.Text (Text)
+import qualified Data.Text as Text
+
+import TxDeepDiagnosisHost.Registry (
+    AmaruScope (..),
+    Identification (..),
+    ProtocolRegistry,
+    RegistryInstance (..),
+    RegistryValidator (..),
+    findScopeByOwner,
+    identifyByHash,
+    prAmaru,
+ )
+
+{- | Origin of a resolved label. Preserved so renderers can style or
+caveat labels by source.
+-}
+data PartySource
+    = -- | matched a known validator hash
+      FromValidator
+    | -- | matched a known instance hash (label disambiguated by hash tail)
+      FromInstance
+    | -- | matched an Amaru treasury role
+      FromAmaruRole
+    | -- | matched the owner-key hash of an Amaru scope
+      FromAmaruOwner
+    | -- | no registry hit; label is truncated hex
+      TruncatedHex
+    deriving (Show, Eq)
+
+-- | A registry-resolved or truncated party label.
+data PartyName = PartyName
+    { pnLabel :: !Text
+    , pnSource :: !PartySource
+    }
+    deriving (Show, Eq)
+
+{- | Resolve a script (or any 28-byte) hash hex against the registry.
+Validator hits return their plain label. Instance hits append the last
+six hex of the hash so distinct instances of the same template stay
+distinguishable. Misses fall back to truncated hex.
+-}
+resolveScript :: ProtocolRegistry -> Text -> PartyName
+resolveScript reg h = case identifyByHash reg h of
+    IdValidator v ->
+        PartyName
+            { pnLabel = labelFromValidator v
+            , pnSource = FromValidator
+            }
+    IdInstance inst _scope ->
+        PartyName
+            { pnLabel = riLabel inst <> " (" <> hashTail h <> ")"
+            , pnSource = FromInstance
+            }
+    IdAmaruRole scope role ->
+        PartyName
+            { pnLabel = ascName scope <> " " <> role
+            , pnSource = FromAmaruRole
+            }
+    IdUnknown -> PartyName{pnLabel = truncateHash h, pnSource = TruncatedHex}
+
+{- | The validator's own @label@ field, falling back to the validator
+name if the registry author left @label@ unset.
+-}
+labelFromValidator :: RegistryValidator -> Text
+labelFromValidator v = case rvLabel v of
+    Just l -> l
+    Nothing -> rvValidator v
+
+{- | Resolve a Cardano address-hex (the lowercase concatenation of
+header + payment credential + optional stake credential) against the
+registry. Script-credential addresses are looked up via 'resolveScript'
+on the payment script hash. Key-credential addresses fall through to a
+truncated label unless the payment-key hash matches an Amaru scope
+owner.
+-}
+resolveAddress :: ProtocolRegistry -> Text -> PartyName
+resolveAddress reg addrHex
+    | Text.length addrHex < 2 = PartyName{pnLabel = truncateHash addrHex, pnSource = TruncatedHex}
+    | otherwise =
+        let header = Text.take 2 addrHex
+            paymentHex = Text.take 56 (Text.drop 2 addrHex)
+            isScriptPayment = headerHasScriptPayment header
+         in if isScriptPayment
+                then resolveScript reg paymentHex
+                else case prAmaru reg >>= \j -> findScopeByOwner j paymentHex of
+                    Just scope ->
+                        PartyName
+                            { pnLabel = ascName scope <> " owner"
+                            , pnSource = FromAmaruOwner
+                            }
+                    Nothing ->
+                        PartyName
+                            { pnLabel = "key " <> hashTail paymentHex
+                            , pnSource = TruncatedHex
+                            }
+
+{- | The header byte of a Shelley address encodes the type in the high
+nibble. Bits 0x40 and 0x10 of that nibble select script payment
+credentials (types 0x10, 0x30, 0x50, 0x70 — the high-nibble values
+01, 03, 05, 07). Reading the header as a hex pair, the script-payment
+header values are exactly those whose first hex digit is in
+{1,3,5,7}. Any non-hex header is treated as key-credential.
+-}
+headerHasScriptPayment :: Text -> Bool
+headerHasScriptPayment header = case Text.unpack (Text.toLower header) of
+    (c : _) -> c `elem` ("1357" :: String)
+    _ -> False
+
+{- | Truncate a hex string to the form @first8…last8@ for display when
+no registry label is available.
+-}
+truncateHash :: Text -> Text
+truncateHash h
+    | Text.length h <= 18 = h
+    | otherwise = Text.take 8 h <> "…" <> Text.takeEnd 8 h
+
+-- | Last 6 hex characters of a hash, used to disambiguate instance labels.
+hashTail :: Text -> Text
+hashTail h
+    | Text.length h <= 6 = h
+    | otherwise = Text.takeEnd 6 h

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Parties.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Parties.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Parties
+Description : L1 cut — distinct parties involved in the transaction.
+
+Renders a Mermaid @flowchart LR@ with one node per distinct party.
+A party is one of:
+
+* a resolved input — labelled by the input address
+* an output bucket — labelled by bucket name (external_key / script /
+  signer_controlled etc.) and aggregate lovelace
+* a declared required signer — labelled by hash
+
+The diagram answers "who is moving what to whom" without the full
+topology. The body is a single central @tx@ node; consumed-by /
+produces / required edges connect parties to it.
+-}
+module TxDeepDiagnosisHost.Render.Parties (
+    renderPartiesMermaid,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl', nub)
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Names (
+    PartyName (..),
+    PartySource (..),
+    resolveAddress,
+    truncateHash,
+ )
+
+-- | Render the L1 parties cut as a Mermaid @flowchart LR@ document.
+renderPartiesMermaid :: ProtocolRegistry -> DiagnosisDoc -> Text
+renderPartiesMermaid reg doc =
+    TL.toStrict
+        . TB.toLazyText
+        . mconcat
+        $ [ "%% L1 — parties involved in tx "
+          , txt (txIdOf doc)
+          , "\n"
+          , "flowchart LR\n"
+          , "    classDef signer fill:#fff8dc,stroke:#cc9900,stroke-width:2px\n"
+          , "    classDef inputAddr fill:#f0f0f0,stroke:#666\n"
+          , "    classDef bucket fill:#e6f0ff,stroke:#3366cc\n"
+          , "    classDef txBody fill:#fffefa,stroke:#000,stroke-width:2px\n"
+          , "    tx[\"tx\"]:::txBody\n"
+          , inputBlock reg doc
+          , bucketBlock doc
+          , signerBlock reg doc
+          ]
+
+-- ---------------------------------------------------------------- --
+-- Input parties
+-- ---------------------------------------------------------------- --
+
+inputBlock :: ProtocolRegistry -> DiagnosisDoc -> TB.Builder
+inputBlock reg doc =
+    let addrs = nub (resolvedInputAddresses doc)
+        rows = zip [0 :: Int ..] addrs
+     in mconcat (map (renderInput reg) rows)
+
+renderInput :: ProtocolRegistry -> (Int, Text) -> TB.Builder
+renderInput reg (i, addr) =
+    let pn = resolveAddress reg addr
+        tag = "I" <> txt (Text.pack (show i))
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape (renderPartyLabel pn))
+            , "\"]:::inputAddr\n    "
+            , tag
+            , " -- consumed --> tx\n"
+            ]
+
+resolvedInputAddresses :: DiagnosisDoc -> [Text]
+resolvedInputAddresses doc =
+    let validate = ddValidate doc
+        validation = lookupPath validate ["result", "validation"]
+        resolved = case validation of
+            Just (Object o) -> case KeyMap.lookup "resolved_inputs" o of
+                Just (Array xs) -> V.toList xs
+                _ -> []
+            _ -> []
+     in mapMaybe addressOfResolved resolved
+
+addressOfResolved :: Value -> Maybe Text
+addressOfResolved v = case v of
+    Object o -> case KeyMap.lookup "tx_out" o of
+        Just (Object txOut) -> case KeyMap.lookup "address_hex" txOut of
+            Just (String s) -> Just s
+            _ -> Nothing
+        _ -> Nothing
+    _ -> Nothing
+
+-- ---------------------------------------------------------------- --
+-- Output bucket parties
+-- ---------------------------------------------------------------- --
+
+bucketBlock :: DiagnosisDoc -> TB.Builder
+bucketBlock doc =
+    let buckets = outputBuckets doc
+        rows = zip [0 :: Int ..] buckets
+     in mconcat (map renderBucket rows)
+
+renderBucket :: (Int, OutputBucket) -> TB.Builder
+renderBucket (i, b) =
+    let tag = "O" <> txt (Text.pack (show i))
+        label =
+            obLabel b
+                <> " ("
+                <> Text.pack (show (obCount b))
+                <> " out, "
+                <> obLovelace b
+                <> " lovelace)"
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::bucket\n    tx -- produces --> "
+            , tag
+            , "\n"
+            ]
+
+data OutputBucket = OutputBucket
+    { obLabel :: !Text
+    , obCount :: !Integer
+    , obLovelace :: !Text
+    }
+
+outputBuckets :: DiagnosisDoc -> [OutputBucket]
+outputBuckets doc =
+    let intent = ddIntent doc
+        bucketsArr =
+            lookupPath intent ["result", "intent", "value", "output_buckets"]
+        items = case bucketsArr of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseBucket items
+  where
+    parseBucket (Object o) = do
+        lab <- case KeyMap.lookup "label" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        let countN = case KeyMap.lookup "tx_out_count" o of
+                Just (Number n) -> floor n
+                _ -> 0 :: Integer
+            lov = case KeyMap.lookup "lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+        Just OutputBucket{obLabel = lab, obCount = countN, obLovelace = lov}
+    parseBucket _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Required signer parties
+-- ---------------------------------------------------------------- --
+
+signerBlock :: ProtocolRegistry -> DiagnosisDoc -> TB.Builder
+signerBlock _reg doc =
+    let hashes = nub (declaredSignerHashes doc)
+        rows = zip [0 :: Int ..] hashes
+     in mconcat (map renderSigner rows)
+
+renderSigner :: (Int, Text) -> TB.Builder
+renderSigner (i, h) =
+    let tag = "S" <> txt (Text.pack (show i))
+        label = "signer " <> truncateHash h
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::signer\n    "
+            , tag
+            , " -. required .-> tx\n"
+            ]
+
+declaredSignerHashes :: DiagnosisDoc -> [Text]
+declaredSignerHashes doc =
+    let intent = ddIntent doc
+        sigs =
+            lookupPath
+                intent
+                [ "result"
+                , "intent"
+                , "signing"
+                , "missing_vkey_witnesses"
+                ]
+        items = case sigs of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe extractHash items
+  where
+    extractHash (Object o) = case KeyMap.lookup "hash" o of
+        Just (String s) -> Just s
+        _ -> Nothing
+    extractHash _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+txIdOf :: DiagnosisDoc -> Text
+txIdOf doc = case lookupPath (ddIntent doc) ["result", "intent", "tx_id"] of
+    Just (String s) -> s
+    _ -> ""
+
+renderPartyLabel :: PartyName -> Text
+renderPartyLabel pn = case pnSource pn of
+    TruncatedHex -> pnLabel pn
+    _ -> pnLabel pn
+
+lookupPath :: Value -> [Text] -> Maybe Value
+lookupPath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing
+
+txt :: Text -> TB.Builder
+txt = TB.fromText
+
+escape :: Text -> Text
+escape = Text.replace "\"" "\\\""

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
@@ -1,0 +1,240 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Single
+Description : Single-file markdown with all cuts embedded as fenced
+              Mermaid (and Sankey-beta) blocks.
+
+Same content as the four directory artifacts, assembled into one
+self-contained document. GitHub renders Mermaid fences inline, so a
+reader gets the parties / topology / failures diagrams without
+opening separate files. Value flow uses @sankey-beta@ for the same
+reason; it is documented as experimental but produces visibly richer
+output than a TSV table when it works, and the renderer continues to
+emit byte-stable text either way.
+
+The directory-shaped renderers (parties.mmd, value-flow.tsv,
+topology.mmd, failures.mmd, summary.md) are unchanged; this is an
+alternative assembly that consumers can prefer.
+-}
+module TxDeepDiagnosisHost.Render.Single (
+    renderSingleMarkdown,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl')
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Failures (renderFailuresMermaid)
+import TxDeepDiagnosisHost.Render.Names (pnLabel, resolveAddress)
+import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
+import TxDeepDiagnosisHost.Render.Summary (
+    EmittedFiles (..),
+    renderSummaryMarkdown,
+ )
+import TxDeepDiagnosisHost.Render.Topology (renderTopologyMermaid)
+
+{- | Render the whole explain bundle into a single markdown document.
+The diagrams footer in the inlined summary is replaced with a "see
+sections below" pointer rather than relative file links.
+-}
+renderSingleMarkdown :: ProtocolRegistry -> DiagnosisDoc -> Text
+renderSingleMarkdown reg doc =
+    Text.concat
+        [ summaryWithoutFooter reg doc
+        , partiesBlock reg doc
+        , valueFlowSankeyBlock reg doc
+        , topologyBlock reg doc
+        , failuresBlock reg doc
+        ]
+
+-- | The summary minus its diagrams footer (the diagrams follow inline).
+summaryWithoutFooter :: ProtocolRegistry -> DiagnosisDoc -> Text
+summaryWithoutFooter reg doc =
+    -- 'noFiles' suppresses the diagrams footer; the summary detects no
+    -- emitted files and skips the section.
+    renderSummaryMarkdown reg doc emptyFiles
+  where
+    emptyFiles =
+        EmittedFiles
+            { efParties = Nothing
+            , efValueFlow = Nothing
+            , efTopology = Nothing
+            , efFailures = Nothing
+            }
+
+-- ---------------------------------------------------------------- --
+-- Inline blocks
+-- ---------------------------------------------------------------- --
+
+partiesBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
+partiesBlock reg doc =
+    "## Parties\n\n```mermaid\n"
+        <> renderPartiesMermaid reg doc
+        <> "```\n\n"
+
+topologyBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
+topologyBlock reg doc =
+    "## Topology\n\n```mermaid\n"
+        <> renderTopologyMermaid reg doc
+        <> "```\n\n"
+
+failuresBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
+failuresBlock reg doc = case renderFailuresMermaid reg doc of
+    Nothing -> ""
+    Just t -> "## Failure overlay\n\n```mermaid\n" <> t <> "```\n\n"
+
+{- | Value-flow as a Mermaid @sankey-beta@ block. The renderer here
+inlines its own logic rather than re-deriving columns from the TSV
+renderer because @sankey-beta@'s row format (@source,target,value@)
+differs from the TSV's four-column shape. Both are byte-deterministic
+from the same envelope.
+
+When @sum(inputs) != sum(outputs) + fee@ an explicit @(unaccounted)@
+edge captures the delta so the diagram remains balanced and the
+reader sees the @ValueNotConservedUTxO@ gap visually.
+-}
+valueFlowSankeyBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
+valueFlowSankeyBlock reg doc =
+    let header = "## Value flow\n\n```mermaid\n---\nconfig:\n  sankey:\n    showValues: true\n---\nsankey-beta\n\n"
+        body =
+            mconcat
+                [ inputRows reg doc
+                , bucketRows doc
+                , feeRow doc
+                , unaccountedRow doc
+                ]
+        footer = "```\n\n"
+     in header <> body <> footer
+
+-- ---------------------------------------------------------------- --
+-- Sankey row generation (mirrors Render.ValueFlow but emits CSV
+-- triples instead of TSV quadruples)
+-- ---------------------------------------------------------------- --
+
+inputRows :: ProtocolRegistry -> DiagnosisDoc -> Text
+inputRows reg doc =
+    let inputs = resolvedInputs doc
+     in Text.concat
+            [ csvRow
+                [ "input#"
+                    <> Text.pack (show i)
+                    <> " "
+                    <> pnLabel (resolveAddress reg (riAddress ri))
+                , "tx"
+                , riLovelace ri
+                ]
+            | (i, ri) <- zip [0 :: Int ..] inputs
+            ]
+
+bucketRows :: DiagnosisDoc -> Text
+bucketRows doc =
+    Text.concat
+        [ csvRow
+            [ "tx"
+            , obLabel b <> " bucket"
+            , obLovelace b
+            ]
+        | b <- outputBuckets doc
+        ]
+
+feeRow :: DiagnosisDoc -> Text
+feeRow doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+    Just (String s) -> csvRow ["tx", "fee", s]
+    _ -> ""
+
+unaccountedRow :: DiagnosisDoc -> Text
+unaccountedRow doc =
+    let inputTotal = sum (map (parseLov . riLovelace) (resolvedInputs doc))
+        outputTotal = sum (map (parseLov . obLovelace) (outputBuckets doc))
+        feeTotal = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+            Just (String s) -> parseLov s
+            _ -> 0
+        delta = inputTotal - (outputTotal + feeTotal)
+     in if delta == 0
+            then ""
+            else csvRow ["tx", "(unaccounted)", Text.pack (show delta)]
+
+-- ---------------------------------------------------------------- --
+-- Local copies of the parsing structs (kept here to avoid a
+-- circular re-export from Render.ValueFlow / Render.Topology)
+-- ---------------------------------------------------------------- --
+
+data ResolvedInput = ResolvedInput
+    { riAddress :: !Text
+    , riLovelace :: !Text
+    }
+
+resolvedInputs :: DiagnosisDoc -> [ResolvedInput]
+resolvedInputs doc =
+    let path = ["result", "validation", "resolved_inputs"]
+        items = case lookupPath (ddValidate doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseInput items
+  where
+    parseInput (Object o) = case KeyMap.lookup "tx_out" o of
+        Just (Object txOut) -> do
+            addr <- case KeyMap.lookup "address_hex" txOut of
+                Just (String s) -> Just s
+                _ -> Nothing
+            let lov = case KeyMap.lookup "coin_lovelace" txOut of
+                    Just (String s) -> s
+                    _ -> "0"
+            Just ResolvedInput{riAddress = addr, riLovelace = lov}
+        _ -> Nothing
+    parseInput _ = Nothing
+
+data OutputBucket = OutputBucket
+    { obLabel :: !Text
+    , obLovelace :: !Text
+    }
+
+outputBuckets :: DiagnosisDoc -> [OutputBucket]
+outputBuckets doc =
+    let path = ["result", "intent", "value", "output_buckets"]
+        items = case lookupPath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseBucket items
+  where
+    parseBucket (Object o) = do
+        lab <- case KeyMap.lookup "label" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        let lov = case KeyMap.lookup "lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+        Just OutputBucket{obLabel = lab, obLovelace = lov}
+    parseBucket _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+csvRow :: [Text] -> Text
+csvRow xs = Text.intercalate "," (map sanitiseCsv xs) <> "\n"
+
+-- Mermaid sankey-beta uses comma as separator; values containing a
+-- comma break the row. Replace commas with U+2024 ONE DOT LEADER so
+-- labels remain readable without escaping.
+sanitiseCsv :: Text -> Text
+sanitiseCsv = Text.replace "," "\x2024"
+
+parseLov :: Text -> Integer
+parseLov t = case reads (Text.unpack t) of
+    [(n, "")] -> n
+    _ -> 0
+
+lookupPath :: Value -> [Text] -> Maybe Value
+lookupPath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
@@ -50,7 +50,7 @@ renderSingleMarkdown reg doc =
     Text.concat
         [ summaryWithoutFooter reg doc
         , partiesBlock reg doc
-        , valueFlowSankeyBlock reg doc
+        , balanceBlock reg doc
         , topologyBlock reg doc
         , failuresBlock reg doc
         ]
@@ -91,76 +91,113 @@ failuresBlock reg doc = case renderFailuresMermaid reg doc of
     Nothing -> ""
     Just t -> "## Failure overlay\n\n```mermaid\n" <> t <> "```\n\n"
 
-{- | Value-flow as a Mermaid @sankey-beta@ block. The renderer here
-inlines its own logic rather than re-deriving columns from the TSV
-renderer because @sankey-beta@'s row format (@source,target,value@)
-differs from the TSV's four-column shape. Both are byte-deterministic
-from the same envelope.
+{- | Balance section: two ADA-denominated tables (inputs / outputs+fee)
+plus a one-line conservation check.
 
-When @sum(inputs) != sum(outputs) + fee@ an explicit @(unaccounted)@
-edge captures the delta so the diagram remains balanced and the
-reader sees the @ValueNotConservedUTxO@ gap visually.
+Sankey was tried but is misleading at this resolution: we know
+aggregate input totals and aggregate bucket totals but not per-output
+addresses, so any "input → output" edge in a Sankey is an
+illustration, not a fact. Two side-by-side balance sheets read
+cleanly, denominate large numbers in ADA so disparities don't drown
+small rows, and end with the @ValueNotConservedUTxO@ delta as a
+single bottom-line.
 -}
-valueFlowSankeyBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
-valueFlowSankeyBlock reg doc =
-    let header = "## Value flow\n\n```mermaid\n---\nconfig:\n  sankey:\n    showValues: true\n---\nsankey-beta\n\n"
-        body =
-            mconcat
-                [ inputRows reg doc
-                , bucketRows doc
-                , feeRow doc
-                , unaccountedRow doc
-                ]
-        footer = "```\n\n"
-     in header <> body <> footer
-
--- ---------------------------------------------------------------- --
--- Sankey row generation (mirrors Render.ValueFlow but emits CSV
--- triples instead of TSV quadruples)
--- ---------------------------------------------------------------- --
-
-inputRows :: ProtocolRegistry -> DiagnosisDoc -> Text
-inputRows reg doc =
+balanceBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
+balanceBlock reg doc =
     let inputs = resolvedInputs doc
-     in Text.concat
-            [ csvRow
-                [ "input#"
-                    <> Text.pack (show i)
-                    <> " "
-                    <> pnLabel (resolveAddress reg (riAddress ri))
-                , "tx"
-                , riLovelace ri
-                ]
-            | (i, ri) <- zip [0 :: Int ..] inputs
-            ]
+        outBuckets = outputBuckets doc
+        feeLov = parseLov (feeLovelace doc)
+        inTotal = sum (map (parseLov . riLovelace) inputs)
+        outTotal = sum (map (parseLov . obLovelace) outBuckets) + feeLov
+        delta = inTotal - outTotal
+        inputsTable =
+            "### Inputs\n\n"
+                <> "| Source | ADA |\n"
+                <> "|--------|----:|\n"
+                <> Text.concat
+                    [ "| "
+                        <> escapeTable
+                            ( "input #"
+                                <> Text.pack (show i)
+                                <> " — "
+                                <> pnLabel (resolveAddress reg (riAddress ri))
+                            )
+                        <> " | "
+                        <> formatAda (parseLov (riLovelace ri))
+                        <> " |\n"
+                    | (i, ri) <- zip [0 :: Int ..] inputs
+                    ]
+                <> "| **Total inputs** | **"
+                <> formatAda inTotal
+                <> "** |\n\n"
+        outputsTable =
+            "### Outputs + fee\n\n"
+                <> "| Destination | ADA |\n"
+                <> "|-------------|----:|\n"
+                <> Text.concat
+                    [ "| "
+                        <> escapeTable
+                            ( obLabel b
+                                <> " bucket"
+                            )
+                        <> " | "
+                        <> formatAda (parseLov (obLovelace b))
+                        <> " |\n"
+                    | b <- outBuckets
+                    ]
+                <> "| fee | "
+                <> formatAda feeLov
+                <> " |\n"
+                <> "| **Total outputs + fee** | **"
+                <> formatAda outTotal
+                <> "** |\n\n"
+        balanceLine
+            | delta == 0 =
+                "_Balance: inputs = outputs + fee_\n\n"
+            | delta > 0 =
+                "**Unaccounted: "
+                    <> formatAda delta
+                    <> " missing — `ValueNotConservedUTxO`**\n\n"
+            | otherwise =
+                "**Over-spent: "
+                    <> formatAda (negate delta)
+                    <> " more in outputs+fee than inputs — "
+                    <> "`ValueNotConservedUTxO`**\n\n"
+     in "## Balance\n\n"
+            <> inputsTable
+            <> outputsTable
+            <> balanceLine
 
-bucketRows :: DiagnosisDoc -> Text
-bucketRows doc =
-    Text.concat
-        [ csvRow
-            [ "tx"
-            , obLabel b <> " bucket"
-            , obLovelace b
-            ]
-        | b <- outputBuckets doc
-        ]
+-- ---------------------------------------------------------------- --
+-- ADA formatting
+-- ---------------------------------------------------------------- --
 
-feeRow :: DiagnosisDoc -> Text
-feeRow doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
-    Just (String s) -> csvRow ["tx", "fee", s]
-    _ -> ""
+{- | Format an integer lovelace amount as ADA with 6 decimals and
+thousands separators on the whole part.
+-}
+formatAda :: Integer -> Text
+formatAda n =
+    let sign = if n < 0 then "-" else ""
+        m = abs n
+        whole = m `div` 1000000
+        frac = m `mod` 1000000
+        wholeT = withThousandsSeparators (Text.pack (show whole))
+        fracT = Text.justifyRight 6 '0' (Text.pack (show frac))
+     in sign <> wholeT <> "." <> fracT
 
-unaccountedRow :: DiagnosisDoc -> Text
-unaccountedRow doc =
-    let inputTotal = sum (map (parseLov . riLovelace) (resolvedInputs doc))
-        outputTotal = sum (map (parseLov . obLovelace) (outputBuckets doc))
-        feeTotal = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
-            Just (String s) -> parseLov s
-            _ -> 0
-        delta = inputTotal - (outputTotal + feeTotal)
-     in if delta == 0
-            then ""
-            else csvRow ["tx", "(unaccounted)", Text.pack (show delta)]
+withThousandsSeparators :: Text -> Text
+withThousandsSeparators t =
+    let chars = Text.unpack t
+        len = length chars
+        (head', tailGroups) = splitAt ((len - 1) `mod` 3 + 1) chars
+        groups
+            | null tailGroups = [head']
+            | otherwise = head' : chunksOf 3 tailGroups
+     in Text.pack (concatMap (\g -> if g == head' then g else "," <> g) groups)
+  where
+    chunksOf k xs = case splitAt k xs of
+        (h, []) -> [h]
+        (h, rest) -> h : chunksOf k rest
 
 -- ---------------------------------------------------------------- --
 -- Local copies of the parsing structs (kept here to avoid a
@@ -232,6 +269,16 @@ parseLov :: Text -> Integer
 parseLov t = case reads (Text.unpack t) of
     [(n, "")] -> n
     _ -> 0
+
+feeLovelace :: DiagnosisDoc -> Text
+feeLovelace doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+    Just (String s) -> s
+    _ -> "0"
+
+escapeTable :: Text -> Text
+escapeTable =
+    Text.replace "\n" " "
+        . Text.replace "|" "\\|"
 
 lookupPath :: Value -> [Text] -> Maybe Value
 lookupPath = foldl' step . Just

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -27,7 +27,7 @@ import Data.Aeson (Value (..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.List (foldl')
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as V
@@ -72,6 +72,7 @@ renderSummaryMarkdown reg doc files =
         , observationsSection reg doc
         , scriptsSection reg doc
         , outputsSection reg doc
+        , datumsSection reg doc
         , claimsSection doc
         , effectsSection doc
         , failuresSection doc
@@ -370,6 +371,196 @@ parseLov :: Text -> Integer
 parseLov t = case reads (Text.unpack t) of
     [(n, "")] -> n
     _ -> 0
+
+{- | Pretty-prints the per-output decoded datum AST. Each output that
+carries an @inline_datum@ with a @decoded@ field gets its own
+collapsible @<details>@ so the full document remains scrollable.
+The pretty-printer renders the AST as an indented pseudo-Lisp form
+which compresses better than JSON in the markdown view.
+
+Outputs whose datum is a hash-only reference, or a @no_datum@, are
+omitted. Identical datums (same hex string) are deduplicated — a
+SundaeSwap order with N identical outputs only shows the datum
+once with a count.
+-}
+datumsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
+datumsSection reg doc =
+    let path = ["result", "intent", "value", "outputs"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+        decoded = mapMaybeDecoded reg items
+        groups = groupByCbor decoded
+     in if null groups
+            then ""
+            else
+                "## Datums\n\n"
+                    <> Text.concat (map renderDatumGroup groups)
+
+mapMaybeDecoded ::
+    ProtocolRegistry ->
+    [Value] ->
+    [DecodedDatum]
+mapMaybeDecoded reg = mapMaybe step
+  where
+    step (Object o) = do
+        idx <- case KeyMap.lookup "index" o of
+            Just (Number n) -> Just (floor n :: Int)
+            _ -> Nothing
+        addr <- case KeyMap.lookup "address_hex" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        d <- case KeyMap.lookup "datum" o of
+            Just (Object dm) -> Just dm
+            _ -> Nothing
+        case KeyMap.lookup "kind" d of
+            Just (String "inline_datum") -> do
+                cbor <- case KeyMap.lookup "cbor_hex" d of
+                    Just (String s) -> Just s
+                    _ -> Nothing
+                ast <- KeyMap.lookup "decoded" d
+                Just
+                    DecodedDatum
+                        { ddIndex = idx
+                        , ddDestination = pnLabel (resolveAddress reg addr)
+                        , ddCbor = cbor
+                        , ddAst = ast
+                        }
+            _ -> Nothing
+    step _ = Nothing
+
+data DecodedDatum = DecodedDatum
+    { ddIndex :: !Int
+    , ddDestination :: !Text
+    , ddCbor :: !Text
+    , ddAst :: !Value
+    }
+
+groupByCbor :: [DecodedDatum] -> [(DecodedDatum, [Int])]
+groupByCbor = foldr add []
+  where
+    add d acc = case partitionBy (\(rep, _) -> ddCbor rep == ddCbor d) acc of
+        (Just (rep, idxs), rest) -> (rep, ddIndex d : idxs) : rest
+        (Nothing, _) -> (d, [ddIndex d]) : acc
+
+partitionBy :: (a -> Bool) -> [a] -> (Maybe a, [a])
+partitionBy _ [] = (Nothing, [])
+partitionBy p (x : xs)
+    | p x = (Just x, xs)
+    | otherwise = case partitionBy p xs of
+        (m, rest) -> (m, x : rest)
+
+renderDatumGroup :: (DecodedDatum, [Int]) -> Text
+renderDatumGroup (rep, indices) =
+    let title = case sortedIndices indices of
+            [i] -> "Output #" <> Text.pack (show i) <> " — " <> ddDestination rep
+            xs ->
+                "Outputs "
+                    <> Text.intercalate ", " ["#" <> Text.pack (show i) | i <- xs]
+                    <> " — "
+                    <> ddDestination rep
+                    <> " ("
+                    <> Text.pack (show (length xs))
+                    <> " identical)"
+     in "<details><summary>"
+            <> escapeTable title
+            <> "</summary>\n\n"
+            <> "```\n"
+            <> prettyPlutusData 0 (ddAst rep)
+            <> "```\n\n"
+            <> "</details>\n\n"
+
+sortedIndices :: [Int] -> [Int]
+sortedIndices = foldr insertSorted []
+  where
+    insertSorted x [] = [x]
+    insertSorted x (y : ys)
+        | x <= y = x : y : ys
+        | otherwise = y : insertSorted x ys
+
+{- | Pseudo-Lisp pretty-print of a Plutus Data AST node. Indented two
+spaces per nesting level. Constr is rendered with its constructor
+index; bytes show their hex (truncated for display) plus a UTF-8
+preview when present; ints render as decimal.
+-}
+prettyPlutusData :: Int -> Value -> Text
+prettyPlutusData lvl v =
+    let pad = Text.replicate (lvl * 2) " "
+     in case v of
+            Object o -> case KeyMap.lookup "kind" o of
+                Just (String "constr") ->
+                    let idx = case KeyMap.lookup "index" o of
+                            Just (Number n) -> Text.pack (show (floor n :: Integer))
+                            _ -> "?"
+                        fields = case KeyMap.lookup "fields" o of
+                            Just (Array xs) -> V.toList xs
+                            _ -> []
+                     in pad
+                            <> "Constr "
+                            <> idx
+                            <> "\n"
+                            <> Text.concat
+                                (map (prettyPlutusData (lvl + 1)) fields)
+                Just (String "list") ->
+                    let items = case KeyMap.lookup "items" o of
+                            Just (Array xs) -> V.toList xs
+                            _ -> []
+                     in pad
+                            <> "List "
+                            <> Text.pack (show (length items))
+                            <> "\n"
+                            <> Text.concat
+                                (map (prettyPlutusData (lvl + 1)) items)
+                Just (String "map") ->
+                    let entries = case KeyMap.lookup "entries" o of
+                            Just (Array xs) -> V.toList xs
+                            _ -> []
+                     in pad
+                            <> "Map\n"
+                            <> Text.concat
+                                (map (prettyMapEntry (lvl + 1)) entries)
+                Just (String "int") -> case KeyMap.lookup "value" o of
+                    Just (String s) -> pad <> "Int " <> s <> "\n"
+                    _ -> pad <> "Int ?\n"
+                Just (String "bytes") ->
+                    let hex = case KeyMap.lookup "hex" o of
+                            Just (String s) -> s
+                            _ -> ""
+                        len = case KeyMap.lookup "len" o of
+                            Just (Number n) -> floor n :: Int
+                            _ -> 0
+                        utf = case KeyMap.lookup "utf8" o of
+                            Just (String s) -> Just s
+                            _ -> Nothing
+                        hexShort
+                            | Text.length hex <= 32 = hex
+                            | otherwise = Text.take 16 hex <> "…" <> Text.takeEnd 8 hex
+                        utfTail = case utf of
+                            Just s -> "  // \"" <> s <> "\""
+                            Nothing -> ""
+                     in pad
+                            <> "Bytes "
+                            <> Text.pack (show len)
+                            <> "B "
+                            <> hexShort
+                            <> utfTail
+                            <> "\n"
+                _ -> pad <> "?\n"
+            _ -> pad <> "?\n"
+
+prettyMapEntry :: Int -> Value -> Text
+prettyMapEntry lvl v = case v of
+    Object o ->
+        let pad = Text.replicate (lvl * 2) " "
+            k = fromMaybe Null (KeyMap.lookup "k" o)
+            mv = fromMaybe Null (KeyMap.lookup "v" o)
+         in pad
+                <> "k:\n"
+                <> prettyPlutusData (lvl + 1) k
+                <> pad
+                <> "v:\n"
+                <> prettyPlutusData (lvl + 1) mv
+    _ -> ""
 
 {- | Per-redeemer table from @intent.scripts[]@. Each row identifies
 the redeemer's purpose, what it targets, the ex_units it commits, and

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -70,6 +70,8 @@ renderSummaryMarkdown reg doc files =
         [ titleSection doc
         , verdictSection doc
         , observationsSection reg doc
+        , scriptsSection reg doc
+        , outputsSection reg doc
         , claimsSection doc
         , effectsSection doc
         , failuresSection doc
@@ -297,6 +299,145 @@ scriptOutputCount doc =
      in case scriptB of
             (n : _) -> Just n
             [] -> Nothing
+
+{- | Per-output table from @intent.value.outputs[]@. Lets the reader
+see exactly how a script bucket's lovelace splits across individual
+outputs and which datum (by hash or by inline cbor preview)
+parameterises each one. Critical for swap analysis: SundaeSwap V3
+order outputs encode min-receive amounts and beneficiaries in their
+inline datums.
+-}
+outputsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
+outputsSection reg doc =
+    let path = ["result", "intent", "value", "outputs"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in if null items
+            then ""
+            else
+                "## Outputs\n\n"
+                    <> "| # | Bucket | Destination | ADA | Datum |\n"
+                    <> "|---|--------|-------------|----:|-------|\n"
+                    <> Text.concat (map (renderOutputRow reg) items)
+                    <> "\n"
+
+renderOutputRow :: ProtocolRegistry -> Value -> Text
+renderOutputRow reg v = case v of
+    Object o ->
+        let idx = case KeyMap.lookup "index" o of
+                Just (Number n) -> Text.pack (show (floor n :: Int))
+                _ -> "?"
+            bucket = case KeyMap.lookup "bucket" o of
+                Just (String s) -> s
+                _ -> ""
+            addr = case KeyMap.lookup "address_hex" o of
+                Just (String s) -> s
+                _ -> ""
+            party = pnLabel (resolveAddress reg addr)
+            lov = case KeyMap.lookup "coin_lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+            ada = formatAdaSimple (parseLov lov)
+            datumCell = case KeyMap.lookup "datum" o of
+                Just (Object d) -> renderDatumCell d
+                _ -> ""
+         in "| "
+                <> idx
+                <> " | "
+                <> escapeTable bucket
+                <> " | "
+                <> escapeTable party
+                <> " | "
+                <> ada
+                <> " | "
+                <> escapeTable datumCell
+                <> " |\n"
+    _ -> ""
+
+renderDatumCell :: KeyMap.KeyMap Value -> Text
+renderDatumCell d = case KeyMap.lookup "kind" d of
+    Just (String "no_datum") -> "—"
+    Just (String "datum_hash") -> case KeyMap.lookup "hash" d of
+        Just (String h) -> "hash `" <> Text.take 10 h <> "…`"
+        _ -> "hash"
+    Just (String "inline_datum") -> case KeyMap.lookup "cbor_hex" d of
+        Just (String h) -> "inline `" <> Text.take 14 h <> "…` (" <> Text.pack (show (Text.length h `div` 2)) <> "B)"
+        _ -> "inline"
+    _ -> ""
+
+parseLov :: Text -> Integer
+parseLov t = case reads (Text.unpack t) of
+    [(n, "")] -> n
+    _ -> 0
+
+{- | Per-redeemer table from @intent.scripts[]@. Each row identifies
+the redeemer's purpose, what it targets, the ex_units it commits, and
+a CBOR preview so the reader can spot-check the redeemer body without
+re-running the inspector.
+-}
+scriptsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
+scriptsSection reg doc =
+    let path = ["result", "intent", "scripts"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in if null items
+            then ""
+            else
+                "## Smart-contract calls\n\n"
+                    <> "| # | Purpose | Target | ex_units (mem / steps) | Redeemer |\n"
+                    <> "|---|---------|--------|------------------------|----------|\n"
+                    <> Text.concat (zipWith (renderScriptRow reg) [0 ..] items)
+                    <> "\n"
+
+renderScriptRow :: ProtocolRegistry -> Int -> Value -> Text
+renderScriptRow _reg n v = case v of
+    Object o ->
+        let purpose = case KeyMap.lookup "purpose" o of
+                Just (String s) -> s
+                _ -> "?"
+            idx = case KeyMap.lookup "index" o of
+                Just (Number x) -> Text.pack (show (floor x :: Int))
+                _ -> "?"
+            target = case purpose of
+                "spending" -> case KeyMap.lookup "input" o of
+                    Just (Object inp) ->
+                        let txid = case KeyMap.lookup "tx_id" inp of
+                                Just (String s) -> Text.take 16 s <> "…"
+                                _ -> "?"
+                            i = case KeyMap.lookup "index" inp of
+                                Just (Number x) -> Text.pack (show (floor x :: Int))
+                                _ -> "?"
+                         in "input " <> txid <> "#" <> i
+                    _ -> "input #" <> idx
+                _ -> purpose <> " #" <> idx
+            exu = case KeyMap.lookup "ex_units_committed" o of
+                Just (Object e) ->
+                    let mem = case KeyMap.lookup "memory" e of
+                            Just (String s) -> s
+                            _ -> "?"
+                        st = case KeyMap.lookup "steps" e of
+                            Just (String s) -> s
+                            _ -> "?"
+                     in mem <> " / " <> st
+                _ -> "?"
+            cbor = case KeyMap.lookup "redeemer_cbor_hex" o of
+                Just (String s) ->
+                    "`" <> Text.take 14 s <> "…` (" <> Text.pack (show (Text.length s `div` 2)) <> "B)"
+                _ -> ""
+         in "| "
+                <> Text.pack (show n)
+                <> " | "
+                <> escapeTable purpose
+                <> " | "
+                <> escapeTable target
+                <> " | "
+                <> escapeTable exu
+                <> " | "
+                <> escapeTable cbor
+                <> " |\n"
+    _ -> ""
 
 claimsSection :: DiagnosisDoc -> Text
 claimsSection doc =

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Summary
+Description : Top-level summary.md tying the cuts together with prose.
+
+Sections, in fixed order so the file diffs cleanly:
+
+* Title — from @intent.title@
+* Verdict paragraph — combines @summary@, @valid_for_supplied_context@,
+  and the failure count
+* Claims — @intent.metadata_claims@ as a table
+* Effects — @intent.sections[]@ rows (already pre-rendered for display
+  by the inspector library)
+* Signer perspective — @intent.signing@ + signer-perspective rows
+* Validation failures — one row per failure
+* Warnings — @intent.warnings@
+* Diagrams — relative links to whatever cuts were emitted
+-}
+module TxDeepDiagnosisHost.Render.Summary (
+    EmittedFiles (..),
+    noEmittedFiles,
+    renderSummaryMarkdown,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl')
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+
+{- | Which artifacts the caller wrote alongside @summary.md@.
+Each Maybe holds the relative file name when written.
+-}
+data EmittedFiles = EmittedFiles
+    { efParties :: !(Maybe FilePath)
+    , efValueFlow :: !(Maybe FilePath)
+    , efTopology :: !(Maybe FilePath)
+    , efFailures :: !(Maybe FilePath)
+    }
+
+-- | Default 'EmittedFiles' with everything missing.
+noEmittedFiles :: EmittedFiles
+noEmittedFiles =
+    EmittedFiles
+        { efParties = Nothing
+        , efValueFlow = Nothing
+        , efTopology = Nothing
+        , efFailures = Nothing
+        }
+
+renderSummaryMarkdown ::
+    ProtocolRegistry ->
+    DiagnosisDoc ->
+    EmittedFiles ->
+    Text
+renderSummaryMarkdown _reg doc files =
+    Text.concat
+        [ titleSection doc
+        , verdictSection doc
+        , claimsSection doc
+        , effectsSection doc
+        , failuresSection doc
+        , warningsSection doc
+        , diagramsSection files
+        ]
+
+-- ---------------------------------------------------------------- --
+-- Sections
+-- ---------------------------------------------------------------- --
+
+titleSection :: DiagnosisDoc -> Text
+titleSection doc =
+    let title = textPath doc ["result", "intent", "title"] "Transaction"
+        subtitle =
+            textPath
+                doc
+                ["result", "intent", "subtitle"]
+                ""
+     in "# "
+            <> title
+            <> "\n\n"
+            <> ( if Text.null subtitle
+                    then ""
+                    else "_" <> subtitle <> "_\n\n"
+               )
+            <> "Tx id: `"
+            <> textPath doc ["result", "intent", "tx_id"] ""
+            <> "`\n\n"
+
+verdictSection :: DiagnosisDoc -> Text
+verdictSection doc =
+    let topSummary = ddSummary doc
+        valid =
+            valuePath
+                (ddValidate doc)
+                [ "result"
+                , "validation"
+                , "valid_for_supplied_context"
+                ]
+        verdict = case valid of
+            Just (Bool True) -> "valid"
+            Just (Bool False) -> "invalid"
+            _ -> "unknown"
+     in "## Verdict\n\n"
+            <> "- "
+            <> topSummary
+            <> "\n"
+            <> "- ledger validation: **"
+            <> verdict
+            <> "**\n\n"
+
+claimsSection :: DiagnosisDoc -> Text
+claimsSection doc =
+    let intent = ddIntent doc
+        claims = case valuePath
+            intent
+            ["result", "intent", "claims"] of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in if null claims
+            then ""
+            else
+                "## Claims\n\n"
+                    <> "| Label | Value | Detail |\n"
+                    <> "|-------|-------|--------|\n"
+                    <> Text.concat (map renderClaim claims)
+                    <> "\n"
+  where
+    renderClaim (Object o) =
+        let lab = textOf "label" o ""
+            val = textOf "value" o ""
+            det = textOf "detail" o ""
+         in "| "
+                <> escapeTable lab
+                <> " | "
+                <> escapeTable val
+                <> " | "
+                <> escapeTable det
+                <> " |\n"
+    renderClaim _ = ""
+
+effectsSection :: DiagnosisDoc -> Text
+effectsSection doc =
+    let intent = ddIntent doc
+        sections = case valuePath
+            intent
+            ["result", "intent", "sections"] of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in Text.concat (map renderSectionHeading sections)
+  where
+    renderSectionHeading (Object o) =
+        let title = textOf "title" o ""
+            rows = case KeyMap.lookup "rows" o of
+                Just (Array xs) -> V.toList xs
+                _ -> []
+            empty = textOf "empty" o ""
+         in "## "
+                <> title
+                <> "\n\n"
+                <> ( if null rows
+                        then "_" <> empty <> "_\n\n"
+                        else
+                            "| Label | Value | Detail |\n"
+                                <> "|-------|-------|--------|\n"
+                                <> Text.concat (map renderRow rows)
+                                <> "\n"
+                   )
+    renderSectionHeading _ = ""
+    renderRow (Object o) =
+        let lab = textOf "label" o ""
+            val = textOf "value" o ""
+            det = textOf "detail" o ""
+         in "| "
+                <> escapeTable lab
+                <> " | "
+                <> escapeTable val
+                <> " | "
+                <> escapeTable det
+                <> " |\n"
+    renderRow _ = ""
+
+failuresSection :: DiagnosisDoc -> Text
+failuresSection doc =
+    let items = case valuePath
+            (ddValidate doc)
+            ["result", "validation", "failures"] of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in if null items
+            then ""
+            else
+                "## Validation failures\n\n"
+                    <> "| Rule | Message |\n"
+                    <> "|------|---------|\n"
+                    <> Text.concat (map renderFail items)
+                    <> "\n"
+  where
+    renderFail (Object o) =
+        let rule = textOf "rule" o ""
+            msg = textOf "message" o ""
+         in "| "
+                <> escapeTable rule
+                <> " | "
+                <> escapeTable msg
+                <> " |\n"
+    renderFail _ = ""
+
+warningsSection :: DiagnosisDoc -> Text
+warningsSection doc =
+    let warnings = case valuePath
+            (ddIntent doc)
+            ["result", "intent", "warnings"] of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+        textWarnings = [s | String s <- warnings]
+     in if null textWarnings
+            then ""
+            else
+                "## Warnings\n\n"
+                    <> Text.concat (map (\w -> "- " <> w <> "\n") textWarnings)
+                    <> "\n"
+
+diagramsSection :: EmittedFiles -> Text
+diagramsSection files =
+    let entries =
+            [ ("Parties (L1)", efParties files)
+            , ("Value flow (L2, Sankey TSV)", efValueFlow files)
+            , ("Topology (L3)", efTopology files)
+            , ("Failures (L4)", efFailures files)
+            ]
+        present =
+            [ "- [" <> label <> "](" <> Text.pack p <> ")\n"
+            | (label, Just p) <- entries
+            ]
+     in if null present
+            then ""
+            else "## Diagrams\n\n" <> Text.concat present <> "\n"
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+textOf :: Text -> KeyMap.KeyMap Value -> Text -> Text
+textOf k o def = case KeyMap.lookup (Key.fromText k) o of
+    Just (String s) -> s
+    _ -> def
+
+textPath :: DiagnosisDoc -> [Text] -> Text -> Text
+textPath doc path def =
+    let v =
+            valuePath
+                ( -- intent paths start with "result", validate paths
+                  -- start with "result"; pick intent by default since
+                  -- almost every textPath consumer wants the intent
+                  -- subtree.
+                  ddIntent doc
+                )
+                path
+     in case v of
+            Just (String s) -> s
+            _ -> fromMaybe def (Just def)
+
+valuePath :: Value -> [Text] -> Maybe Value
+valuePath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing
+
+{- | Escape a text for safe inclusion in a Markdown table cell. Pipes
+become escaped pipes; literal newlines collapse to spaces.
+-}
+escapeTable :: Text -> Text
+escapeTable =
+    Text.replace "\n" " "
+        . Text.replace "|" "\\|"

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -34,6 +34,10 @@ import qualified Data.Vector as V
 
 import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Names (
+    PartyName (..),
+    resolveAddress,
+ )
 
 {- | Which artifacts the caller wrote alongside @summary.md@.
 Each Maybe holds the relative file name when written.
@@ -60,10 +64,11 @@ renderSummaryMarkdown ::
     DiagnosisDoc ->
     EmittedFiles ->
     Text
-renderSummaryMarkdown _reg doc files =
+renderSummaryMarkdown reg doc files =
     Text.concat
         [ titleSection doc
         , verdictSection doc
+        , observationsSection reg doc
         , claimsSection doc
         , effectsSection doc
         , failuresSection doc
@@ -115,6 +120,134 @@ verdictSection doc =
             <> "- ledger validation: **"
             <> verdict
             <> "**\n\n"
+
+{- | Lists the facts that drive flow understanding: who owns the
+inputs (per registry), what the metadata declares as the destination
+(self-declared, separately listed because the inspector library
+already warns it is unverified), and what the envelope structurally
+cannot tell us (per-output addresses).
+
+The reader is expected to compare the input parties against the
+metadata destination on their own. Stating "self-swap detected"
+would mean asserting an output flow direction that the envelope
+does not actually expose.
+-}
+observationsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
+observationsSection reg doc =
+    let inParties = inputParties reg doc
+        metaDestinations = metadataDestinations doc
+        outputCount = countOutputs doc
+        scriptOutputs = scriptOutputCount doc
+        body =
+            Text.concat
+                [ "Input parties (registry-resolved):\n\n"
+                , bulletList (map renderParty inParties)
+                , "\n"
+                , metaSection metaDestinations
+                , outputsObservation outputCount scriptOutputs
+                ]
+     in if null inParties && null metaDestinations
+            then ""
+            else "## Observations\n\n" <> body
+  where
+    metaSection [] = ""
+    metaSection ds =
+        "Metadata-declared destinations (self-declared, "
+            <> "_not verified against actual output addresses_):\n\n"
+            <> bulletList (map (\d -> "_" <> d <> "_") ds)
+            <> "\n"
+    outputsObservation total scriptN =
+        let prelude =
+                "Output addresses are not exposed by the diagnosis "
+                    <> "envelope at this layer; "
+         in case (total, scriptN) of
+                (Nothing, _) -> ""
+                (Just t, _) ->
+                    prelude
+                        <> "of the "
+                        <> Text.pack (show t)
+                        <> " outputs"
+                        <> ( case scriptN of
+                                Just s
+                                    | s > 0 ->
+                                        " ("
+                                            <> Text.pack (show s)
+                                            <> " under script credentials)"
+                                _ -> ""
+                           )
+                        <> ", whether any returns to a party listed above "
+                        <> "cannot be confirmed without per-output address "
+                        <> "data.\n\n"
+
+bulletList :: [Text] -> Text
+bulletList = Text.concat . map (\x -> "- " <> x <> "\n")
+
+renderParty :: (Int, Text, PartyName) -> Text
+renderParty (i, lov, pn) =
+    "input #"
+        <> Text.pack (show i)
+        <> " — **"
+        <> pnLabel pn
+        <> "** (`"
+        <> partySource pn
+        <> "`) — "
+        <> lov
+        <> " lovelace"
+
+partySource :: PartyName -> Text
+partySource pn = case pnSource pn of
+    _ -> Text.pack (show (pnSource pn))
+
+inputParties :: ProtocolRegistry -> DiagnosisDoc -> [(Int, Text, PartyName)]
+inputParties reg doc =
+    let path = ["result", "validation", "resolved_inputs"]
+        items = case valuePath (ddValidate doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in zipWith (\i v -> mkParty i v) [0 ..] items
+            >>= maybe [] pure
+  where
+    mkParty i (Object o) = case KeyMap.lookup "tx_out" o of
+        Just (Object txOut) -> case KeyMap.lookup "address_hex" txOut of
+            Just (String addr) ->
+                let lov = case KeyMap.lookup "coin_lovelace" txOut of
+                        Just (String s) -> s
+                        _ -> "0"
+                 in Just (i, lov, resolveAddress reg addr)
+            _ -> Nothing
+        _ -> Nothing
+    mkParty _ _ = Nothing
+
+metadataDestinations :: DiagnosisDoc -> [Text]
+metadataDestinations doc =
+    let path = ["result", "intent", "metadata_claims"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in [d | Object o <- items, Just (String d) <- [KeyMap.lookup "destination" o], not (Text.null d)]
+
+countOutputs :: DiagnosisDoc -> Maybe Int
+countOutputs doc = case valuePath
+    (ddIntent doc)
+    ["result", "intent", "features", "output_count"] of
+    Just (Number n) -> Just (floor n)
+    _ -> Nothing
+
+scriptOutputCount :: DiagnosisDoc -> Maybe Int
+scriptOutputCount doc =
+    let path = ["result", "intent", "value", "output_buckets"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+        scriptB =
+            [ floor n
+            | Object o <- items
+            , Just (String "Script") <- [KeyMap.lookup "label" o]
+            , Just (Number n) <- [KeyMap.lookup "tx_out_count" o]
+            ]
+     in case scriptB of
+            (n : _) -> Just n
+            [] -> Nothing
 
 claimsSection :: DiagnosisDoc -> Text
 claimsSection doc =

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -36,6 +36,7 @@ import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
 import TxDeepDiagnosisHost.Render.Names (
     PartyName (..),
+    PartySource (..),
     resolveAddress,
  )
 
@@ -135,49 +136,35 @@ does not actually expose.
 observationsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
 observationsSection reg doc =
     let inParties = inputParties reg doc
+        outParties = outputParties reg doc
         metaDestinations = metadataDestinations doc
-        outputCount = countOutputs doc
-        scriptOutputs = scriptOutputCount doc
+        crossover = inputOutputOverlap inParties outParties
         body =
             Text.concat
                 [ "Input parties (registry-resolved):\n\n"
                 , bulletList (map renderParty inParties)
                 , "\n"
+                , "Output parties (registry-resolved, from `intent.value.output_buckets[].addresses`):\n\n"
+                , bulletList (map renderOutputParty outParties)
+                , "\n"
                 , metaSection metaDestinations
-                , outputsObservation outputCount scriptOutputs
+                , crossoverSection crossover
                 ]
-     in if null inParties && null metaDestinations
+     in if null inParties && null outParties && null metaDestinations
             then ""
             else "## Observations\n\n" <> body
   where
     metaSection [] = ""
     metaSection ds =
-        "Metadata-declared destinations (self-declared, "
-            <> "_not verified against actual output addresses_):\n\n"
+        "Metadata-declared destination(s) (`self_declared`):\n\n"
             <> bulletList (map (\d -> "_" <> d <> "_") ds)
             <> "\n"
-    outputsObservation total scriptN =
-        let prelude =
-                "Output addresses are not exposed by the diagnosis "
-                    <> "envelope at this layer; "
-         in case (total, scriptN) of
-                (Nothing, _) -> ""
-                (Just t, _) ->
-                    prelude
-                        <> "of the "
-                        <> Text.pack (show t)
-                        <> " outputs"
-                        <> ( case scriptN of
-                                Just s
-                                    | s > 0 ->
-                                        " ("
-                                            <> Text.pack (show s)
-                                            <> " under script credentials)"
-                                _ -> ""
-                           )
-                        <> ", whether any returns to a party listed above "
-                        <> "cannot be confirmed without per-output address "
-                        <> "data.\n\n"
+    crossoverSection [] = ""
+    crossoverSection ms =
+        "Inputs that also receive outputs (same payment credential on "
+            <> "both sides):\n\n"
+            <> bulletList ms
+            <> "\n"
 
 bulletList :: [Text] -> Text
 bulletList = Text.concat . map (\x -> "- " <> x <> "\n")
@@ -194,9 +181,71 @@ renderParty (i, lov, pn) =
         <> lov
         <> " lovelace"
 
+renderOutputParty :: (Text, PartyName) -> Text
+renderOutputParty (bucket, pn) =
+    bucket
+        <> " bucket → **"
+        <> pnLabel pn
+        <> "** (`"
+        <> partySource pn
+        <> "`)"
+
 partySource :: PartyName -> Text
-partySource pn = case pnSource pn of
-    _ -> Text.pack (show (pnSource pn))
+partySource pn = Text.pack (show (pnSource pn))
+
+{- | Output parties extracted from
+@intent.value.output_buckets[].addresses[]@. One row per (bucket,
+address); duplicates collapsed by 'pnLabel' to keep the list short
+when many script outputs share a contract.
+-}
+outputParties :: ProtocolRegistry -> DiagnosisDoc -> [(Text, PartyName)]
+outputParties reg doc =
+    let path = ["result", "intent", "value", "output_buckets"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+        bucketEntries =
+            [ (label, addrs)
+            | Object o <- items
+            , Just (String label) <- [KeyMap.lookup "label" o]
+            , Just (Array as) <- [KeyMap.lookup "addresses" o]
+            , let addrs = [a | String a <- V.toList as]
+            ]
+     in dedupByLabel
+            [ (b, resolveAddress reg a)
+            | (b, addrs) <- bucketEntries
+            , a <- addrs
+            ]
+
+dedupByLabel :: [(Text, PartyName)] -> [(Text, PartyName)]
+dedupByLabel =
+    foldr keep []
+  where
+    keep x acc
+        | any (\y -> fst x == fst y && pnLabel (snd x) == pnLabel (snd y)) acc =
+            acc
+        | otherwise = x : acc
+
+{- | Pairs of (input-party label, "appears in output bucket B") where
+the input's resolved party label also shows up in an output bucket's
+addresses. The match is on registry-resolved label, so a treasury
+that owns both input and output is detected even if its addresses use
+different stake credentials.
+-}
+inputOutputOverlap :: [(Int, Text, PartyName)] -> [(Text, PartyName)] -> [Text]
+inputOutputOverlap inputs outputs =
+    [ "input #"
+        <> Text.pack (show i)
+        <> " — **"
+        <> pnLabel ipn
+        <> "** also appears as a destination in the **"
+        <> bucket
+        <> "** output bucket"
+    | (i, _, ipn) <- inputs
+    , pnSource ipn /= TruncatedHex
+    , (bucket, opn) <- outputs
+    , pnLabel ipn == pnLabel opn
+    ]
 
 inputParties :: ProtocolRegistry -> DiagnosisDoc -> [(Int, Text, PartyName)]
 inputParties reg doc =

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -380,20 +380,145 @@ failuresSection doc =
             then ""
             else
                 "## Validation failures\n\n"
-                    <> "| Rule | Message |\n"
-                    <> "|------|---------|\n"
                     <> Text.concat (map renderFail items)
-                    <> "\n"
   where
     renderFail (Object o) =
         let rule = textOf "rule" o ""
+            predicate = textOf "predicate" o ""
             msg = textOf "message" o ""
-         in "| "
-                <> escapeTable rule
-                <> " | "
-                <> escapeTable msg
-                <> " |\n"
+         in "### "
+                <> rule
+                <> " — "
+                <> shortName predicate
+                <> "\n\n"
+                <> humanise predicate msg
+                <> "\n"
     renderFail _ = ""
+
+{- | Convert a verbose ledger predicate into one human-readable name
+that the reader can grep for. Falls back to the first 60 chars of the
+predicate so unmapped failures still produce useful output.
+-}
+shortName :: Text -> Text
+shortName p
+    | "ValueNotConservedUTxO" `Text.isInfixOf` p = "ValueNotConservedUTxO"
+    | "MissingVKeyWitnessesUTXOW" `Text.isInfixOf` p =
+        "MissingVKeyWitnessesUTXOW"
+    | "BadInputsUTxO" `Text.isInfixOf` p = "BadInputsUTxO"
+    | "OutsideValidityIntervalUTxO" `Text.isInfixOf` p =
+        "OutsideValidityInterval"
+    | otherwise = Text.take 60 p
+
+{- | Translate the predicate into a few lines of ADA-denominated /
+hash-listed prose. Falls back to the raw message in a fenced block
+when the predicate shape is not recognised.
+-}
+humanise :: Text -> Text -> Text
+humanise predicate msg
+    | "ValueNotConservedUTxO" `Text.isInfixOf` predicate =
+        humaniseValueNotConserved predicate
+    | "MissingVKeyWitnessesUTXOW" `Text.isInfixOf` predicate =
+        humaniseMissingVKey predicate
+    | otherwise = "```\n" <> msg <> "\n```\n"
+
+humaniseValueNotConserved :: Text -> Text
+humaniseValueNotConserved predicate =
+    let supplied = extractCoin "supplied: MaryValue (Coin " predicate
+        expected = extractCoin "expected: MaryValue (Coin " predicate
+        delta = supplied - expected
+        direction
+            | delta > 0 =
+                "Inputs supply **"
+                    <> formatAdaSimple delta
+                    <> " ADA** more than outputs + fee — that ADA is "
+                    <> "unaccounted for."
+            | delta < 0 =
+                "Outputs + fee claim **"
+                    <> formatAdaSimple (negate delta)
+                    <> " ADA** more than inputs supply — over-spent."
+            | otherwise = "Both sides equal but the ledger still rejected — re-check predicate."
+     in "- supplied (inputs): **"
+            <> formatAdaSimple supplied
+            <> " ADA**\n"
+            <> "- expected (outputs + fee): **"
+            <> formatAdaSimple expected
+            <> " ADA**\n"
+            <> "- "
+            <> direction
+            <> "\n"
+
+humaniseMissingVKey :: Text -> Text
+humaniseMissingVKey predicate =
+    let hashes = extractKeyHashes predicate
+     in if null hashes
+            then "No vkey witness hashes recovered from the predicate.\n"
+            else
+                "The following payment-key hashes are listed as required \
+                \signers but are missing from the witness set:\n\n"
+                    <> Text.concat (map (\h -> "- `" <> h <> "`\n") hashes)
+                    <> "\n_Tip:_ each hash above is the `payment_key_hash` of one \
+                       \of the resolved inputs (or an explicitly declared required \
+                       \signer in the tx body). Compare with the `Observations` \
+                       \section above to see which party each hash belongs to.\n"
+
+{- | Pull a Coin integer out of @\"supplied: MaryValue (Coin 12345)\"@
+or @\"expected: ... (Coin 12345)\"@. Returns 0 on no match.
+-}
+extractCoin :: Text -> Text -> Integer
+extractCoin marker predicate =
+    case Text.breakOn marker predicate of
+        (_, rest)
+            | not (Text.null rest) ->
+                let after = Text.drop (Text.length marker) rest
+                    digits = Text.takeWhile (\c -> c >= '0' && c <= '9') after
+                 in case reads (Text.unpack digits) of
+                        [(n, "")] -> n
+                        _ -> 0
+        _ -> 0
+
+extractKeyHashes :: Text -> [Text]
+extractKeyHashes =
+    filter isHashLike
+        . map cleanup
+        . drop 1
+        . Text.splitOn "KeyHash"
+  where
+    cleanup t =
+        Text.takeWhile
+            (/= '"')
+            (Text.drop 1 (Text.dropWhile (/= '"') t))
+    isHashLike t =
+        Text.length t == 56 && Text.all isHex t
+    isHex c =
+        (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+
+{- | Format an Integer lovelace amount as ADA with thousands
+separators and 6 decimals. Local copy to avoid a Render.Single ↔
+Render.Summary dependency cycle; both call sites are deterministic.
+-}
+formatAdaSimple :: Integer -> Text
+formatAdaSimple n =
+    let sign = if n < 0 then "-" else ""
+        m = abs n
+        whole = m `div` 1000000
+        frac = m `mod` 1000000
+        wholeT = withThousandsSeparators (Text.pack (show whole))
+        fracT = Text.justifyRight 6 '0' (Text.pack (show frac))
+     in sign <> wholeT <> "." <> fracT
+
+withThousandsSeparators :: Text -> Text
+withThousandsSeparators t =
+    let chars = Text.unpack t
+        len = length chars
+        (head', tailGroups) = splitAt ((len - 1) `mod` 3 + 1) chars
+        groups
+            | null tailGroups = [head']
+            | otherwise = head' : chunksOf 3 tailGroups
+     in Text.pack (concatMap (\g -> if g == head' then g else "," <> g) groups)
+  where
+    chunksOf k xs = case splitAt k xs of
+        (h, []) -> [h]
+        (h, rest) -> h : chunksOf k rest
 
 warningsSection :: DiagnosisDoc -> Text
 warningsSection doc =

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Topology.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Topology.hs
@@ -1,0 +1,411 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.Topology
+Description : L3 cut — full transaction topology as a Mermaid flowchart.
+
+One node per resolved input, output bucket, reference input,
+collateral input/return, body, and synthetic signer. Validation
+failures are overlaid as Mermaid 'classDef' classes on the affected
+nodes (mapping in 'TxDeepDiagnosisHost.Render.Failures').
+
+Per-output topology (one node per output, not per bucket) requires
+output address data that the diagnosis envelope does not currently
+expose; bucket aggregates are used until the inspector library
+surfaces per-output addresses.
+-}
+module TxDeepDiagnosisHost.Render.Topology (
+    renderTopologyMermaid,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl', nub)
+import Data.Maybe (mapMaybe)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TB
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Names (
+    PartyName (..),
+    resolveAddress,
+    truncateHash,
+ )
+
+-- | Render the L3 topology cut.
+renderTopologyMermaid :: ProtocolRegistry -> DiagnosisDoc -> Text
+renderTopologyMermaid reg doc =
+    TL.toStrict
+        . TB.toLazyText
+        . mconcat
+        $ [ "%% L3 — full topology for tx "
+          , txt (txIdOf doc)
+          , "\n"
+          , "flowchart TD\n"
+          , "    classDef body fill:#fffefa,stroke:#000,stroke-width:2px\n"
+          , "    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px\n"
+          , "    classDef inputNode fill:#f0f0f0,stroke:#666\n"
+          , "    classDef inputFail fill:#ffe6e6,stroke:#cc0000\n"
+          , "    classDef refInput fill:#f8f8f0,stroke:#999,stroke-dasharray:4 4\n"
+          , "    classDef collateral fill:#fff0f0,stroke:#aa6666\n"
+          , "    classDef bucket fill:#e6f0ff,stroke:#3366cc\n"
+          , "    classDef signer fill:#fff8dc,stroke:#cc9900\n"
+          , "    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px\n"
+          , bodyNode bodyFailing doc
+          , inputBlock reg doc
+          , bucketBlock doc
+          , refInputBlock reg doc
+          , collateralBlock doc
+          , signerBlock signerFailingHashes doc
+          ]
+  where
+    failureClasses = classifyFailures doc
+    bodyFailing = fcBodyFail failureClasses
+    signerFailingHashes = fcSignerFailHashes failureClasses
+
+-- ---------------------------------------------------------------- --
+-- Body
+-- ---------------------------------------------------------------- --
+
+bodyNode :: Bool -> DiagnosisDoc -> TB.Builder
+bodyNode failing doc =
+    let cls = if failing then "bodyFail" else "body"
+        annotations = bodyAnnotations doc
+        label = "tx body\\n" <> Text.intercalate "\\n" annotations
+     in mconcat
+            [ "    body[\""
+            , txt (escape label)
+            , "\"]:::"
+            , txt cls
+            , "\n"
+            ]
+
+bodyAnnotations :: DiagnosisDoc -> [Text]
+bodyAnnotations doc =
+    let intent = ddIntent doc
+        feeT = case lookupPath intent ["result", "intent", "fee_lovelace"] of
+            Just (String s) -> "fee " <> s <> " lovelace"
+            _ -> "fee unknown"
+        features =
+            lookupPath intent ["result", "intent", "features"]
+        feat k =
+            case features of
+                Just (Object o) -> case KeyMap.lookup (Key.fromText k) o of
+                    Just (Number n) -> Just (floor n :: Integer)
+                    _ -> Nothing
+                _ -> Nothing
+        redeemers = maybe "redeemers ?" (\n -> "redeemers " <> Text.pack (show n)) (feat "redeemer_count")
+        withdrawals =
+            maybe
+                "withdrawals ?"
+                (\n -> "withdrawals " <> Text.pack (show n))
+                (feat "withdrawal_count")
+        mintBurn =
+            case (feat "minted_asset_count", feat "burned_asset_count") of
+                (Just 0, Just 0) -> "no mint/burn"
+                (Just m, Just b) ->
+                    "mint " <> Text.pack (show m) <> " / burn " <> Text.pack (show b)
+                _ -> "mint/burn ?"
+        collateralFlag =
+            case feat "collateral_input_count" of
+                Just 0 -> "no collateral"
+                Just n -> "collateral " <> Text.pack (show n)
+                Nothing -> "collateral ?"
+     in [feeT, redeemers, withdrawals, mintBurn, collateralFlag]
+
+-- ---------------------------------------------------------------- --
+-- Inputs
+-- ---------------------------------------------------------------- --
+
+inputBlock :: ProtocolRegistry -> DiagnosisDoc -> TB.Builder
+inputBlock reg doc =
+    let inputs = resolvedInputs doc
+        rows = zip [0 :: Int ..] inputs
+     in mconcat (map (renderInput reg) rows)
+
+renderInput :: ProtocolRegistry -> (Int, ResolvedInput) -> TB.Builder
+renderInput reg (i, ri) =
+    let pn = resolveAddress reg (riAddress ri)
+        tag = "in" <> txt (Text.pack (show i))
+        label =
+            "input #"
+                <> Text.pack (show i)
+                <> "\\n"
+                <> pnLabel pn
+                <> "\\n"
+                <> riLovelace ri
+                <> " lovelace"
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::inputNode\n    "
+            , tag
+            , " --> body\n"
+            ]
+
+data ResolvedInput = ResolvedInput
+    { riAddress :: !Text
+    , riLovelace :: !Text
+    }
+
+resolvedInputs :: DiagnosisDoc -> [ResolvedInput]
+resolvedInputs doc =
+    parseResolvedList (ddValidate doc) ["result", "validation", "resolved_inputs"]
+
+resolvedReferenceInputs :: DiagnosisDoc -> [ResolvedInput]
+resolvedReferenceInputs doc =
+    parseResolvedList
+        (ddValidate doc)
+        ["result", "validation", "resolved_reference_inputs"]
+
+parseResolvedList :: Value -> [Text] -> [ResolvedInput]
+parseResolvedList v path =
+    let items = case lookupPath v path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseInput items
+  where
+    parseInput (Object o) = case KeyMap.lookup "tx_out" o of
+        Just (Object txOut) -> do
+            addr <- case KeyMap.lookup "address_hex" txOut of
+                Just (String s) -> Just s
+                _ -> Nothing
+            let lov = case KeyMap.lookup "coin_lovelace" txOut of
+                    Just (String s) -> s
+                    _ -> "0"
+            Just ResolvedInput{riAddress = addr, riLovelace = lov}
+        _ -> Nothing
+    parseInput _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Output buckets (until per-output addresses are exposed)
+-- ---------------------------------------------------------------- --
+
+bucketBlock :: DiagnosisDoc -> TB.Builder
+bucketBlock doc =
+    mconcat (map renderBucket (zip [0 :: Int ..] (outputBuckets doc)))
+
+renderBucket :: (Int, OutputBucket) -> TB.Builder
+renderBucket (i, b) =
+    let tag = "out" <> txt (Text.pack (show i))
+        label =
+            obLabel b
+                <> " bucket\\n"
+                <> Text.pack (show (obCount b))
+                <> " outputs / "
+                <> obLovelace b
+                <> " lovelace"
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::bucket\n    body --> "
+            , tag
+            , "\n"
+            ]
+
+data OutputBucket = OutputBucket
+    { obLabel :: !Text
+    , obCount :: !Integer
+    , obLovelace :: !Text
+    }
+
+outputBuckets :: DiagnosisDoc -> [OutputBucket]
+outputBuckets doc =
+    let items =
+            case lookupPath
+                (ddIntent doc)
+                ["result", "intent", "value", "output_buckets"] of
+                Just (Array xs) -> V.toList xs
+                _ -> []
+     in mapMaybe parseBucket items
+  where
+    parseBucket (Object o) = do
+        lab <- case KeyMap.lookup "label" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        let countN = case KeyMap.lookup "tx_out_count" o of
+                Just (Number n) -> floor n
+                _ -> 0 :: Integer
+            lov = case KeyMap.lookup "lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+        Just OutputBucket{obLabel = lab, obCount = countN, obLovelace = lov}
+    parseBucket _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Reference inputs
+-- ---------------------------------------------------------------- --
+
+refInputBlock :: ProtocolRegistry -> DiagnosisDoc -> TB.Builder
+refInputBlock reg doc =
+    mconcat (map (renderRef reg) (zip [0 :: Int ..] (resolvedReferenceInputs doc)))
+
+renderRef :: ProtocolRegistry -> (Int, ResolvedInput) -> TB.Builder
+renderRef reg (i, ri) =
+    let pn = resolveAddress reg (riAddress ri)
+        tag = "ref" <> txt (Text.pack (show i))
+        label =
+            "ref #"
+                <> Text.pack (show i)
+                <> "\\n"
+                <> pnLabel pn
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::refInput\n    "
+            , tag
+            , " -. read .-> body\n"
+            ]
+
+-- ---------------------------------------------------------------- --
+-- Collateral
+-- ---------------------------------------------------------------- --
+
+collateralBlock :: DiagnosisDoc -> TB.Builder
+collateralBlock doc =
+    let intent = ddIntent doc
+        feat k = case lookupPath intent ["result", "intent", "features"] of
+            Just (Object o) -> case KeyMap.lookup (Key.fromText k) o of
+                Just (Bool b) -> Just b
+                Just (Number n) -> Just (n /= 0)
+                _ -> Nothing
+            _ -> Nothing
+        hasCollIn = feat "collateral_input_count" == Just True
+        hasReturn = feat "has_collateral_return" == Just True
+        block =
+            (if hasCollIn then "    coll[\"collateral input\"]:::collateral\n    coll -. fee guard .-> body\n" else "")
+                <> (if hasReturn then "    collret[\"collateral return\"]:::collateral\n    body -. on script fail .-> collret\n" else "")
+     in TB.fromText block
+
+-- ---------------------------------------------------------------- --
+-- Signers
+-- ---------------------------------------------------------------- --
+
+signerBlock :: Set Text -> DiagnosisDoc -> TB.Builder
+signerBlock failing doc =
+    mconcat
+        ( map
+            (renderSigner failing)
+            (zip [0 :: Int ..] (nub (declaredSignerHashes doc)))
+        )
+
+renderSigner :: Set Text -> (Int, Text) -> TB.Builder
+renderSigner failing (i, h) =
+    let tag = "sig" <> txt (Text.pack (show i))
+        label = "signer " <> truncateHash h
+        cls =
+            if Set.member h failing
+                then "signerFail"
+                else "signer"
+     in mconcat
+            [ "    "
+            , tag
+            , "[\""
+            , txt (escape label)
+            , "\"]:::"
+            , txt cls
+            , "\n    "
+            , tag
+            , " -. required .-> body\n"
+            ]
+
+declaredSignerHashes :: DiagnosisDoc -> [Text]
+declaredSignerHashes doc =
+    let path =
+            [ "result"
+            , "intent"
+            , "signing"
+            , "missing_vkey_witnesses"
+            ]
+        items = case lookupPath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe extractHash items
+  where
+    extractHash (Object o) = case KeyMap.lookup "hash" o of
+        Just (String s) -> Just s
+        _ -> Nothing
+    extractHash _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Failure classification
+-- ---------------------------------------------------------------- --
+
+data FailureClasses = FailureClasses
+    { fcBodyFail :: !Bool
+    , fcSignerFailHashes :: !(Set Text)
+    }
+
+classifyFailures :: DiagnosisDoc -> FailureClasses
+classifyFailures doc =
+    let items = case lookupPath
+            (ddValidate doc)
+            ["result", "validation", "failures"] of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+        classify acc (Object o) =
+            let predicate = case KeyMap.lookup "predicate" o of
+                    Just (String s) -> s
+                    _ -> ""
+                msg = case KeyMap.lookup "message" o of
+                    Just (String s) -> s
+                    _ -> ""
+                blob = predicate <> " " <> msg
+                isMissingWit = "MissingVKeyWitnesses" `Text.isInfixOf` blob
+                hashesIn =
+                    if isMissingWit
+                        then extractHashesFromMessage blob
+                        else Set.empty
+             in FailureClasses
+                    { fcBodyFail = fcBodyFail acc || not isMissingWit
+                    , fcSignerFailHashes =
+                        Set.union (fcSignerFailHashes acc) hashesIn
+                    }
+        classify acc _ = acc
+     in foldl' classify FailureClasses{fcBodyFail = False, fcSignerFailHashes = Set.empty} items
+
+extractHashesFromMessage :: Text -> Set Text
+extractHashesFromMessage =
+    Set.fromList
+        . filter isHashLike
+        . map cleanup
+        . Text.splitOn "KeyHash"
+  where
+    cleanup t =
+        Text.takeWhile (/= '"') (Text.drop 1 (Text.dropWhile (/= '"') t))
+    isHashLike t = Text.length t == 56 && Text.all isHex t
+    isHex c = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+txIdOf :: DiagnosisDoc -> Text
+txIdOf doc = case lookupPath (ddIntent doc) ["result", "intent", "tx_id"] of
+    Just (String s) -> s
+    _ -> ""
+
+lookupPath :: Value -> [Text] -> Maybe Value
+lookupPath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing
+
+txt :: Text -> TB.Builder
+txt = TB.fromText
+
+escape :: Text -> Text
+escape = Text.replace "\"" "\\\""

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/ValueFlow.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/ValueFlow.hs
@@ -1,0 +1,204 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+{- |
+Module      : TxDeepDiagnosisHost.Render.ValueFlow
+Description : L2 cut — lovelace flow as Sankey-shaped TSV.
+
+Emits a tab-separated value document with the columns
+@source\\ttarget\\tlovelace\\tlabel@. Designed to be consumed by any
+generic Sankey renderer (d3-sankey, observable, pivot tools); the
+renderer here only assembles the table.
+
+Flow shape until per-output address data is available in the
+diagnosis envelope:
+
+>   resolved input -- lovelace --> (tx body)
+>   (tx body)       -- lovelace --> output bucket
+>   (tx body)       -- lovelace --> fee
+>   (tx body)       -- lovelace --> (unaccounted)   when value is not
+>                                                   conserved
+
+The unaccounted edge captures the @ValueNotConservedUTxO@ delta
+honestly rather than smearing it across buckets.
+-}
+module TxDeepDiagnosisHost.Render.ValueFlow (
+    renderValueFlowTsv,
+) where
+
+import Data.Aeson (Value (..))
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+import Data.List (foldl')
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as V
+
+import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Names (
+    PartyName (..),
+    resolveAddress,
+ )
+
+-- | Render the L2 value flow as TSV.
+renderValueFlowTsv :: ProtocolRegistry -> DiagnosisDoc -> Text
+renderValueFlowTsv reg doc =
+    let header = "source\ttarget\tlovelace\tlabel\n"
+        body =
+            mconcat
+                [ inputRows reg doc
+                , bucketRows doc
+                , feeRow doc
+                , unaccountedRow doc
+                ]
+     in header <> body
+
+-- ---------------------------------------------------------------- --
+-- Input rows
+-- ---------------------------------------------------------------- --
+
+inputRows :: ProtocolRegistry -> DiagnosisDoc -> Text
+inputRows reg doc =
+    let inputs = resolvedInputs doc
+        rows = zip [0 :: Int ..] inputs
+     in Text.concat (map (renderInputRow reg) rows)
+
+renderInputRow :: ProtocolRegistry -> (Int, ResolvedInput) -> Text
+renderInputRow reg (i, ri) =
+    let pn = resolveAddress reg (riAddress ri)
+        sourceLabel = "input#" <> Text.pack (show i) <> " " <> pnLabel pn
+     in tsvRow
+            [ sourceLabel
+            , "tx"
+            , riLovelace ri
+            , "input"
+            ]
+
+data ResolvedInput = ResolvedInput
+    { riAddress :: !Text
+    , riLovelace :: !Text
+    }
+
+resolvedInputs :: DiagnosisDoc -> [ResolvedInput]
+resolvedInputs doc =
+    let path = ["result", "validation", "resolved_inputs"]
+        items = case lookupPath (ddValidate doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseInput items
+  where
+    parseInput (Object o) = case KeyMap.lookup "tx_out" o of
+        Just (Object txOut) -> do
+            addr <- case KeyMap.lookup "address_hex" txOut of
+                Just (String s) -> Just s
+                _ -> Nothing
+            let lov = case KeyMap.lookup "coin_lovelace" txOut of
+                    Just (String s) -> s
+                    _ -> "0"
+            Just ResolvedInput{riAddress = addr, riLovelace = lov}
+        _ -> Nothing
+    parseInput _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Output bucket rows
+-- ---------------------------------------------------------------- --
+
+bucketRows :: DiagnosisDoc -> Text
+bucketRows doc =
+    Text.concat (map renderBucketRow (outputBuckets doc))
+
+renderBucketRow :: OutputBucket -> Text
+renderBucketRow b =
+    tsvRow
+        [ "tx"
+        , obLabel b <> " bucket"
+        , obLovelace b
+        , obLabel b <> " (" <> Text.pack (show (obCount b)) <> " outputs)"
+        ]
+
+data OutputBucket = OutputBucket
+    { obLabel :: !Text
+    , obCount :: !Integer
+    , obLovelace :: !Text
+    }
+
+outputBuckets :: DiagnosisDoc -> [OutputBucket]
+outputBuckets doc =
+    let path = ["result", "intent", "value", "output_buckets"]
+        items = case lookupPath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseBucket items
+  where
+    parseBucket (Object o) = do
+        lab <- case KeyMap.lookup "label" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        let countN = case KeyMap.lookup "tx_out_count" o of
+                Just (Number n) -> floor n
+                _ -> 0 :: Integer
+            lov = case KeyMap.lookup "lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+        Just OutputBucket{obLabel = lab, obCount = countN, obLovelace = lov}
+    parseBucket _ = Nothing
+
+-- ---------------------------------------------------------------- --
+-- Fee row
+-- ---------------------------------------------------------------- --
+
+feeRow :: DiagnosisDoc -> Text
+feeRow doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+    Just (String s) -> tsvRow ["tx", "fee", s, "fee paid"]
+    _ -> ""
+
+-- ---------------------------------------------------------------- --
+-- Unaccounted row (ValueNotConserved delta)
+-- ---------------------------------------------------------------- --
+
+unaccountedRow :: DiagnosisDoc -> Text
+unaccountedRow doc =
+    let inputTotal = sumInputs doc
+        outputTotal = sumOutputs doc
+        feeTotal = parseLovelace (feeOf doc)
+        delta = inputTotal - (outputTotal + feeTotal)
+     in if delta == 0
+            then ""
+            else
+                tsvRow
+                    [ "tx"
+                    , "(unaccounted)"
+                    , Text.pack (show delta)
+                    , "input total - (output total + fee); "
+                        <> "non-zero implies ValueNotConservedUTxO"
+                    ]
+
+sumInputs :: DiagnosisDoc -> Integer
+sumInputs = foldl' (\acc ri -> acc + parseLovelace (riLovelace ri)) 0 . resolvedInputs
+
+sumOutputs :: DiagnosisDoc -> Integer
+sumOutputs = foldl' (\acc b -> acc + parseLovelace (obLovelace b)) 0 . outputBuckets
+
+feeOf :: DiagnosisDoc -> Text
+feeOf doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+    Just (String s) -> s
+    _ -> "0"
+
+parseLovelace :: Text -> Integer
+parseLovelace t = case reads (Text.unpack t) of
+    [(n, "")] -> n
+    _ -> 0
+
+-- ---------------------------------------------------------------- --
+-- Helpers
+-- ---------------------------------------------------------------- --
+
+tsvRow :: [Text] -> Text
+tsvRow xs = Text.intercalate "\t" xs <> "\n"
+
+lookupPath :: Value -> [Text] -> Maybe Value
+lookupPath = foldl' step . Just
+  where
+    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
+    step _ _ = Nothing

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -54,6 +54,88 @@ Inputs that also receive outputs (same payment credential on both sides):
 | 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
 | 11 | external_key | key d2626d | 49,897.955481 | — |
 
+## Datums
+
+<details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
+
+```
+Constr 0
+  Constr 0
+    Bytes 28B 64f35d26b237ad58…6e2540ef
+  Constr 1
+    List 4
+      Constr 0
+        Bytes 28B 7095faf3d48d582f…2bbdeffb
+      Constr 0
+        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      Constr 0
+        Bytes 28B 8bd03209d227956a…b24fb1c1
+      Constr 0
+        Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  Int 1280000
+  Constr 0
+    Constr 0
+      Constr 1
+        Bytes 28B 32201dc1e8270836…a10baa0d
+      Constr 0
+        Constr 0
+          Constr 1
+            Bytes 28B 32201dc1e8270836…a10baa0d
+    Constr 0
+  Constr 1
+    List 3
+      Bytes 0B 
+      Bytes 0B 
+      Int 12500000000
+    List 3
+      Bytes 28B c48cbb3d5e57ed56…02da47ad
+      Bytes 8B 0014df105553444d
+      Int 3062500000
+  Constr 0
+```
+
+</details>
+
+<details><summary>Output #9 — SundaeSwap V3 order</summary>
+
+```
+Constr 0
+  Constr 0
+    Bytes 28B 64f35d26b237ad58…6e2540ef
+  Constr 1
+    List 4
+      Constr 0
+        Bytes 28B 7095faf3d48d582f…2bbdeffb
+      Constr 0
+        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      Constr 0
+        Bytes 28B 8bd03209d227956a…b24fb1c1
+      Constr 0
+        Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  Int 1280000
+  Constr 0
+    Constr 0
+      Constr 1
+        Bytes 28B 32201dc1e8270836…a10baa0d
+      Constr 0
+        Constr 0
+          Constr 1
+            Bytes 28B 32201dc1e8270836…a10baa0d
+    Constr 0
+  Constr 1
+    List 3
+      Bytes 0B 
+      Bytes 0B 
+      Int 8163265306
+    List 3
+      Bytes 28B c48cbb3d5e57ed56…02da47ad
+      Bytes 8B 0014df105553444d
+      Int 2000000000
+  Constr 0
+```
+
+</details>
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -68,10 +68,21 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Validation failures
 
-| Rule | Message |
-|------|---------|
-| UTXOW | Transaction witness or UTxO validation failed: UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))}) |
-| UTXOW | Transaction witness or UTxO validation failed: MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"},KeyHash {unKeyHash = "dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d"},KeyHash {unKeyHash = "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"}])) |
+### UTXOW — ValueNotConservedUTxO
+
+- supplied (inputs): **1,500,007.239276 ADA**
+- expected (outputs + fee): **1,212,431.799276 ADA**
+- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
+
+### UTXOW — MissingVKeyWitnessesUTXOW
+
+The following payment-key hashes are listed as required signers but are missing from the witness set:
+
+- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
+- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
+- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
+
+_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
 
 ## Warnings
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -81,23 +81,26 @@ flowchart LR
     S1 -. required .-> tx
 ```
 
-## Value flow
+## Balance
 
-```mermaid
----
-config:
-  sankey:
-    showValues: true
----
-sankey-beta
+### Inputs
 
-input#0 key d2626d,tx,50007239276
-input#1 Amaru Network Compliance treasury (0baa0d),tx,1450000000000
-tx,External key bucket,49897955481
-tx,Script bucket,1162532800000
-tx,fee,1043795
-tx,(unaccounted),287575440000
-```
+| Source | ADA |
+|--------|----:|
+| input #0 — key d2626d | 50,007.239276 |
+| input #1 — Amaru Network Compliance treasury (0baa0d) | 1,450,000.000000 |
+| **Total inputs** | **1,500,007.239276** |
+
+### Outputs + fee
+
+| Destination | ADA |
+|-------------|----:|
+| External key bucket | 49,897.955481 |
+| Script bucket | 1,162,532.800000 |
+| fee | 1.043795 |
+| **Total outputs + fee** | **1,212,431.799276** |
+
+**Unaccounted: 287,575.440000 missing — `ValueNotConservedUTxO`**
 
 ## Topology
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -30,6 +30,30 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
 
+## Smart-contract calls
+
+| # | Purpose | Target | ex_units (mem / steps) | Redeemer |
+|---|---------|--------|------------------------|----------|
+| 0 | spending | input 64f27254f3c0311f…#0 | 609151 / 242364094 | `d87c9fa140a140…` (17B) |
+| 1 | rewarding | rewarding #0 | 206629 / 66382393 | `80…` (1B) |
+
+## Outputs
+
+| # | Bucket | Destination | ADA | Datum |
+|---|--------|-------------|----:|-------|
+| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | inline `d8799fd8799f58…` (338B) |
+| 1 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 2 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 3 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 4 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 5 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 6 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 7 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 8 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 9 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
+| 11 | external_key | key d2626d | 49,897.955481 | — |
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -1,0 +1,164 @@
+# Signing summary
+
+_1 metadata claim / 2 missing required signers / 2 redeemers_
+
+Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
+
+## Verdict
+
+- 6/6 producer txs resolved, network=mainnet
+- ledger validation: **invalid**
+
+## Claims
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 / self-declared |
+
+## Signer value perspective
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
+| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
+| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
+| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
+
+## Critical effects
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Consumes inputs | 2 inputs | source outputs not supplied |
+| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
+| Pays fee | 1043795 lovelace |  |
+| Required signatures | 2 signers | 2 declared signers missing from witnesses |
+| Scripts | 2 redeemers | 0 script witnesses |
+| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
+| Withdrawals | 1 withdrawal |  |
+| Mint/burn | No mint/burn |  |
+| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
+
+## Missing required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
+
+## Validation failures
+
+| Rule | Message |
+|------|---------|
+| UTXOW | Transaction witness or UTxO validation failed: UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))}) |
+| UTXOW | Transaction witness or UTxO validation failed: MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"},KeyHash {unKeyHash = "dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d"},KeyHash {unKeyHash = "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"}])) |
+
+## Warnings
+
+- Metadata describes intent but is self-declared; verify it against the destination addresses and contract policy.
+- Declared required signer hashes are absent from the witness set.
+
+## Parties
+
+```mermaid
+%% L1 — parties involved in tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart LR
+    classDef signer fill:#fff8dc,stroke:#cc9900,stroke-width:2px
+    classDef inputAddr fill:#f0f0f0,stroke:#666
+    classDef bucket fill:#e6f0ff,stroke:#3366cc
+    classDef txBody fill:#fffefa,stroke:#000,stroke-width:2px
+    tx["tx"]:::txBody
+    I0["key d2626d"]:::inputAddr
+    I0 -- consumed --> tx
+    I1["Amaru Network Compliance treasury (0baa0d)"]:::inputAddr
+    I1 -- consumed --> tx
+    O0["External key (1 out, 49897955481 lovelace)"]:::bucket
+    tx -- produces --> O0
+    O1["Script (11 out, 1162532800000 lovelace)"]:::bucket
+    tx -- produces --> O1
+    S0["signer 8bd03209…b24fb1c1"]:::signer
+    S0 -. required .-> tx
+    S1["signer f3ab64b0…04d23e2e"]:::signer
+    S1 -. required .-> tx
+```
+
+## Value flow
+
+```mermaid
+---
+config:
+  sankey:
+    showValues: true
+---
+sankey-beta
+
+input#0 key d2626d,tx,50007239276
+input#1 Amaru Network Compliance treasury (0baa0d),tx,1450000000000
+tx,External key bucket,49897955481
+tx,Script bucket,1162532800000
+tx,fee,1043795
+tx,(unaccounted),287575440000
+```
+
+## Topology
+
+```mermaid
+%% L3 — full topology for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart TD
+    classDef body fill:#fffefa,stroke:#000,stroke-width:2px
+    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef inputNode fill:#f0f0f0,stroke:#666
+    classDef inputFail fill:#ffe6e6,stroke:#cc0000
+    classDef refInput fill:#f8f8f0,stroke:#999,stroke-dasharray:4 4
+    classDef collateral fill:#fff0f0,stroke:#aa6666
+    classDef bucket fill:#e6f0ff,stroke:#3366cc
+    classDef signer fill:#fff8dc,stroke:#cc9900
+    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    body["tx body\nfee 1043795 lovelace\nredeemers 2\nwithdrawals 1\nno mint/burn\ncollateral 1"]:::bodyFail
+    in0["input #0\nkey d2626d\n50007239276 lovelace"]:::inputNode
+    in0 --> body
+    in1["input #1\nAmaru Network Compliance treasury (0baa0d)\n1450000000000 lovelace"]:::inputNode
+    in1 --> body
+    out0["External key bucket\n1 outputs / 49897955481 lovelace"]:::bucket
+    body --> out0
+    out1["Script bucket\n11 outputs / 1162532800000 lovelace"]:::bucket
+    body --> out1
+    ref0["ref #0\n5a7350fe…35614365"]:::refInput
+    ref0 -. read .-> body
+    ref1["ref #1\nkey e15954"]:::refInput
+    ref1 -. read .-> body
+    ref2["ref #2\nkey e15954"]:::refInput
+    ref2 -. read .-> body
+    ref3["ref #3\nnetwork_compliance registry"]:::refInput
+    ref3 -. read .-> body
+    coll["collateral input"]:::collateral
+    coll -. fee guard .-> body
+    collret["collateral return"]:::collateral
+    body -. on script fail .-> collret
+    sig0["signer 8bd03209…b24fb1c1"]:::signerFail
+    sig0 -. required .-> body
+    sig1["signer f3ab64b0…04d23e2e"]:::signerFail
+    sig1 -. required .-> body
+```
+
+## Failure overlay
+
+```mermaid
+%% L4 — failures for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart TD
+    classDef body fill:#fff,stroke:#000
+    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef ruleFail fill:#fff0f0,stroke:#aa3333,stroke-dasharray:3 3
+    body["tx body"]:::body
+    f0["UTXOW / ValueNotConservedUTxO"]:::ruleFail
+    f0 --> body
+    body:::bodyFail
+    f1["UTXOW / MissingVKeyWitnesses"]:::ruleFail
+    f1_s0["missing signer 8bd03209…b24fb1c1"]:::signerFail
+    f1 --> f1_s0
+    f1_s1["missing signer dea7197a…c5d2626d"]:::signerFail
+    f1 --> f1_s1
+    f1_s2["missing signer f3ab64b0…04d23e2e"]:::signerFail
+    f1 --> f1_s2
+```
+

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -16,11 +16,19 @@ Input parties (registry-resolved):
 - input #0 — **key d2626d** (`TruncatedHex`) — 50007239276 lovelace
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`) — 1450000000000 lovelace
 
-Metadata-declared destinations (self-declared, _not verified against actual output addresses_):
+Output parties (registry-resolved, from `intent.value.output_buckets[].addresses`):
+
+- External key bucket → **key d2626d** (`TruncatedHex`)
+- Script bucket → **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`)
+- Script bucket → **SundaeSwap V3 order** (`FromValidator`)
+
+Metadata-declared destination(s) (`self_declared`):
 
 - _Network Compliance's treasury_
 
-Output addresses are not exposed by the diagnosis envelope at this layer; of the 12 outputs (11 under script credentials), whether any returns to a party listed above cannot be confirmed without per-output address data.
+Inputs that also receive outputs (same payment credential on both sides):
+
+- input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
 
 ## Claims
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -9,6 +9,19 @@ Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
 - 6/6 producer txs resolved, network=mainnet
 - ledger validation: **invalid**
 
+## Observations
+
+Input parties (registry-resolved):
+
+- input #0 — **key d2626d** (`TruncatedHex`) — 50007239276 lovelace
+- input #1 — **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`) — 1450000000000 lovelace
+
+Metadata-declared destinations (self-declared, _not verified against actual output addresses_):
+
+- _Network Compliance's treasury_
+
+Output addresses are not exposed by the diagnosis envelope at this layer; of the 12 outputs (11 under script credentials), whether any returns to a party listed above cannot be confirmed without per-output address data.
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/failures.mmd
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/failures.mmd
@@ -1,0 +1,17 @@
+%% L4 — failures for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart TD
+    classDef body fill:#fff,stroke:#000
+    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef ruleFail fill:#fff0f0,stroke:#aa3333,stroke-dasharray:3 3
+    body["tx body"]:::body
+    f0["UTXOW / ValueNotConservedUTxO"]:::ruleFail
+    f0 --> body
+    body:::bodyFail
+    f1["UTXOW / MissingVKeyWitnesses"]:::ruleFail
+    f1_s0["missing signer 8bd03209…b24fb1c1"]:::signerFail
+    f1 --> f1_s0
+    f1_s1["missing signer dea7197a…c5d2626d"]:::signerFail
+    f1 --> f1_s1
+    f1_s2["missing signer f3ab64b0…04d23e2e"]:::signerFail
+    f1 --> f1_s2

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/parties.mmd
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/parties.mmd
@@ -1,0 +1,19 @@
+%% L1 — parties involved in tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart LR
+    classDef signer fill:#fff8dc,stroke:#cc9900,stroke-width:2px
+    classDef inputAddr fill:#f0f0f0,stroke:#666
+    classDef bucket fill:#e6f0ff,stroke:#3366cc
+    classDef txBody fill:#fffefa,stroke:#000,stroke-width:2px
+    tx["tx"]:::txBody
+    I0["key d2626d"]:::inputAddr
+    I0 -- consumed --> tx
+    I1["Amaru Network Compliance treasury (0baa0d)"]:::inputAddr
+    I1 -- consumed --> tx
+    O0["External key (1 out, 49897955481 lovelace)"]:::bucket
+    tx -- produces --> O0
+    O1["Script (11 out, 1162532800000 lovelace)"]:::bucket
+    tx -- produces --> O1
+    S0["signer 8bd03209…b24fb1c1"]:::signer
+    S0 -. required .-> tx
+    S1["signer f3ab64b0…04d23e2e"]:::signer
+    S1 -. required .-> tx

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -54,6 +54,88 @@ Inputs that also receive outputs (same payment credential on both sides):
 | 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
 | 11 | external_key | key d2626d | 49,897.955481 | — |
 
+## Datums
+
+<details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
+
+```
+Constr 0
+  Constr 0
+    Bytes 28B 64f35d26b237ad58…6e2540ef
+  Constr 1
+    List 4
+      Constr 0
+        Bytes 28B 7095faf3d48d582f…2bbdeffb
+      Constr 0
+        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      Constr 0
+        Bytes 28B 8bd03209d227956a…b24fb1c1
+      Constr 0
+        Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  Int 1280000
+  Constr 0
+    Constr 0
+      Constr 1
+        Bytes 28B 32201dc1e8270836…a10baa0d
+      Constr 0
+        Constr 0
+          Constr 1
+            Bytes 28B 32201dc1e8270836…a10baa0d
+    Constr 0
+  Constr 1
+    List 3
+      Bytes 0B 
+      Bytes 0B 
+      Int 12500000000
+    List 3
+      Bytes 28B c48cbb3d5e57ed56…02da47ad
+      Bytes 8B 0014df105553444d
+      Int 3062500000
+  Constr 0
+```
+
+</details>
+
+<details><summary>Output #9 — SundaeSwap V3 order</summary>
+
+```
+Constr 0
+  Constr 0
+    Bytes 28B 64f35d26b237ad58…6e2540ef
+  Constr 1
+    List 4
+      Constr 0
+        Bytes 28B 7095faf3d48d582f…2bbdeffb
+      Constr 0
+        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      Constr 0
+        Bytes 28B 8bd03209d227956a…b24fb1c1
+      Constr 0
+        Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  Int 1280000
+  Constr 0
+    Constr 0
+      Constr 1
+        Bytes 28B 32201dc1e8270836…a10baa0d
+      Constr 0
+        Constr 0
+          Constr 1
+            Bytes 28B 32201dc1e8270836…a10baa0d
+    Constr 0
+  Constr 1
+    List 3
+      Bytes 0B 
+      Bytes 0B 
+      Int 8163265306
+    List 3
+      Bytes 28B c48cbb3d5e57ed56…02da47ad
+      Bytes 8B 0014df105553444d
+      Int 2000000000
+  Constr 0
+```
+
+</details>
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -1,0 +1,66 @@
+# Signing summary
+
+_1 metadata claim / 2 missing required signers / 2 redeemers_
+
+Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
+
+## Verdict
+
+- 6/6 producer txs resolved, network=mainnet
+- ledger validation: **invalid**
+
+## Claims
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 / self-declared |
+
+## Signer value perspective
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
+| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
+| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
+| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
+
+## Critical effects
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Consumes inputs | 2 inputs | source outputs not supplied |
+| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
+| Pays fee | 1043795 lovelace |  |
+| Required signatures | 2 signers | 2 declared signers missing from witnesses |
+| Scripts | 2 redeemers | 0 script witnesses |
+| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
+| Withdrawals | 1 withdrawal |  |
+| Mint/burn | No mint/burn |  |
+| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
+
+## Missing required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
+
+## Validation failures
+
+| Rule | Message |
+|------|---------|
+| UTXOW | Transaction witness or UTxO validation failed: UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))}) |
+| UTXOW | Transaction witness or UTxO validation failed: MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"},KeyHash {unKeyHash = "dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d"},KeyHash {unKeyHash = "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"}])) |
+
+## Warnings
+
+- Metadata describes intent but is self-declared; verify it against the destination addresses and contract policy.
+- Declared required signer hashes are absent from the witness set.
+
+## Diagrams
+
+- [Parties (L1)](parties.mmd)
+- [Value flow (L2, Sankey TSV)](value-flow.tsv)
+- [Topology (L3)](topology.mmd)
+- [Failures (L4)](failures.mmd)
+

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -68,10 +68,21 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Validation failures
 
-| Rule | Message |
-|------|---------|
-| UTXOW | Transaction witness or UTxO validation failed: UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))}) |
-| UTXOW | Transaction witness or UTxO validation failed: MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"},KeyHash {unKeyHash = "dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d"},KeyHash {unKeyHash = "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"}])) |
+### UTXOW — ValueNotConservedUTxO
+
+- supplied (inputs): **1,500,007.239276 ADA**
+- expected (outputs + fee): **1,212,431.799276 ADA**
+- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
+
+### UTXOW — MissingVKeyWitnessesUTXOW
+
+The following payment-key hashes are listed as required signers but are missing from the witness set:
+
+- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
+- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
+- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
+
+_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
 
 ## Warnings
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -30,6 +30,30 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
 
+## Smart-contract calls
+
+| # | Purpose | Target | ex_units (mem / steps) | Redeemer |
+|---|---------|--------|------------------------|----------|
+| 0 | spending | input 64f27254f3c0311f…#0 | 609151 / 242364094 | `d87c9fa140a140…` (17B) |
+| 1 | rewarding | rewarding #0 | 206629 / 66382393 | `80…` (1B) |
+
+## Outputs
+
+| # | Bucket | Destination | ADA | Datum |
+|---|--------|-------------|----:|-------|
+| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | inline `d8799fd8799f58…` (338B) |
+| 1 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 2 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 3 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 4 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 5 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 6 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 7 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 8 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 9 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
+| 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
+| 11 | external_key | key d2626d | 49,897.955481 | — |
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -16,11 +16,19 @@ Input parties (registry-resolved):
 - input #0 — **key d2626d** (`TruncatedHex`) — 50007239276 lovelace
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`) — 1450000000000 lovelace
 
-Metadata-declared destinations (self-declared, _not verified against actual output addresses_):
+Output parties (registry-resolved, from `intent.value.output_buckets[].addresses`):
+
+- External key bucket → **key d2626d** (`TruncatedHex`)
+- Script bucket → **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`)
+- Script bucket → **SundaeSwap V3 order** (`FromValidator`)
+
+Metadata-declared destination(s) (`self_declared`):
 
 - _Network Compliance's treasury_
 
-Output addresses are not exposed by the diagnosis envelope at this layer; of the 12 outputs (11 under script credentials), whether any returns to a party listed above cannot be confirmed without per-output address data.
+Inputs that also receive outputs (same payment credential on both sides):
+
+- input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
 
 ## Claims
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -9,6 +9,19 @@ Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
 - 6/6 producer txs resolved, network=mainnet
 - ledger validation: **invalid**
 
+## Observations
+
+Input parties (registry-resolved):
+
+- input #0 — **key d2626d** (`TruncatedHex`) — 50007239276 lovelace
+- input #1 — **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`) — 1450000000000 lovelace
+
+Metadata-declared destinations (self-declared, _not verified against actual output addresses_):
+
+- _Network Compliance's treasury_
+
+Output addresses are not exposed by the diagnosis envelope at this layer; of the 12 outputs (11 under script credentials), whether any returns to a party listed above cannot be confirmed without per-output address data.
+
 ## Claims
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/topology.mmd
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/topology.mmd
@@ -1,0 +1,36 @@
+%% L3 — full topology for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
+flowchart TD
+    classDef body fill:#fffefa,stroke:#000,stroke-width:2px
+    classDef bodyFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    classDef inputNode fill:#f0f0f0,stroke:#666
+    classDef inputFail fill:#ffe6e6,stroke:#cc0000
+    classDef refInput fill:#f8f8f0,stroke:#999,stroke-dasharray:4 4
+    classDef collateral fill:#fff0f0,stroke:#aa6666
+    classDef bucket fill:#e6f0ff,stroke:#3366cc
+    classDef signer fill:#fff8dc,stroke:#cc9900
+    classDef signerFail fill:#ffe6e6,stroke:#cc0000,stroke-width:2px
+    body["tx body\nfee 1043795 lovelace\nredeemers 2\nwithdrawals 1\nno mint/burn\ncollateral 1"]:::bodyFail
+    in0["input #0\nkey d2626d\n50007239276 lovelace"]:::inputNode
+    in0 --> body
+    in1["input #1\nAmaru Network Compliance treasury (0baa0d)\n1450000000000 lovelace"]:::inputNode
+    in1 --> body
+    out0["External key bucket\n1 outputs / 49897955481 lovelace"]:::bucket
+    body --> out0
+    out1["Script bucket\n11 outputs / 1162532800000 lovelace"]:::bucket
+    body --> out1
+    ref0["ref #0\n5a7350fe…35614365"]:::refInput
+    ref0 -. read .-> body
+    ref1["ref #1\nkey e15954"]:::refInput
+    ref1 -. read .-> body
+    ref2["ref #2\nkey e15954"]:::refInput
+    ref2 -. read .-> body
+    ref3["ref #3\nnetwork_compliance registry"]:::refInput
+    ref3 -. read .-> body
+    coll["collateral input"]:::collateral
+    coll -. fee guard .-> body
+    collret["collateral return"]:::collateral
+    body -. on script fail .-> collret
+    sig0["signer 8bd03209…b24fb1c1"]:::signerFail
+    sig0 -. required .-> body
+    sig1["signer f3ab64b0…04d23e2e"]:::signerFail
+    sig1 -. required .-> body

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/value-flow.tsv
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/value-flow.tsv
@@ -1,0 +1,7 @@
+source	target	lovelace	label
+input#0 key d2626d	tx	50007239276	input
+input#1 Amaru Network Compliance treasury (0baa0d)	tx	1450000000000	input
+tx	External key bucket	49897955481	External key (1 outputs)
+tx	Script bucket	1162532800000	Script (11 outputs)
+tx	fee	1043795	fee paid
+tx	(unaccounted)	287575440000	input total - (output total + fee); non-zero implies ValueNotConservedUTxO

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
@@ -163,6 +163,30 @@
               "value": "No mint/burn"
             }
           ],
+          "scripts": [
+            {
+              "ex_units_committed": {
+                "memory": "609151",
+                "steps": "242364094"
+              },
+              "index": 1,
+              "input": {
+                "index": 0,
+                "tx_id": "64f27254f3c0311fb2e672cdb87de200089a596aa90dc09f8be4248540267cf0"
+              },
+              "purpose": "spending",
+              "redeemer_cbor_hex": "d87c9fa140a1401b0000005f086d2b1aff"
+            },
+            {
+              "ex_units_committed": {
+                "memory": "206629",
+                "steps": "66382393"
+              },
+              "index": 0,
+              "purpose": "rewarding",
+              "redeemer_cbor_hex": "80"
+            }
+          ],
           "sections": [
             {
               "empty": "No signer value perspective available.",
@@ -335,6 +359,148 @@
               }
             ],
             "output_lovelace": "1212430755481",
+            "outputs": [
+              {
+                "address_hex": "3132201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "1041836734694",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 0
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 1
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 2
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 3
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 4
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 5
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 6
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 7
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 8
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "12503280000",
+                "datum": {
+                  "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000001e6918b1aff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1a77359400ffffd87980ff",
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                },
+                "index": 9
+              },
+              {
+                "address_hex": "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "bucket": "script",
+                "coin_lovelace": "8166545306",
+                "datum": {
+                  "kind": "no_datum"
+                },
+                "index": 10
+              },
+              {
+                "address_hex": "01dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626dbc1597ad71c55d2d009a9274b3831ded155118dd769f5376decc1369",
+                "assets": {},
+                "bucket": "external_key",
+                "coin_lovelace": "49897955481",
+                "datum": {
+                  "kind": "no_datum"
+                },
+                "index": 11
+              }
+            ],
             "resolved_input_buckets": [],
             "resolved_input_count": 0,
             "resolved_input_lovelace": "0",

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
@@ -367,8 +367,183 @@
                 "coin_lovelace": "1041836734694",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 0
               },
@@ -379,8 +554,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 1
               },
@@ -391,8 +741,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 2
               },
@@ -403,8 +928,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 3
               },
@@ -415,8 +1115,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 4
               },
@@ -427,8 +1302,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 5
               },
@@ -439,8 +1489,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 6
               },
@@ -451,8 +1676,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 7
               },
@@ -463,8 +1863,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000002e90edd00ff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1ab68a0aa0ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "12500000000"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "3062500000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 8
               },
@@ -475,8 +2050,183 @@
                 "coin_lovelace": "12503280000",
                 "datum": {
                   "cbor_hex": "d8799fd8799f581c64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540efffd87a9f9fd8799f581c7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffbffd8799f581cf3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2effd8799f581c8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1ffd8799f581c97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2ffffff1a00138800d8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffd8799fd8799fd87a9f581c32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0dffffffffd87980ffd87a9f9f40401b00000001e6918b1aff9f581cc48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad480014df105553444d1a77359400ffffd87980ff",
-                  "kind": "inline_datum",
-                  "note": "Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes"
+                  "decoded": {
+                    "fields": [
+                      {
+                        "fields": [
+                          {
+                            "hex": "64f35d26b237ad58e099041bc14c687ea7fdc58969d7d5b66e2540ef",
+                            "kind": "bytes",
+                            "len": 28
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "kind": "int",
+                        "value": "1280000"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "fields": [
+                              {
+                                "fields": [
+                                  {
+                                    "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                    "kind": "bytes",
+                                    "len": 28
+                                  }
+                                ],
+                                "index": 1,
+                                "kind": "constr"
+                              },
+                              {
+                                "fields": [
+                                  {
+                                    "fields": [
+                                      {
+                                        "fields": [
+                                          {
+                                            "hex": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                                            "kind": "bytes",
+                                            "len": 28
+                                          }
+                                        ],
+                                        "index": 1,
+                                        "kind": "constr"
+                                      }
+                                    ],
+                                    "index": 0,
+                                    "kind": "constr"
+                                  }
+                                ],
+                                "index": 0,
+                                "kind": "constr"
+                              }
+                            ],
+                            "index": 0,
+                            "kind": "constr"
+                          },
+                          {
+                            "fields": [],
+                            "index": 0,
+                            "kind": "constr"
+                          }
+                        ],
+                        "index": 0,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [
+                          {
+                            "items": [
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "hex": "",
+                                "kind": "bytes",
+                                "len": 0
+                              },
+                              {
+                                "kind": "int",
+                                "value": "8163265306"
+                              }
+                            ],
+                            "kind": "list"
+                          },
+                          {
+                            "items": [
+                              {
+                                "hex": "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                                "kind": "bytes",
+                                "len": 28
+                              },
+                              {
+                                "hex": "0014df105553444d",
+                                "kind": "bytes",
+                                "len": 8
+                              },
+                              {
+                                "kind": "int",
+                                "value": "2000000000"
+                              }
+                            ],
+                            "kind": "list"
+                          }
+                        ],
+                        "index": 1,
+                        "kind": "constr"
+                      },
+                      {
+                        "fields": [],
+                        "index": 0,
+                        "kind": "constr"
+                      }
+                    ],
+                    "index": 0,
+                    "kind": "constr"
+                  },
+                  "kind": "inline_datum"
                 },
                 "index": 9
               },

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
@@ -313,6 +313,9 @@
             "net_spend_note": "Signer net is unknown until producer transaction CBOR resolves every regular input; output totals are still ledger facts.",
             "output_buckets": [
               {
+                "addresses": [
+                  "01dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626dbc1597ad71c55d2d009a9274b3831ded155118dd769f5376decc1369"
+                ],
                 "asset_class_count": 0,
                 "bucket": "external_key",
                 "label": "External key",
@@ -320,6 +323,10 @@
                 "tx_out_count": 1
               },
               {
+                "addresses": [
+                  "3132201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                  "31fa6a58bbe2d0ff05534431c8e2f0ef2cbdc1602a8456e4b13c8f307732201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d"
+                ],
                 "asset_class_count": 0,
                 "bucket": "script",
                 "label": "Script",

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
@@ -1,0 +1,583 @@
+{
+  "tx-deep-diagnosis": {
+    "intent": {
+      "ledger_functional_layer": "cardano-ledger-functional/v1",
+      "op": "tx.intent",
+      "result": {
+        "intent": {
+          "body_hash": "30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f",
+          "claims": [
+            {
+              "detail": "Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 / self-declared",
+              "label": "Swap ADA<->USDM",
+              "value": "Swapping ADA for $100k at a rate of $0.245 per ADA"
+            }
+          ],
+          "context": {
+            "complete": false,
+            "decoded_producer_tx_count": 0,
+            "input_count": 2,
+            "input_policy": "preserve",
+            "missing_input_count": 2,
+            "missing_reference_input_count": 4,
+            "producer_tx_count": 0,
+            "producer_tx_errors": [],
+            "reference_input_count": 4,
+            "resolution": null,
+            "resolved_input_count": 0,
+            "resolved_reference_input_count": 0,
+            "supplied": false
+          },
+          "effects": [
+            {
+              "detail": "source outputs not supplied",
+              "label": "Consumes inputs",
+              "value": "2 inputs"
+            },
+            {
+              "detail": "1212430755481 lovelace total across all outputs",
+              "label": "Creates outputs",
+              "value": "12 outputs"
+            },
+            {
+              "detail": "",
+              "label": "Pays fee",
+              "value": "1043795 lovelace"
+            },
+            {
+              "detail": "2 declared signers missing from witnesses",
+              "label": "Required signatures",
+              "value": "2 signers"
+            },
+            {
+              "detail": "0 script witnesses",
+              "label": "Scripts",
+              "value": "2 redeemers"
+            },
+            {
+              "detail": "reference inputs are available to scripts but are not spent",
+              "label": "Reference inputs",
+              "value": "4 read-only inputs"
+            },
+            {
+              "detail": "",
+              "label": "Withdrawals",
+              "value": "1 withdrawal"
+            },
+            {
+              "detail": "",
+              "label": "Mint/burn",
+              "value": "No mint/burn"
+            },
+            {
+              "detail": "total 1565693 lovelace / return 50005673583 lovelace",
+              "label": "Collateral",
+              "value": "1 collateral input"
+            }
+          ],
+          "features": {
+            "burned_asset_count": 0,
+            "cert_count": 0,
+            "collateral_input_count": 1,
+            "datum_count": 0,
+            "has_collateral_return": true,
+            "has_total_collateral": true,
+            "input_count": 2,
+            "minted_asset_count": 0,
+            "output_count": 12,
+            "redeemer_count": 2,
+            "reference_input_count": 4,
+            "script_count": 0,
+            "withdrawal_count": 1
+          },
+          "fee_lovelace": "1043795",
+          "input_policy": "preserve",
+          "metadata_claims": [
+            {
+              "context": "",
+              "description": "Swapping ADA for $100k at a rate of $0.245 per ADA",
+              "destination": "Network Compliance's treasury",
+              "event": "disburse",
+              "hash": "",
+              "hash_algorithm": "blake2b-256",
+              "justification": "Required to pay Antithesis as vendor",
+              "label": "1694",
+              "self_declared": true,
+              "title": "Swap ADA<->USDM",
+              "value": {
+                "@context": [
+                  "https://github.com/SundaeSwap-finance/treasury-contracts/blob/",
+                  "ad4316d0d36cdef780f85fc2ec8b307e645ddc2a",
+                  "/offchain/src/metadata/spec.md"
+                ],
+                "body": {
+                  "description": [
+                    "Swapping ADA for $100k at a rate of $0.245 per ADA"
+                  ],
+                  "destination": {
+                    "label": "Network Compliance's treasury"
+                  },
+                  "event": "disburse",
+                  "justification": [
+                    "Required to pay Antithesis as vendor"
+                  ],
+                  "label": "Swap ADA<->USDM",
+                  "references": []
+                },
+                "hashAlgorithm": "blake2b-256",
+                "instance": "38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d"
+              }
+            }
+          ],
+          "metrics": [
+            {
+              "label": "Fee",
+              "value": "1.043795 ADA"
+            },
+            {
+              "label": "Signer net ADA",
+              "value": "unknown"
+            },
+            {
+              "label": "Output total",
+              "value": "1212430.755481 ADA"
+            },
+            {
+              "label": "Required signers",
+              "value": "2"
+            },
+            {
+              "label": "Missing signers",
+              "value": "2 missing required signers"
+            },
+            {
+              "label": "Redeemers",
+              "value": "2 redeemers"
+            },
+            {
+              "label": "Withdrawals",
+              "value": "1 withdrawal"
+            },
+            {
+              "label": "Mint/burn",
+              "value": "No mint/burn"
+            }
+          ],
+          "sections": [
+            {
+              "empty": "No signer value perspective available.",
+              "rows": [
+                {
+                  "copyValue": "unknown",
+                  "detail": "producer transaction CBOR must resolve every regular input before signer net can be known",
+                  "label": "Net signer ADA",
+                  "path": "[\"intent\",\"value\",\"signer_perspective\",\"#0\"]",
+                  "value": "unknown"
+                },
+                {
+                  "copyValue": "unknown",
+                  "detail": "0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs",
+                  "label": "Signer-controlled inputs",
+                  "path": "[\"intent\",\"value\",\"signer_perspective\",\"#1\"]",
+                  "value": "unknown"
+                },
+                {
+                  "copyValue": "0 ADA",
+                  "detail": "0 outputs matched signer payment key hashes out of 12 outputs",
+                  "label": "Signer-controlled outputs",
+                  "path": "[\"intent\",\"value\",\"signer_perspective\",\"#2\"]",
+                  "value": "0 ADA"
+                },
+                {
+                  "copyValue": "1212430.755481 ADA",
+                  "detail": "outputs not controlled by declared or witnessed signer payment key hashes",
+                  "label": "External/script outputs",
+                  "path": "[\"intent\",\"value\",\"signer_perspective\",\"#3\"]",
+                  "value": "1212430.755481 ADA"
+                }
+              ],
+              "title": "Signer value perspective"
+            },
+            {
+              "empty": "No transaction effects reported.",
+              "rows": [
+                {
+                  "copyValue": "2 inputs",
+                  "detail": "source outputs not supplied",
+                  "label": "Consumes inputs",
+                  "path": "[\"intent\",\"effects\",\"#0\"]",
+                  "value": "2 inputs"
+                },
+                {
+                  "copyValue": "12 outputs",
+                  "detail": "1212430755481 lovelace total across all outputs",
+                  "label": "Creates outputs",
+                  "path": "[\"intent\",\"effects\",\"#1\"]",
+                  "value": "12 outputs"
+                },
+                {
+                  "copyValue": "1043795 lovelace",
+                  "detail": "",
+                  "label": "Pays fee",
+                  "path": "[\"intent\",\"effects\",\"#2\"]",
+                  "value": "1043795 lovelace"
+                },
+                {
+                  "copyValue": "2 signers",
+                  "detail": "2 declared signers missing from witnesses",
+                  "label": "Required signatures",
+                  "path": "[\"intent\",\"effects\",\"#3\"]",
+                  "value": "2 signers"
+                },
+                {
+                  "copyValue": "2 redeemers",
+                  "detail": "0 script witnesses",
+                  "label": "Scripts",
+                  "path": "[\"intent\",\"effects\",\"#4\"]",
+                  "value": "2 redeemers"
+                },
+                {
+                  "copyValue": "4 read-only inputs",
+                  "detail": "reference inputs are available to scripts but are not spent",
+                  "label": "Reference inputs",
+                  "path": "[\"intent\",\"effects\",\"#5\"]",
+                  "value": "4 read-only inputs"
+                },
+                {
+                  "copyValue": "1 withdrawal",
+                  "detail": "",
+                  "label": "Withdrawals",
+                  "path": "[\"intent\",\"effects\",\"#6\"]",
+                  "value": "1 withdrawal"
+                },
+                {
+                  "copyValue": "No mint/burn",
+                  "detail": "",
+                  "label": "Mint/burn",
+                  "path": "[\"intent\",\"effects\",\"#7\"]",
+                  "value": "No mint/burn"
+                },
+                {
+                  "copyValue": "1 collateral input",
+                  "detail": "total 1565693 lovelace / return 50005673583 lovelace",
+                  "label": "Collateral",
+                  "path": "[\"intent\",\"effects\",\"#8\"]",
+                  "value": "1 collateral input"
+                }
+              ],
+              "title": "Critical effects"
+            },
+            {
+              "empty": "None missing.",
+              "rows": [
+                {
+                  "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                  "label": "declared required signer not present in vkey or bootstrap witnesses",
+                  "path": "[\"intent\",\"signing\",\"missing_vkey_witnesses\",\"#0\",\"hash\"]",
+                  "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"
+                },
+                {
+                  "copyValue": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                  "label": "declared required signer not present in vkey or bootstrap witnesses",
+                  "path": "[\"intent\",\"signing\",\"missing_vkey_witnesses\",\"#1\",\"hash\"]",
+                  "value": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"
+                }
+              ],
+              "title": "Missing required signers"
+            }
+          ],
+          "signing": {
+            "missing_vkey_witness_count": 2,
+            "missing_vkey_witnesses": [
+              {
+                "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                "reason": "declared required signer not present in vkey or bootstrap witnesses"
+              },
+              {
+                "hash": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                "reason": "declared required signer not present in vkey or bootstrap witnesses"
+              }
+            ],
+            "present_bootstrap_witness_count": 0,
+            "present_vkey_witness_count": 0,
+            "required_signer_count": 2
+          },
+          "subtitle": "1 metadata claim / 2 missing required signers / 2 redeemers",
+          "title": "Signing summary",
+          "tx_id": "30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f",
+          "value": {
+            "input_lovelace_complete": false,
+            "net_spend_known": false,
+            "net_spend_note": "Signer net is unknown until producer transaction CBOR resolves every regular input; output totals are still ledger facts.",
+            "output_buckets": [
+              {
+                "asset_class_count": 0,
+                "bucket": "external_key",
+                "label": "External key",
+                "lovelace": "49897955481",
+                "tx_out_count": 1
+              },
+              {
+                "asset_class_count": 0,
+                "bucket": "script",
+                "label": "Script",
+                "lovelace": "1162532800000",
+                "tx_out_count": 11
+              }
+            ],
+            "output_lovelace": "1212430755481",
+            "resolved_input_buckets": [],
+            "resolved_input_count": 0,
+            "resolved_input_lovelace": "0",
+            "signer_lovelace": {
+              "basis": "payment key credentials matching declared required signers or present key witnesses",
+              "external_or_script_output_lovelace": "1212430755481",
+              "known": false,
+              "net_lovelace": null,
+              "output_lovelace": "0",
+              "resolved_input_lovelace": "0"
+            }
+          },
+          "warnings": [
+            "Metadata describes intent but is self-declared; verify it against the destination addresses and contract policy.",
+            "Declared required signer hashes are absent from the witness set."
+          ]
+        }
+      }
+    },
+    "summary": "6/6 producer txs resolved, network=mainnet",
+    "validate": {
+      "ledger_functional_layer": "cardano-ledger-functional/v1",
+      "op": "tx.validate",
+      "result": {
+        "validation": {
+          "body_hash": "30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f",
+          "checks": [
+            {
+              "id": "context.explicit",
+              "message": "Supplied context is syntactically usable.",
+              "path": [
+                "args",
+                "context"
+              ],
+              "required_context": [],
+              "scope": "context",
+              "status": "passed",
+              "title": "Explicit validation context"
+            },
+            {
+              "id": "ledger.apply_tx",
+              "message": "Conway applyTx rejected the transaction for the supplied context.",
+              "path": [
+                "args",
+                "context"
+              ],
+              "required_context": [
+                "source_output",
+                "protocol_parameters",
+                "slot",
+                "epoch",
+                "network"
+              ],
+              "scope": "ledger",
+              "status": "failed",
+              "title": "Conway ledger validation"
+            }
+          ],
+          "complete": true,
+          "context": {
+            "complete": true,
+            "decoded_producer_tx_count": 6,
+            "epoch": "628",
+            "input_count": 2,
+            "input_policy": "preserve",
+            "missing_input_count": 0,
+            "missing_reference_input_count": 0,
+            "network": "mainnet",
+            "producer_tx_count": 6,
+            "producer_tx_errors": [],
+            "reference_input_count": 4,
+            "resolution": null,
+            "resolved_input_count": 2,
+            "resolved_reference_input_count": 4,
+            "slot": "186251734",
+            "supplied": true,
+            "unspent_status": "not_checked"
+          },
+          "errors": [],
+          "failures": [
+            {
+              "index": 0,
+              "kind": "ledger_failure",
+              "message": "Transaction witness or UTxO validation failed: UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))})",
+              "path": [
+                "body"
+              ],
+              "predicate": "ConwayUtxowFailure (UtxoFailure (ValueNotConservedUTxO Mismatch (RelEQ) {supplied: MaryValue (Coin 1500007239276) (MultiAsset (fromList [])), expected: MaryValue (Coin 1212431799276) (MultiAsset (fromList []))}))",
+              "rule": "UTXOW"
+            },
+            {
+              "index": 1,
+              "kind": "ledger_failure",
+              "message": "Transaction witness or UTxO validation failed: MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = \"8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1\"},KeyHash {unKeyHash = \"dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d\"},KeyHash {unKeyHash = \"f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e\"}]))",
+              "path": [
+                "body"
+              ],
+              "predicate": "ConwayUtxowFailure (MissingVKeyWitnessesUTXOW (NonEmptySet (fromList [KeyHash {unKeyHash = \"8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1\"},KeyHash {unKeyHash = \"dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d\"},KeyHash {unKeyHash = \"f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e\"}])))",
+              "rule": "UTXOW"
+            }
+          ],
+          "missing_context": [],
+          "resolved_inputs": [
+            {
+              "index": 0,
+              "key": "42e4c279036e3ab6070bc969392b823917d8b998204d5dcbdfe69fec4b442da0#0",
+              "kind": "input",
+              "path": [
+                "body",
+                "inputs",
+                "#0"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "42e4c279036e3ab6070bc969392b823917d8b998204d5dcbdfe69fec4b442da0",
+              "tx_out": {
+                "address_hex": "01dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626dbc1597ad71c55d2d009a9274b3831ded155118dd769f5376decc1369",
+                "assets": {},
+                "coin_lovelace": "50007239276",
+                "datum": {
+                  "kind": "no_datum"
+                }
+              }
+            },
+            {
+              "index": 0,
+              "key": "64f27254f3c0311fb2e672cdb87de200089a596aa90dc09f8be4248540267cf0#0",
+              "kind": "input",
+              "path": [
+                "body",
+                "inputs",
+                "#1"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "64f27254f3c0311fb2e672cdb87de200089a596aa90dc09f8be4248540267cf0",
+              "tx_out": {
+                "address_hex": "3132201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+                "assets": {},
+                "coin_lovelace": "1450000000000",
+                "datum": {
+                  "kind": "no_datum"
+                }
+              }
+            }
+          ],
+          "resolved_reference_inputs": [
+            {
+              "index": 0,
+              "key": "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#0",
+              "kind": "reference_input",
+              "path": [
+                "body",
+                "reference_inputs",
+                "#0"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54",
+              "tx_out": {
+                "address_hex": "715a7350fef97581498697d679aa1cbc4fb72f51991bde8ad535614365",
+                "assets": {
+                  "5a7350fef97581498697d679aa1cbc4fb72f51991bde8ad535614365": {
+                    "616d61727520323032362073636f706573": "1"
+                  }
+                },
+                "coin_lovelace": "2000000",
+                "datum": {
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST rendering deferred"
+                }
+              }
+            },
+            {
+              "index": 2,
+              "key": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#2",
+              "kind": "reference_input",
+              "path": [
+                "body",
+                "reference_inputs",
+                "#1"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095",
+              "tx_out": {
+                "address_hex": "012613b73d0961f4a63e2ea0551a9689f8e42121b5f1705f1b72e1595423a476e5a8dbfffd3fb5e9026fba36c195ae5ab0fd9df92b2866ea06",
+                "assets": {},
+                "coin_lovelace": "25000000",
+                "datum": {
+                  "kind": "no_datum"
+                }
+              }
+            },
+            {
+              "index": 0,
+              "key": "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#0",
+              "kind": "reference_input",
+              "path": [
+                "body",
+                "reference_inputs",
+                "#2"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c",
+              "tx_out": {
+                "address_hex": "012613b73d0961f4a63e2ea0551a9689f8e42121b5f1705f1b72e1595423a476e5a8dbfffd3fb5e9026fba36c195ae5ab0fd9df92b2866ea06",
+                "assets": {},
+                "coin_lovelace": "25000000",
+                "datum": {
+                  "kind": "no_datum"
+                }
+              }
+            },
+            {
+              "index": 2,
+              "key": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#2",
+              "kind": "reference_input",
+              "path": [
+                "body",
+                "reference_inputs",
+                "#3"
+              ],
+              "resolved": true,
+              "source": "blockfrost.txs.cbor",
+              "tx_id": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c",
+              "tx_out": {
+                "address_hex": "7138c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d",
+                "assets": {
+                  "38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d": {
+                    "5245474953545259": "1"
+                  }
+                },
+                "coin_lovelace": "2000000",
+                "datum": {
+                  "kind": "inline_datum",
+                  "note": "Plutus Data AST rendering deferred"
+                }
+              }
+            }
+          ],
+          "status": "invalid",
+          "tx_id": "30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f",
+          "valid_for_supplied_context": false,
+          "warnings": [
+            "tx.validate did not mutate or return transaction CBOR."
+          ]
+        }
+      }
+    }
+  }
+}

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -28,6 +28,7 @@ library
     TxDeepDiagnosisHost.Render.Doc
     TxDeepDiagnosisHost.Render.Names
     TxDeepDiagnosisHost.Render.Parties
+    TxDeepDiagnosisHost.Render.ValueFlow
     TxDeepDiagnosisHost.Report
 
   build-depends:

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -28,6 +28,7 @@ library
     TxDeepDiagnosisHost.Render.Doc
     TxDeepDiagnosisHost.Render.Names
     TxDeepDiagnosisHost.Render.Parties
+    TxDeepDiagnosisHost.Render.Topology
     TxDeepDiagnosisHost.Render.ValueFlow
     TxDeepDiagnosisHost.Report
 

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -25,6 +25,7 @@ library
     TxDeepDiagnosisHost.Blockfrost
     TxDeepDiagnosisHost.Diagnosis
     TxDeepDiagnosisHost.Registry
+    TxDeepDiagnosisHost.Render.Doc
     TxDeepDiagnosisHost.Report
 
   build-depends:

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -26,8 +26,10 @@ library
     TxDeepDiagnosisHost.Diagnosis
     TxDeepDiagnosisHost.Registry
     TxDeepDiagnosisHost.Render.Doc
+    TxDeepDiagnosisHost.Render.Failures
     TxDeepDiagnosisHost.Render.Names
     TxDeepDiagnosisHost.Render.Parties
+    TxDeepDiagnosisHost.Render.Summary
     TxDeepDiagnosisHost.Render.Topology
     TxDeepDiagnosisHost.Render.ValueFlow
     TxDeepDiagnosisHost.Report

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -27,6 +27,7 @@ library
     TxDeepDiagnosisHost.Registry
     TxDeepDiagnosisHost.Render.Doc
     TxDeepDiagnosisHost.Render.Names
+    TxDeepDiagnosisHost.Render.Parties
     TxDeepDiagnosisHost.Report
 
   build-depends:
@@ -44,6 +45,7 @@ library
     , http-types
     , scientific
     , text
+    , vector
     , cardano-ledger-inspector
 
   default-language: Haskell2010

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -68,3 +68,20 @@ executable tx-deep-diagnosis
 
   default-language: Haskell2010
   ghc-options:      -Wall
+
+executable tx-deep-diagnosis-render-snapshot
+  main-is:          Main.hs
+  hs-source-dirs:   snapshot
+  other-modules:    Paths_tx_deep_diagnosis
+  autogen-modules:  Paths_tx_deep_diagnosis
+  build-depends:
+    , aeson
+    , base                  >=4.18 && <5
+    , bytestring
+    , directory
+    , filepath
+    , text
+    , tx-deep-diagnosis
+
+  default-language: Haskell2010
+  ghc-options:      -Wall

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -26,6 +26,7 @@ library
     TxDeepDiagnosisHost.Diagnosis
     TxDeepDiagnosisHost.Registry
     TxDeepDiagnosisHost.Render.Doc
+    TxDeepDiagnosisHost.Render.Names
     TxDeepDiagnosisHost.Report
 
   build-depends:

--- a/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
+++ b/apps/tx-deep-diagnosis/tx-deep-diagnosis.cabal
@@ -29,6 +29,7 @@ library
     TxDeepDiagnosisHost.Render.Failures
     TxDeepDiagnosisHost.Render.Names
     TxDeepDiagnosisHost.Render.Parties
+    TxDeepDiagnosisHost.Render.Single
     TxDeepDiagnosisHost.Render.Summary
     TxDeepDiagnosisHost.Render.Topology
     TxDeepDiagnosisHost.Render.ValueFlow

--- a/flake.nix
+++ b/flake.nix
@@ -636,7 +636,8 @@
           # apps/tx-deep-diagnosis/test/golden/<case>/ and asserts each
           # produced artifact equals expected/<file> byte-for-byte. The
           # binary calls only pure renderers — no ledger / no network.
-          tx-explain-render-smoke = pkgs.runCommand "tx-explain-render-smoke" { } ''
+          tx-explain-render-smoke = pkgs.runCommand "tx-explain-render-smoke"
+            { LANG = "C.UTF-8"; LC_ALL = "C.UTF-8"; } ''
             mkdir -p $out
             ${hostTargets.tx-deep-diagnosis-render-snapshot}/bin/tx-deep-diagnosis-render-snapshot \
               ${./apps/tx-deep-diagnosis/test/golden} \

--- a/flake.nix
+++ b/flake.nix
@@ -631,12 +631,24 @@
               evaluate-scripts-response.json wasi-evaluate-scripts-response.json \
               $out/
           '';
+
+          # Snapshot harness for the explain-artifact renderers. Walks
+          # apps/tx-deep-diagnosis/test/golden/<case>/ and asserts each
+          # produced artifact equals expected/<file> byte-for-byte. The
+          # binary calls only pure renderers — no ledger / no network.
+          tx-explain-render-smoke = pkgs.runCommand "tx-explain-render-smoke" { } ''
+            mkdir -p $out
+            ${hostTargets.tx-deep-diagnosis-render-snapshot}/bin/tx-deep-diagnosis-render-snapshot \
+              ${./apps/tx-deep-diagnosis/test/golden} \
+              | tee $out/snapshot.log
+          '';
         in
         {
           packages = {
             inherit (wasmTargets)
               wasm-smoke wasm-ledger-smoke wasm-tx-inspector wasm-extism-spike;
-            inherit (hostTargets) extism-spike-host libextism tx-deep-diagnosis;
+            inherit (hostTargets) extism-spike-host libextism
+              tx-deep-diagnosis tx-deep-diagnosis-render-snapshot;
             inherit
               ledger-functional-openapi
               ledger-functional-openapi-generated
@@ -655,7 +667,8 @@
               tx-input-context-smoke
               tx-validate-smoke
               tx-evaluate-scripts-smoke
-              tx-extism-spike-smoke;
+              tx-extism-spike-smoke
+              tx-explain-render-smoke;
             ledger-functional-swagger-check = ledger-functional-openapi-check;
           };
 
@@ -733,6 +746,8 @@
                 mkApp (mkSmokeApp "tx-input-context-smoke" tx-input-context-smoke);
               tx-extism-spike-smoke =
                 mkApp (mkSmokeApp "tx-extism-spike-smoke" tx-extism-spike-smoke);
+              tx-explain-render-smoke =
+                mkApp (mkSmokeApp "tx-explain-render-smoke" tx-explain-render-smoke);
               ledger-functional-openapi-check =
                 mkApp (mkSmokeApp "ledger-functional-openapi-check"
                   ledger-functional-openapi-check);

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
@@ -585,6 +585,10 @@ intentSummaryJson args tx =
                             ]
                     , "resolved_input_buckets" .= map valueBucketJson inputValueBuckets
                     , "output_buckets" .= map valueBucketJson outputValueBuckets
+                    , "outputs"
+                        .= map
+                            (intentOutputJson signerHexSet)
+                            (zip [0 ..] outputs)
                     ]
             , "features"
                 .= Aeson.object
@@ -724,6 +728,32 @@ txOutBucketTotals signerHashes txOuts =
 txOutAddressHex :: L.TxOut Conway.ConwayEra -> T.Text
 txOutAddressHex txOut =
     T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
+
+{- | Per-output detail emitted under @intent.value.outputs[]@. Adds
+@index@ + @bucket@ to the existing 'txOutJson' shape so consumers can
+read individual output values and datums without re-running the
+inspector. Required to verify swap order parameters from the
+@intent@ envelope alone.
+-}
+intentOutputJson ::
+    Set.Set T.Text ->
+    (Int, L.TxOut Conway.ConwayEra) ->
+    Aeson.Value
+intentOutputJson signerHashes (i, txOut) =
+    case txOutJson txOut of
+        Aeson.Object fields ->
+            Aeson.Object
+                ( fields
+                    <> KeyMap.fromList
+                        [ ("index", Aeson.toJSON i)
+                        ,
+                            ( "bucket"
+                            , Aeson.String
+                                (valueBucketName (txOutValueBucket signerHashes txOut))
+                            )
+                        ]
+                )
+        other -> other
 
 allValueBuckets :: [ValueBucket]
 allValueBuckets =

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
@@ -19,6 +19,7 @@ module Conway.Inspector (
 ) where
 
 import qualified Cardano.Ledger.Address as Addr
+import qualified Cardano.Ledger.Alonzo.Scripts as AlonzoScripts
 import qualified Cardano.Ledger.Api as L
 import qualified Cardano.Ledger.BaseTypes as BaseTypes
 import qualified Cardano.Ledger.Coin as Coin
@@ -606,6 +607,7 @@ intentSummaryJson args tx =
                     , "has_collateral_return" .= hasStrictMaybe (body ^. L.collateralReturnTxBodyL)
                     , "has_total_collateral" .= hasStrictMaybe (body ^. L.totalCollateralTxBodyL)
                     ]
+            , "scripts" .= map (redeemerEntryJson inputs) redeemers
             , "effects" .= map intentEffect intentEffects
             , "context"
                 .= contextSummaryJson
@@ -728,6 +730,65 @@ txOutBucketTotals signerHashes txOuts =
 txOutAddressHex :: L.TxOut Conway.ConwayEra -> T.Text
 txOutAddressHex txOut =
     T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
+
+{- | One row per redeemer in @intent.scripts[]@. Captures purpose,
+target description, the redeemer's own CBOR (so consumers can decode
+order parameters etc.), and ex_units committed.
+
+Targets are described with as much detail as the @AsIx@ tag allows:
+spending purposes resolve through the canonical input ordering to
+emit the @TxIn@; minting purposes carry the policy id; cert / vote
+/ propose / reward purposes carry the index plus the type. Decoding
+the typed item from the index needs the producer-tx context for
+spending and the body for the others; this output gives the reader
+enough to find the target without re-running the inspector.
+-}
+redeemerEntryJson ::
+    [TxIn.TxIn] ->
+    (ConwayScripts.ConwayPlutusPurpose AlonzoScripts.AsIx Conway.ConwayEra, (PData.Data Conway.ConwayEra, ExUnits.ExUnits)) ->
+    Aeson.Value
+redeemerEntryJson canonicalInputs (purpose, (datum, exu)) =
+    Aeson.object
+        ( purposeFields
+            <> [ "redeemer_cbor_hex"
+                    .= T.decodeUtf8 (B16.encode (Hashes.originalBytes datum))
+               ,
+                   ( "ex_units_committed"
+                   , Aeson.object
+                        [ "memory" .= T.pack (show (ExUnits.exUnitsMem exu))
+                        , "steps" .= T.pack (show (ExUnits.exUnitsSteps exu))
+                        ]
+                   )
+               ]
+        )
+  where
+    purposeFields = case purpose of
+        ConwayScripts.ConwaySpending (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("spending" :: T.Text)
+            , "index" .= ix
+            , "input"
+                .= maybe Aeson.Null txInJson (listAt (fromIntegral ix) canonicalInputs)
+            ]
+        ConwayScripts.ConwayMinting (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("minting" :: T.Text)
+            , "index" .= ix
+            ]
+        ConwayScripts.ConwayCertifying (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("certifying" :: T.Text)
+            , "index" .= ix
+            ]
+        ConwayScripts.ConwayRewarding (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("rewarding" :: T.Text)
+            , "index" .= ix
+            ]
+        ConwayScripts.ConwayVoting (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("voting" :: T.Text)
+            , "index" .= ix
+            ]
+        ConwayScripts.ConwayProposing (AlonzoScripts.AsIx ix) ->
+            [ "purpose" .= ("proposing" :: T.Text)
+            , "index" .= ix
+            ]
 
 {- | Per-output detail emitted under @intent.value.outputs[]@. Adds
 @index@ + @bucket@ to the existing 'txOutJson' shape so consumers can

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
@@ -688,6 +688,11 @@ data ValueBucketTotals = ValueBucketTotals
     , vbtCount :: Int
     , vbtLovelace :: Integer
     , vbtAssetCount :: Int
+    , vbtAddresses :: [T.Text]
+    -- ^ Sorted, de-duplicated hex addresses contributing to this
+    -- bucket. Lets consumers verify metadata-declared destinations
+    -- ('Network Compliance treasury' etc.) against the actual output
+    -- addresses without re-running the inspector.
     }
 
 txOutBucketTotals ::
@@ -701,12 +706,24 @@ txOutBucketTotals signerHashes txOuts =
     bucketTotals bucket =
         let matching =
                 filter ((== bucket) . txOutValueBucket signerHashes) txOuts
+            addrs =
+                Set.toAscList
+                    ( Set.fromList
+                        [ txOutAddressHex out
+                        | out <- matching
+                        ]
+                    )
          in ValueBucketTotals
                 { vbtBucket = bucket
                 , vbtCount = length matching
                 , vbtLovelace = sum (txOutLovelace <$> matching)
                 , vbtAssetCount = sum (txOutAssetCount <$> matching)
+                , vbtAddresses = addrs
                 }
+
+txOutAddressHex :: L.TxOut Conway.ConwayEra -> T.Text
+txOutAddressHex txOut =
+    T.decodeUtf8 (B16.encode (Addr.serialiseAddr (txOut ^. L.addrTxOutL)))
 
 allValueBuckets :: [ValueBucket]
 allValueBuckets =
@@ -841,6 +858,7 @@ valueBucketJson totals =
         , "tx_out_count" .= vbtCount totals
         , "lovelace" .= T.pack (show (vbtLovelace totals))
         , "asset_class_count" .= vbtAssetCount totals
+        , "addresses" .= vbtAddresses totals
         ]
 
 valueBucketName :: ValueBucket -> T.Text

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
@@ -162,10 +162,11 @@ datumJson (PData.DatumHash h) =
         [ "kind" .= ("datum_hash" :: T.Text)
         , "hash" .= T.decodeUtf8 (B16.encode (Crypto.hashToBytes (Hashes.extractHash h)))
         ]
-datumJson (PData.Datum _) =
+datumJson (PData.Datum bd) =
     Aeson.object
         [ "kind" .= ("inline_datum" :: T.Text)
-        , "note" .= ("Plutus Data AST rendering deferred" :: T.Text)
+        , "cbor_hex" .= T.decodeUtf8 (B16.encode (Hashes.originalBytes bd))
+        , "note" .= ("Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes" :: T.Text)
         ]
 
 txInJson :: TxIn.TxIn -> Aeson.Value

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -55,6 +56,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Lens.Micro ((^.))
+import qualified PlutusLedgerApi.V1 as PV1
 
 data InspectError
     = MalformedHex String
@@ -166,8 +168,74 @@ datumJson (PData.Datum bd) =
     Aeson.object
         [ "kind" .= ("inline_datum" :: T.Text)
         , "cbor_hex" .= T.decodeUtf8 (B16.encode (Hashes.originalBytes bd))
-        , "note" .= ("Plutus Data AST decoding deferred; cbor_hex is the inline datum bytes" :: T.Text)
+        , "decoded" .= case PData.binaryDataToData bd of
+            d -> plutusDataJson (PData.getPlutusData d)
         ]
+
+{- | Render a Plutus Data AST node as structured JSON so consumers can
+read order parameters / certificate payloads / etc. without further
+tooling. Untyped: the JSON shape is the AST, not blueprint-driven
+record fields, because CIP-57 blueprints frequently leave datums as
+opaque @Data@.
+
+Mapping:
+
+* @Constr i fields@ → @{ \"kind\": \"constr\", \"index\": i, \"fields\": [...] }@
+* @Map kvs@         → @{ \"kind\": \"map\", \"entries\": [{ \"k\": ..., \"v\": ... }] }@
+* @List xs@         → @{ \"kind\": \"list\", \"items\": [...] }@
+* @I n@             → @{ \"kind\": \"int\", \"value\": \"<decimal-string>\" }@ (string-encoded
+                       to preserve precision for arbitrary-size ints)
+* @B bs@            → @{ \"kind\": \"bytes\", \"hex\": \"<hex>\", \"len\": N }@; when
+                       the byte string is plausibly UTF-8 readable, an
+                       additional @\"utf8\"@ field is included.
+-}
+plutusDataJson :: PV1.Data -> Aeson.Value
+plutusDataJson = \case
+    PV1.Constr i fields ->
+        Aeson.object
+            [ "kind" .= ("constr" :: T.Text)
+            , "index" .= i
+            , "fields" .= map plutusDataJson fields
+            ]
+    PV1.Map entries ->
+        Aeson.object
+            [ "kind" .= ("map" :: T.Text)
+            , "entries"
+                .= [ Aeson.object
+                    [ "k" .= plutusDataJson k
+                    , "v" .= plutusDataJson v
+                    ]
+                   | (k, v) <- entries
+                   ]
+            ]
+    PV1.List xs ->
+        Aeson.object
+            [ "kind" .= ("list" :: T.Text)
+            , "items" .= map plutusDataJson xs
+            ]
+    PV1.I n ->
+        Aeson.object
+            [ "kind" .= ("int" :: T.Text)
+            , "value" .= T.pack (show n)
+            ]
+    PV1.B bs ->
+        let hex = T.decodeUtf8 (B16.encode (PV1.fromBuiltin (PV1.toBuiltin bs)))
+            asUtf8 = case T.decodeUtf8' bs of
+                Right t
+                    | not (T.null t) && T.all isPrintable t -> Just t
+                _ -> Nothing
+            base =
+                [ "kind" .= ("bytes" :: T.Text)
+                , "hex" .= hex
+                , "len" .= BS.length bs
+                ]
+         in Aeson.object
+                ( base
+                    <> maybe [] (\u -> ["utf8" .= u]) asUtf8
+                )
+  where
+    isPrintable c =
+        c >= ' ' && c <= '~' || c == '\t' || c == '\n'
 
 txInJson :: TxIn.TxIn -> Aeson.Value
 txInJson (TxIn.TxIn (TxIn.TxId safeHash) (BaseTypes.TxIx ix)) =

--- a/nix/host/default.nix
+++ b/nix/host/default.nix
@@ -46,7 +46,13 @@ let
     if txDeepDiagnosisNative == null
       then null
       else txDeepDiagnosisNative.tx-deep-diagnosis;
+
+  tx-deep-diagnosis-render-snapshot =
+    if txDeepDiagnosisNative == null
+      then null
+      else txDeepDiagnosisNative.tx-deep-diagnosis-render-snapshot;
 in
 {
-  inherit libextism extism-spike-host tx-deep-diagnosis;
+  inherit libextism extism-spike-host
+    tx-deep-diagnosis tx-deep-diagnosis-render-snapshot;
 }

--- a/nix/host/tx-deep-diagnosis-native/default.nix
+++ b/nix/host/tx-deep-diagnosis-native/default.nix
@@ -20,4 +20,6 @@ in
   inherit project;
   tx-deep-diagnosis =
     project.hsPkgs.tx-deep-diagnosis.components.exes.tx-deep-diagnosis;
+  tx-deep-diagnosis-render-snapshot =
+    project.hsPkgs.tx-deep-diagnosis.components.exes.tx-deep-diagnosis-render-snapshot;
 }

--- a/specs/005-tx-explain-artifacts/plan.md
+++ b/specs/005-tx-explain-artifacts/plan.md
@@ -1,0 +1,162 @@
+# Implementation Plan: tx-deep-diagnosis Explain Artifacts
+
+**Branch**: `feat/issue-54-explain-artifacts`
+**Spec**: [spec.md](spec.md)
+**Issue**: #54
+
+## Decision: extend the host CLI, not the ledger op
+
+The renderers consume only the existing `tx-deep-diagnosis` envelope plus
+the `ProtocolRegistry`. Putting them in the host CLI keeps the ledger
+functional API surface untouched and avoids re-running the ledger to
+produce display-only artifacts. No new `tx.explain` op.
+
+## Module layout
+
+Add to `apps/tx-deep-diagnosis/src/`:
+
+- `TxDeepDiagnosisHost.Render.Names`
+  - `data PartyName = PartyName { pnLabel :: !Text, pnSource :: !PartySource }`
+  - `data PartySource = FromValidator | FromInstance | FromAmaruScope | TruncatedHex`
+  - `resolveScript :: ProtocolRegistry -> Text -> PartyName`
+    Looks up a script hash in `prValidators`, then `prInstances`, then
+    `prAmaru` scope owners. Falls back to `first8…last8` truncation.
+  - `resolveAddress :: ProtocolRegistry -> Text -> PartyName`
+    Same, given an address-hex; extracts the payment-script-hash byte
+    range and delegates to `resolveScript`. Key-only addresses get
+    truncated hex with `pnSource = TruncatedHex`.
+
+- `TxDeepDiagnosisHost.Render.Diagram`
+  - `data DiagramOptions = DiagramOptions { dShowReferenceInputs :: !Bool, dShowCollateral :: !Bool }`
+  - `defaultDiagramOptions :: DiagramOptions`
+  - `renderMermaid :: DiagramOptions -> ProtocolRegistry -> DiagnosisDoc -> Text`
+  - One `flowchart TD` document. Nodes are addressed by stable string
+    IDs derived from JSON paths (e.g. `inN`, `outN`, `refN`, `body`,
+    `signerN`). Validation failures are encoded as a `classDef failure`
+    applied to the affected node IDs.
+
+- `TxDeepDiagnosisHost.Render.Report`
+  - `renderMarkdown :: ProtocolRegistry -> DiagnosisDoc -> Text`
+  - Sections in fixed order so output is diffable.
+
+- `TxDeepDiagnosisHost.Render.Doc`
+  - `data DiagnosisDoc = DiagnosisDoc { ddSummary :: !Text, ddIntent :: !Value, ddValidate :: !Value }`
+  - `parseDiagnosisDoc :: Value -> Either String DiagnosisDoc`
+    Pulls the `tx-deep-diagnosis` object from the wrapped envelope.
+
+The four modules form a small subgraph under
+`TxDeepDiagnosisHost.Render.*`. Each exposes pure functions; nothing in
+this subgraph uses `IO`.
+
+Rename the existing `TxDeepDiagnosisHost.Report` to keep its meaning
+clear (it renders the JSON envelope, not the markdown). Two options:
+
+- (A) Leave `Report` alone (it renders the JSON envelope) and put the
+  markdown emitter in `Render.Report`. Slightly confusing but minimal
+  diff.
+- (B) Rename `Report` → `Envelope`. Cleaner names but a churn commit.
+
+Choose (A) for now; if the names get confusing during implementation,
+revisit in a follow-up rename commit.
+
+## CLI surface
+
+Add to `Options`:
+
+```haskell
+, optEmitMermaid :: !(Maybe FilePath)
+, optEmitReport  :: !(Maybe FilePath)
+```
+
+After the existing JSON envelope is written to stdout, if either option
+is set, parse the in-memory `Value` we already have, render, and write
+to the target path. No re-encoding round-trip.
+
+## Failure overlay mapping
+
+Match on `validate.result.validation.failures[].rule` + `kind`:
+
+| Source                                    | Diagram target            | Class       |
+|-------------------------------------------|---------------------------|-------------|
+| `UTXOW` / `ValueNotConservedUTxO`         | body                      | `bodyFail`  |
+| `UTXOW` / `MissingVKeyWitnessesUTXOW`     | one synthetic signer node | `signerFail`|
+| `UTXOW` / `BadInputsUTxO`                 | matching input            | `inputFail` |
+| `UTXOW` / `OutsideValidityIntervalUTxO`   | body                      | `bodyFail`  |
+| anything else under `UTXOW`               | body                      | `bodyFail`  |
+| any other rule                            | body                      | `bodyFail`  |
+
+Unmapped failures still reach the user via the report's failure table.
+
+## Snapshot tests
+
+Test suite under `apps/tx-deep-diagnosis/test/`:
+
+```
+apps/tx-deep-diagnosis/
+├── test/
+│   ├── Main.hs                  -- tasty entrypoint
+│   └── golden/
+│       ├── passing/             -- input.json, diagram.mmd, report.md
+│       ├── value-not-conserved/
+│       ├── missing-witness/
+│       └── multi-redeemer/
+└── tx-deep-diagnosis.cabal      -- adds test-suite stanza
+```
+
+Use `tasty` + a hand-rolled byte-equality assertion (no `tasty-golden`
+dependency to keep CHaP-pinned dep set tight). Each test loads
+`input.json`, runs the renderer, and compares to `diagram.mmd` /
+`report.md`. Mismatch prints the unified diff.
+
+For the parties registry, the tests load the bundled
+`docs/inspector/protocols` registry just like the binary does.
+
+## Nix check
+
+Add `tx-explain-render-smoke` to `flake.nix`:
+
+```nix
+tx-explain-render-smoke = pkgs.runCommand "tx-explain-render-smoke" { } ''
+  ${hostTargets.tx-deep-diagnosis-test}/bin/tx-deep-diagnosis-test
+  touch $out
+'';
+```
+
+Wired into `nix/host/tx-deep-diagnosis-native/default.nix` to expose the
+test executable, and into `apps/x86_64-linux` so `nix run
+.#tx-explain-render-smoke` works (CI pattern).
+
+CI workflow gets a new `tx-explain-render-smoke` job mirroring the
+existing `tx-intent-smoke` job.
+
+## Determinism
+
+- All `Map`/`Set` traversals over JSON: drive layout from
+  `Vector`/list order in the JSON, not from key-set hashing.
+- Lovelace and decimal numbers are reproduced from the JSON strings as-is
+  — never reparsed and reformatted.
+- No timestamps or random IDs in the output.
+
+## Out of scope (this PR)
+
+- Surge preview render integration (the artifacts can be added later to
+  the static site).
+- A graphviz / DOT alternative.
+- Cross-checking metadata claims against destinations.
+
+## Risks
+
+- Mermaid diagrams beyond ~30 nodes get hard to read in default
+  renderers. Mitigation: collapse output buckets into one node per
+  bucket label rather than per-output. The four fixtures cover the
+  expected sizes.
+- The `RegistryInstance` label is sometimes generic (`"SundaeSwap V3
+  Treasury"` for many distinct treasuries). Mitigation: append the last
+  6 hex of the hash to instance-derived labels so distinct instances
+  remain distinguishable.
+
+## Open follow-ups (separate tickets)
+
+- Wire the rendered artifacts into the docs build so the site shows the
+  diagram for the bundled fixture.
+- Add a small fixtures-bumping helper to make snapshot regeneration safe.

--- a/specs/005-tx-explain-artifacts/plan.md
+++ b/specs/005-tx-explain-artifacts/plan.md
@@ -11,70 +11,92 @@ the `ProtocolRegistry`. Putting them in the host CLI keeps the ledger
 functional API surface untouched and avoids re-running the ledger to
 produce display-only artifacts. No new `tx.explain` op.
 
+## Decision: cuts at different heights, not one mega-graph
+
+A single Mermaid diagram of every input/output/reference/collateral
+plus signers is unreadable beyond ~20 nodes and Mermaid's auto-layout
+breaks. The renderer emits a directory of cuts:
+
+- **L1 parties (`parties.mmd`)** — Mermaid `flowchart LR`, ~4–8 nodes
+- **L2 value flow (`value-flow.tsv`)** — Sankey TSV
+- **L3 topology (`topology.mmd`)** — Mermaid `flowchart TD`, full graph
+- **L4 failures (`failures.mmd`)** — Mermaid, only when invalid
+- **`summary.md`** — prose, links to the cuts above
+
 ## Module layout
 
 Add to `apps/tx-deep-diagnosis/src/`:
+
+- `TxDeepDiagnosisHost.Render.Doc`
+  - `data DiagnosisDoc = DiagnosisDoc { ddSummary :: !Text, ddIntent :: !Value, ddValidate :: !Value }`
+  - `parseDiagnosisDoc :: Value -> Either String DiagnosisDoc`
 
 - `TxDeepDiagnosisHost.Render.Names`
   - `data PartyName = PartyName { pnLabel :: !Text, pnSource :: !PartySource }`
   - `data PartySource = FromValidator | FromInstance | FromAmaruScope | TruncatedHex`
   - `resolveScript :: ProtocolRegistry -> Text -> PartyName`
-    Looks up a script hash in `prValidators`, then `prInstances`, then
-    `prAmaru` scope owners. Falls back to `first8…last8` truncation.
   - `resolveAddress :: ProtocolRegistry -> Text -> PartyName`
-    Same, given an address-hex; extracts the payment-script-hash byte
-    range and delegates to `resolveScript`. Key-only addresses get
-    truncated hex with `pnSource = TruncatedHex`.
 
-- `TxDeepDiagnosisHost.Render.Diagram`
-  - `data DiagramOptions = DiagramOptions { dShowReferenceInputs :: !Bool, dShowCollateral :: !Bool }`
-  - `defaultDiagramOptions :: DiagramOptions`
-  - `renderMermaid :: DiagramOptions -> ProtocolRegistry -> DiagnosisDoc -> Text`
-  - One `flowchart TD` document. Nodes are addressed by stable string
-    IDs derived from JSON paths (e.g. `inN`, `outN`, `refN`, `body`,
-    `signerN`). Validation failures are encoded as a `classDef failure`
-    applied to the affected node IDs.
+- `TxDeepDiagnosisHost.Render.Parties`
+  - `renderPartiesMermaid :: ProtocolRegistry -> DiagnosisDoc -> Text`
 
-- `TxDeepDiagnosisHost.Render.Report`
-  - `renderMarkdown :: ProtocolRegistry -> DiagnosisDoc -> Text`
-  - Sections in fixed order so output is diffable.
+- `TxDeepDiagnosisHost.Render.ValueFlow`
+  - `renderValueFlowTsv :: ProtocolRegistry -> DiagnosisDoc -> Text`
+    Header row `source\ttarget\tlovelace\tlabel`. Rows derived from
+    `intent.value.resolved_input_buckets[]` and
+    `intent.value.output_buckets[]`. When inputs are unresolved, only
+    the header is emitted (deterministic empty Sankey).
 
-- `TxDeepDiagnosisHost.Render.Doc`
-  - `data DiagnosisDoc = DiagnosisDoc { ddSummary :: !Text, ddIntent :: !Value, ddValidate :: !Value }`
-  - `parseDiagnosisDoc :: Value -> Either String DiagnosisDoc`
-    Pulls the `tx-deep-diagnosis` object from the wrapped envelope.
+- `TxDeepDiagnosisHost.Render.Topology`
+  - `renderTopologyMermaid :: ProtocolRegistry -> DiagnosisDoc -> Text`
+    Full per-node graph; failures applied as `classDef` overlays.
 
-The four modules form a small subgraph under
-`TxDeepDiagnosisHost.Render.*`. Each exposes pure functions; nothing in
-this subgraph uses `IO`.
+- `TxDeepDiagnosisHost.Render.Failures`
+  - `renderFailuresMermaid :: ProtocolRegistry -> DiagnosisDoc -> Maybe Text`
+    Returns `Nothing` when `validation.failures[]` is empty so the
+    caller knows not to write the file.
 
-Rename the existing `TxDeepDiagnosisHost.Report` to keep its meaning
-clear (it renders the JSON envelope, not the markdown). Two options:
+- `TxDeepDiagnosisHost.Render.Summary`
+  - `data EmittedFiles = EmittedFiles { efParties :: !FilePath, efValueFlow :: !FilePath, efTopology :: !FilePath, efFailures :: !(Maybe FilePath) }`
+  - `renderSummaryMarkdown :: ProtocolRegistry -> DiagnosisDoc -> EmittedFiles -> Text`
+    Sections: title, verdict paragraph, claims table, effects table,
+    signer perspective table, failures table, warnings, diagrams
+    footer. Links use the relative file names in `EmittedFiles`.
 
-- (A) Leave `Report` alone (it renders the JSON envelope) and put the
-  markdown emitter in `Render.Report`. Slightly confusing but minimal
-  diff.
-- (B) Rename `Report` → `Envelope`. Cleaner names but a churn commit.
+- `TxDeepDiagnosisHost.Render.Emit` (Main.hs glue, IO)
+  - `emitExplain :: FilePath -> ProtocolRegistry -> DiagnosisDoc -> IO ()`
+    Creates the directory, writes the four/five files, picks
+    `summary.md` last so its link list reflects what was actually
+    written.
 
-Choose (A) for now; if the names get confusing during implementation,
-revisit in a follow-up rename commit.
+The renderer subgraph under `TxDeepDiagnosisHost.Render.*` is pure —
+nothing in it imports `System.IO`. Only `Render.Emit` does IO.
 
 ## CLI surface
 
 Add to `Options`:
 
 ```haskell
-, optEmitMermaid :: !(Maybe FilePath)
-, optEmitReport  :: !(Maybe FilePath)
+, optEmitExplain :: !(Maybe FilePath)
 ```
 
-After the existing JSON envelope is written to stdout, if either option
-is set, parse the in-memory `Value` we already have, render, and write
-to the target path. No re-encoding round-trip.
+After the existing JSON envelope is written to stdout, if the option is
+set, parse the in-memory `Value` we already have, call `emitExplain`.
+
+Help text:
+
+```
+--emit-explain DIR
+    Write a directory of human-readable artifacts: summary.md,
+    parties.mmd, value-flow.tsv, topology.mmd, and failures.mmd
+    (when the tx is invalid). Existing files are overwritten.
+```
 
 ## Failure overlay mapping
 
-Match on `validate.result.validation.failures[].rule` + `kind`:
+Match on `validate.result.validation.failures[].rule` + the failure
+substring. Applies in `Render.Topology` (for L3 overlay) and in
+`Render.Failures` (for the standalone L4 cut):
 
 | Source                                    | Diagram target            | Class       |
 |-------------------------------------------|---------------------------|-------------|
@@ -85,8 +107,6 @@ Match on `validate.result.validation.failures[].rule` + `kind`:
 | anything else under `UTXOW`               | body                      | `bodyFail`  |
 | any other rule                            | body                      | `bodyFail`  |
 
-Unmapped failures still reach the user via the report's failure table.
-
 ## Snapshot tests
 
 Test suite under `apps/tx-deep-diagnosis/test/`:
@@ -96,38 +116,26 @@ apps/tx-deep-diagnosis/
 ├── test/
 │   ├── Main.hs                  -- tasty entrypoint
 │   └── golden/
-│       ├── passing/             -- input.json, diagram.mmd, report.md
-│       ├── value-not-conserved/
+│       ├── passing/             -- input.json + expected/{summary.md, parties.mmd, value-flow.tsv, topology.mmd}
+│       ├── value-not-conserved/ -- ... + expected/failures.mmd
 │       ├── missing-witness/
 │       └── multi-redeemer/
 └── tx-deep-diagnosis.cabal      -- adds test-suite stanza
 ```
 
-Use `tasty` + a hand-rolled byte-equality assertion (no `tasty-golden`
-dependency to keep CHaP-pinned dep set tight). Each test loads
-`input.json`, runs the renderer, and compares to `diagram.mmd` /
-`report.md`. Mismatch prints the unified diff.
+Use `tasty` + a hand-rolled byte-equality assertion. Each test loads
+`input.json`, runs the renderers, and compares each file to its
+counterpart under `expected/`. Mismatch prints a unified diff.
 
 For the parties registry, the tests load the bundled
-`docs/inspector/protocols` registry just like the binary does.
+`docs/inspector/protocols` registry just like the binary does, via
+`Paths_tx_deep_diagnosis.getDataDir`.
 
 ## Nix check
 
-Add `tx-explain-render-smoke` to `flake.nix`:
-
-```nix
-tx-explain-render-smoke = pkgs.runCommand "tx-explain-render-smoke" { } ''
-  ${hostTargets.tx-deep-diagnosis-test}/bin/tx-deep-diagnosis-test
-  touch $out
-'';
-```
-
-Wired into `nix/host/tx-deep-diagnosis-native/default.nix` to expose the
-test executable, and into `apps/x86_64-linux` so `nix run
-.#tx-explain-render-smoke` works (CI pattern).
-
-CI workflow gets a new `tx-explain-render-smoke` job mirroring the
-existing `tx-intent-smoke` job.
+Add `tx-explain-render-smoke` to `flake.nix`, run the test executable,
+expose an app wrapper, wire to CI Build Gate + a per-job step mirroring
+`tx-intent-smoke`.
 
 ## Determinism
 
@@ -136,27 +144,29 @@ existing `tx-intent-smoke` job.
 - Lovelace and decimal numbers are reproduced from the JSON strings as-is
   — never reparsed and reformatted.
 - No timestamps or random IDs in the output.
+- File write order: parties → value-flow → topology → failures →
+  summary. Summary is last so its link list reflects which files
+  exist.
 
 ## Out of scope (this PR)
 
 - Surge preview render integration (the artifacts can be added later to
   the static site).
-- A graphviz / DOT alternative.
+- D2 / Graphviz alternative backends.
 - Cross-checking metadata claims against destinations.
 
 ## Risks
 
-- Mermaid diagrams beyond ~30 nodes get hard to read in default
-  renderers. Mitigation: collapse output buckets into one node per
-  bucket label rather than per-output. The four fixtures cover the
-  expected sizes.
-- The `RegistryInstance` label is sometimes generic (`"SundaeSwap V3
-  Treasury"` for many distinct treasuries). Mitigation: append the last
-  6 hex of the hash to instance-derived labels so distinct instances
-  remain distinguishable.
+- Mermaid diagrams beyond ~30 nodes get hard to read. Mitigated by the
+  cut design — only `topology.mmd` approaches that size.
+- Generic instance labels (`"SundaeSwap V3 Treasury"` for many distinct
+  treasuries). Mitigation: append the last 6 hex of the hash to
+  instance-derived labels so distinct instances remain
+  distinguishable.
 
 ## Open follow-ups (separate tickets)
 
+- D2 backend swap if any cut looks bad on a real fixture.
 - Wire the rendered artifacts into the docs build so the site shows the
-  diagram for the bundled fixture.
-- Add a small fixtures-bumping helper to make snapshot regeneration safe.
+  diagrams for the bundled fixture.
+- A small fixtures-bumping helper to make snapshot regeneration safe.

--- a/specs/005-tx-explain-artifacts/spec.md
+++ b/specs/005-tx-explain-artifacts/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: tx-deep-diagnosis Explain Artifacts
+
+**Feature Branch**: `feat/issue-54-explain-artifacts`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: GitHub issue #54: "tx-deep-diagnosis: render diagram + narrative artifacts from result JSON"
+
+## Context
+
+`tx-deep-diagnosis` already emits a single JSON document combining `intent`,
+`validate`, and a `summary` line. The intent block is rich enough to drive
+human-facing artifacts: it carries pre-rendered `effects`, `metrics`, and
+`sections` rows, an explicit `failures[]` list on the validate block, and
+labelled output buckets (`external_key` vs `script`).
+
+A CLI consumer today still has to read raw JSON to reason about a transaction.
+The shape is stable enough to render two deterministic artifacts directly:
+
+- a **Mermaid diagram** of inputs → body → outputs with reference and
+  collateral side rails and a failure overlay
+- a **Markdown report** built from the same JSON: title, claims, effects
+  table, signer table, validation verdict, failures, warnings
+
+Naming parties (script / address hashes → human labels) is a registry lookup,
+not a reasoning task. The protocol registry (`docs/inspector/protocols/...`)
+already maps validator and instance hashes to labels and is loaded today by
+`TxDeepDiagnosisHost.Registry.loadRegistries`.
+
+## User Scenarios & Testing
+
+### User Story 1 — Read a transaction at a glance (Priority: P1)
+
+A signer or auditor runs `tx-deep-diagnosis --cbor tx.cbor --emit-mermaid
+diagram.mmd --emit-report report.md` and gets two artifacts that, together,
+explain the transaction without opening the JSON.
+
+**Why this priority**: this is the user-visible value of the ticket.
+
+**Independent Test**: run on the committed SundaeSwap/USDM mainnet fixture;
+the report shows the swap claim, the value-not-conserved failure, the missing
+required signers; the Mermaid diagram renders inputs, twelve outputs split
+into key vs script buckets, four reference inputs, one collateral, and a
+red-tagged body for the value-not-conservation failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** a passing tx, **When** the artifacts are rendered, **Then** the
+   diagram has no red overlays and the report's verdict line is `valid`.
+2. **Given** a tx with a `ValueNotConservedUTxO` failure, **When** the
+   artifacts are rendered, **Then** the body node carries a red badge
+   labelled with the conserved-value mismatch summary.
+3. **Given** a tx missing vkey witnesses, **When** the artifacts are
+   rendered, **Then** each missing-signer hash appears as a red badge
+   (resolved to a human label if known in the registry).
+
+### User Story 2 — Determinism and offline use (Priority: P1)
+
+The same JSON input always produces byte-identical artifacts, so they are
+checked into snapshot tests and used as documentation fixtures.
+
+**Why this priority**: deterministic golden output is what makes these
+artifacts safe to diff and review.
+
+**Independent Test**: render twice in two processes and compare bytes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fixture JSON, **When** the renderers are invoked, **Then** the
+   output bytes match the committed snapshot.
+2. **Given** the same fixture, **When** the renderers are invoked from a
+   different working directory, **Then** the output is unchanged.
+
+### User Story 3 — Names from the registry, not from a guess (Priority: P2)
+
+When a script hash matches a `RegistryValidator` or `RegistryInstance`, its
+label is used in both the diagram and the report. Unknown hashes are
+displayed in truncated hex with no fabricated label.
+
+**Why this priority**: a wrong attribution on a `disburse` claim is worse than
+`unknown`. This rule keeps the renderers honest.
+
+**Independent Test**: render the SundaeSwap fixture; the script-bucket node
+in the diagram is labelled `SundaeSwap V3 Treasury` (or whatever the
+registry says), not `38c627d4…`. Render a tx whose script hashes are not in
+the registry; the node label is `script (38c627d4…)`.
+
+## Functional Requirements
+
+- **FR-001**: `tx-deep-diagnosis` accepts two new CLI options:
+  `--emit-mermaid <PATH>` and `--emit-report <PATH>`. Either or both may be
+  given. When neither is given, behaviour is unchanged.
+- **FR-002**: With `--emit-mermaid`, a Mermaid `flowchart TD` document is
+  written to `<PATH>` after the JSON envelope is emitted on stdout.
+- **FR-003**: With `--emit-report`, a Markdown document is written to
+  `<PATH>` after the JSON envelope is emitted on stdout.
+- **FR-004**: Both renderers consume only the `tx-deep-diagnosis` JSON
+  envelope (`intent`, `validate`, `summary`) and the loaded
+  `ProtocolRegistry`. They do not call the inspector library or the network.
+- **FR-005**: The Mermaid diagram includes nodes for: every resolved input,
+  every output bucket from `intent.value.output_buckets[]`, every reference
+  input, the collateral input/return when present, and the tx body.
+- **FR-006**: Annotations on the body node: fee, redeemer count, withdrawal
+  count, mint/burn status, metadata label (when a single label is dominant),
+  collateral.
+- **FR-007**: Validation failures are overlaid on the diagram by attaching a
+  red-styled badge (Mermaid `classDef`) to the affected node. Mapping:
+  `ValueNotConservedUTxO` → body; `MissingVKeyWitnessesUTXOW` → a synthetic
+  signer node per missing hash; other ledger failures → body with their
+  rule name.
+- **FR-008**: The Markdown report contains, in order: title (intent.title
+  / subtitle), one-paragraph summary derived from `summary` + verdict,
+  metadata claims table, effects table (from `intent.sections[]` rows),
+  signer perspective table, validation verdict + failures table, warnings
+  list.
+- **FR-009**: Hash → label resolution uses the existing
+  `TxDeepDiagnosisHost.Registry.identifyByHash` and treasury scope helpers.
+  Unknown hashes are displayed in truncated form (`first8…last8`) with no
+  fabricated label.
+- **FR-010**: The renderer modules are pure (`Text`-in, `Text`-out). No `IO`.
+
+## Edge Cases
+
+- No producer-tx context resolved (probe-only mode): the diagram still
+  renders inputs as unresolved placeholders; the report's signer perspective
+  shows `unknown net spend` with the existing `net_spend_note` reproduced.
+- Multiple ledger failures: each failure is overlaid; the report lists them
+  in the order returned by the validator.
+- A tx with no script outputs: the script bucket is omitted from the diagram.
+- A tx with no reference inputs / no collateral: the corresponding side
+  rails are omitted.
+- Metadata with no `1694` (or any) label: the metadata-label annotation is
+  omitted but the claim block in the report still renders raw values.
+- Output bucket lovelace totals expressed as decimal strings: rendered as ADA
+  with the existing `intent` formatting (no recomputation).
+
+## Out of Scope
+
+- Cross-checking metadata claims against actual destinations.
+- Free-form prose narrative generation.
+- Resolving stake-pool tickers, ADA Handles, or CIP-26 metadata oracle
+  entries (deferrable; the registry covers the immediate need).
+- A new `tx.explain` ledger op. The renderers live in the host CLI, not the
+  inspector library, so the ledger functional API surface is unchanged.
+
+## Acceptance
+
+- `tx-deep-diagnosis --cbor <hex> --emit-mermaid d.mmd --emit-report r.md`
+  exits 0 and produces both files for the four snapshot fixtures.
+- Snapshot tests cover: passing tx; `ValueNotConservedUTxO` failure;
+  missing-witness failure; multi-redeemer script tx.
+- Running the renderers twice produces byte-identical output.
+- `just ci` is green.

--- a/specs/005-tx-explain-artifacts/spec.md
+++ b/specs/005-tx-explain-artifacts/spec.md
@@ -13,45 +13,50 @@ human-facing artifacts: it carries pre-rendered `effects`, `metrics`, and
 `sections` rows, an explicit `failures[]` list on the validate block, and
 labelled output buckets (`external_key` vs `script`).
 
-A CLI consumer today still has to read raw JSON to reason about a transaction.
-The shape is stable enough to render two deterministic artifacts directly:
+A single mega-graph of every input, output, reference input, collateral,
+signer, and failure does not survive a typical Conway transaction (≥20
+nodes; Mermaid's auto-layout is unstable past ~20 nodes). Pedagogically a
+signer also wants different views at different moments: who is moving
+what, where the money goes, the full topology, what is wrong.
 
-- a **Mermaid diagram** of inputs → body → outputs with reference and
-  collateral side rails and a failure overlay
-- a **Markdown report** built from the same JSON: title, claims, effects
-  table, signer table, validation verdict, failures, warnings
+The output of the renderer is therefore **a directory of cuts at
+different heights**, plus a top-level `summary.md` that tells the story
+in prose with links to the cuts.
 
-Naming parties (script / address hashes → human labels) is a registry lookup,
-not a reasoning task. The protocol registry (`docs/inspector/protocols/...`)
-already maps validator and instance hashes to labels and is loaded today by
+Naming parties (script / address hashes → human labels) is a registry
+lookup, not a reasoning task. The protocol registry
+(`docs/inspector/protocols/...`) already maps validator and instance
+hashes to labels and is loaded today by
 `TxDeepDiagnosisHost.Registry.loadRegistries`.
 
 ## User Scenarios & Testing
 
 ### User Story 1 — Read a transaction at a glance (Priority: P1)
 
-A signer or auditor runs `tx-deep-diagnosis --cbor tx.cbor --emit-mermaid
-diagram.mmd --emit-report report.md` and gets two artifacts that, together,
-explain the transaction without opening the JSON.
+A signer or auditor runs `tx-deep-diagnosis --cbor tx.cbor --emit-explain
+out/` and gets a directory of artifacts that, together, explain the
+transaction without opening the JSON.
 
 **Why this priority**: this is the user-visible value of the ticket.
 
-**Independent Test**: run on the committed SundaeSwap/USDM mainnet fixture;
-the report shows the swap claim, the value-not-conserved failure, the missing
-required signers; the Mermaid diagram renders inputs, twelve outputs split
-into key vs script buckets, four reference inputs, one collateral, and a
-red-tagged body for the value-not-conservation failure.
+**Independent Test**: run on the committed SundaeSwap/USDM mainnet
+fixture; `out/summary.md` opens with the swap claim, the
+value-not-conserved failure, and the missing required signers; the
+embedded links resolve to `parties.mmd`, `value-flow.tsv`,
+`topology.mmd`, and `failures.mmd`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a passing tx, **When** the artifacts are rendered, **Then** the
-   diagram has no red overlays and the report's verdict line is `valid`.
+1. **Given** a passing tx, **When** the artifacts are rendered, **Then**
+   `failures.mmd` is omitted and `summary.md` ends with `verdict: valid`.
 2. **Given** a tx with a `ValueNotConservedUTxO` failure, **When** the
-   artifacts are rendered, **Then** the body node carries a red badge
-   labelled with the conserved-value mismatch summary.
+   artifacts are rendered, **Then** `failures.mmd` shows the body node
+   in the `bodyFail` class and `summary.md` quotes the conserved-value
+   mismatch from the validator message.
 3. **Given** a tx missing vkey witnesses, **When** the artifacts are
-   rendered, **Then** each missing-signer hash appears as a red badge
-   (resolved to a human label if known in the registry).
+   rendered, **Then** each missing-signer hash appears as a red
+   synthetic-signer node in `failures.mmd`, resolved to a human label
+   if known in the registry.
 
 ### User Story 2 — Determinism and offline use (Priority: P1)
 
@@ -65,88 +70,133 @@ artifacts safe to diff and review.
 
 **Acceptance Scenarios**:
 
-1. **Given** a fixture JSON, **When** the renderers are invoked, **Then** the
-   output bytes match the committed snapshot.
+1. **Given** a fixture JSON, **When** the renderers are invoked, **Then**
+   each emitted file matches the committed snapshot byte-for-byte.
 2. **Given** the same fixture, **When** the renderers are invoked from a
    different working directory, **Then** the output is unchanged.
 
 ### User Story 3 — Names from the registry, not from a guess (Priority: P2)
 
-When a script hash matches a `RegistryValidator` or `RegistryInstance`, its
-label is used in both the diagram and the report. Unknown hashes are
-displayed in truncated hex with no fabricated label.
+When a script hash matches a `RegistryValidator` or `RegistryInstance`,
+its label is used in every cut and in the prose summary. Unknown hashes
+are displayed in truncated hex (`first8…last8`) with no fabricated label.
 
-**Why this priority**: a wrong attribution on a `disburse` claim is worse than
-`unknown`. This rule keeps the renderers honest.
+**Why this priority**: a wrong attribution on a `disburse` claim is worse
+than `unknown`. This rule keeps the renderers honest.
 
-**Independent Test**: render the SundaeSwap fixture; the script-bucket node
-in the diagram is labelled `SundaeSwap V3 Treasury` (or whatever the
-registry says), not `38c627d4…`. Render a tx whose script hashes are not in
-the registry; the node label is `script (38c627d4…)`.
+**Independent Test**: render the SundaeSwap fixture; the script-bucket
+node is labelled from the registry, not from raw hex. Render a tx whose
+script hashes are not in the registry; the node label is `script
+(38c627d4…)`.
 
 ## Functional Requirements
 
-- **FR-001**: `tx-deep-diagnosis` accepts two new CLI options:
-  `--emit-mermaid <PATH>` and `--emit-report <PATH>`. Either or both may be
-  given. When neither is given, behaviour is unchanged.
-- **FR-002**: With `--emit-mermaid`, a Mermaid `flowchart TD` document is
-  written to `<PATH>` after the JSON envelope is emitted on stdout.
-- **FR-003**: With `--emit-report`, a Markdown document is written to
-  `<PATH>` after the JSON envelope is emitted on stdout.
-- **FR-004**: Both renderers consume only the `tx-deep-diagnosis` JSON
+- **FR-001**: `tx-deep-diagnosis` accepts a new CLI option
+  `--emit-explain <DIR>`. When absent, behaviour is unchanged. When
+  present, the directory is created (mkdir -p) and the artifacts below
+  are written to it after the JSON envelope is emitted on stdout.
+
+- **FR-002**: The emitted directory contains the following files:
+  - `summary.md` — top-level prose summary, always present
+  - `parties.mmd` — Mermaid `flowchart LR`, parties cut (L1)
+  - `value-flow.tsv` — Sankey-shaped TSV of lovelace flows (L2)
+  - `topology.mmd` — Mermaid `flowchart TD`, full topology cut (L3)
+  - `failures.mmd` — Mermaid `flowchart TD` of failures only, written
+    only when `validation.failures[]` is non-empty (L4)
+
+- **FR-003**: `summary.md` is the human-readable deep summary. Sections
+  in this order: title (intent.title), one-paragraph verdict
+  (parses `summary` line + `valid_for_supplied_context`), claims table,
+  effects table from `intent.sections[]`, signer perspective table,
+  validation failures table, warnings, and a "diagrams" footer with
+  relative links to `parties.mmd`, `value-flow.tsv`, `topology.mmd`, and
+  `failures.mmd` (links are emitted only for files that were written).
+
+- **FR-004**: All renderers consume only the `tx-deep-diagnosis` JSON
   envelope (`intent`, `validate`, `summary`) and the loaded
-  `ProtocolRegistry`. They do not call the inspector library or the network.
-- **FR-005**: The Mermaid diagram includes nodes for: every resolved input,
-  every output bucket from `intent.value.output_buckets[]`, every reference
-  input, the collateral input/return when present, and the tx body.
-- **FR-006**: Annotations on the body node: fee, redeemer count, withdrawal
-  count, mint/burn status, metadata label (when a single label is dominant),
-  collateral.
-- **FR-007**: Validation failures are overlaid on the diagram by attaching a
-  red-styled badge (Mermaid `classDef`) to the affected node. Mapping:
-  `ValueNotConservedUTxO` → body; `MissingVKeyWitnessesUTXOW` → a synthetic
-  signer node per missing hash; other ledger failures → body with their
-  rule name.
-- **FR-008**: The Markdown report contains, in order: title (intent.title
-  / subtitle), one-paragraph summary derived from `summary` + verdict,
-  metadata claims table, effects table (from `intent.sections[]` rows),
-  signer perspective table, validation verdict + failures table, warnings
-  list.
-- **FR-009**: Hash → label resolution uses the existing
-  `TxDeepDiagnosisHost.Registry.identifyByHash` and treasury scope helpers.
-  Unknown hashes are displayed in truncated form (`first8…last8`) with no
+  `ProtocolRegistry`. They do not call the inspector library or the
+  network.
+
+- **FR-005**: Cut definitions:
+
+  - **Parties (L1)** — one Mermaid node per distinct party, where a
+    party is a signer hash, an address payment-credential, or a script
+    hash from `intent.value.output_buckets[].bucket`. Edges represent
+    the consume / produce / withdraw / collateral relations. Node
+    budget: ~4–8 in expected fixtures.
+
+  - **Value flow (L2)** — TSV with columns `source<TAB>target<TAB>lovelace<TAB>label`. Sources are
+    resolved-input nodes; targets are output-bucket nodes. The TSV is a
+    standard Sankey input that any d3-sankey or pivot tool consumes;
+    it is not rendered as Mermaid (Mermaid `sankey-beta` is unstable
+    and we want byte-stable snapshots).
+
+  - **Topology (L3)** — every resolved input, every output (one node
+    per output, not per bucket), every reference input, the collateral
+    input/return when present, the body, and one synthetic signer node
+    per declared required signer. Node budget: ~20–30 in expected
+    fixtures.
+
+  - **Failures (L4)** — only emitted when `validation.failures[]` is
+    non-empty. Each failure becomes one or more red nodes mapped per
+    plan.md.
+
+- **FR-006**: Annotations on the body node in topology: fee, redeemer
+  count, withdrawal count, mint/burn status, metadata label (when a
+  single label is dominant), collateral indicator.
+
+- **FR-007**: Validation failures are styled with Mermaid `classDef`
+  classes named `bodyFail`, `signerFail`, `inputFail`. The mapping is
+  defined in `plan.md`.
+
+- **FR-008**: Hash → label resolution uses the existing
+  `TxDeepDiagnosisHost.Registry.identifyByHash` and treasury scope
+  helpers. Unknown hashes are truncated `first8…last8` with no
   fabricated label.
-- **FR-010**: The renderer modules are pure (`Text`-in, `Text`-out). No `IO`.
+
+- **FR-009**: The renderer modules are pure (`Text`-in, `Text`-out). No
+  `IO` inside the renderers; the `Main` writes the resulting strings to
+  disk.
 
 ## Edge Cases
 
-- No producer-tx context resolved (probe-only mode): the diagram still
-  renders inputs as unresolved placeholders; the report's signer perspective
-  shows `unknown net spend` with the existing `net_spend_note` reproduced.
-- Multiple ledger failures: each failure is overlaid; the report lists them
-  in the order returned by the validator.
-- A tx with no script outputs: the script bucket is omitted from the diagram.
-- A tx with no reference inputs / no collateral: the corresponding side
-  rails are omitted.
-- Metadata with no `1694` (or any) label: the metadata-label annotation is
-  omitted but the claim block in the report still renders raw values.
-- Output bucket lovelace totals expressed as decimal strings: rendered as ADA
-  with the existing `intent` formatting (no recomputation).
+- No producer-tx context resolved (probe-only mode): `summary.md`
+  reproduces `value.net_spend_note`; `topology.mmd` shows inputs as
+  unresolved placeholders; `value-flow.tsv` is emitted with empty rows
+  plus a header so downstream tools do not crash.
+- Multiple ledger failures: each failure overlays a node in
+  `failures.mmd`; `summary.md` lists them in the validator's order.
+- A tx with no script outputs: the parties cut omits the script node;
+  the topology cut still renders the body and signers.
+- A tx with no reference inputs / no collateral: the corresponding
+  side rails are omitted from topology.
+- Metadata with no `1694` (or any) label: the metadata-label
+  annotation is omitted but the claim block in `summary.md` still
+  renders raw values.
+- Lovelace and decimal numbers are reproduced from the JSON strings
+  as-is — never reparsed and reformatted.
 
 ## Out of Scope
 
 - Cross-checking metadata claims against actual destinations.
-- Free-form prose narrative generation.
+- Free-form prose narrative beyond the structured `summary.md` template.
 - Resolving stake-pool tickers, ADA Handles, or CIP-26 metadata oracle
-  entries (deferrable; the registry covers the immediate need).
-- A new `tx.explain` ledger op. The renderers live in the host CLI, not the
-  inspector library, so the ledger functional API surface is unchanged.
+  entries.
+- A new `tx.explain` ledger op. The renderers live in the host CLI, not
+  the inspector library, so the ledger functional API surface is
+  unchanged.
+- D2 / Graphviz alternative backends. If Mermaid layout proves
+  insufficient for the topology cut on a fixture, a D2 swap is a
+  follow-up PR, not part of this scope.
 
 ## Acceptance
 
-- `tx-deep-diagnosis --cbor <hex> --emit-mermaid d.mmd --emit-report r.md`
-  exits 0 and produces both files for the four snapshot fixtures.
+- `tx-deep-diagnosis --cbor <hex> --emit-explain out/` exits 0 and
+  produces `summary.md`, `parties.mmd`, `value-flow.tsv`, `topology.mmd`
+  for the four snapshot fixtures, plus `failures.mmd` for the three
+  invalid ones.
 - Snapshot tests cover: passing tx; `ValueNotConservedUTxO` failure;
   missing-witness failure; multi-redeemer script tx.
-- Running the renderers twice produces byte-identical output.
+- Running the renderers twice produces byte-identical output for every
+  emitted file.
 - `just ci` is green.

--- a/specs/005-tx-explain-artifacts/tasks.md
+++ b/specs/005-tx-explain-artifacts/tasks.md
@@ -1,0 +1,114 @@
+# Tasks: tx-deep-diagnosis Explain Artifacts
+
+Each task is one bisect-safe commit. Order matters — every commit
+compiles and passes tests with no `sorry`-equivalent.
+
+## T1 — `Render.Doc`: parse the envelope
+
+- Add `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Doc.hs`
+  with `DiagnosisDoc` and `parseDiagnosisDoc`. Expose nothing else yet.
+- Wire the new module into `tx-deep-diagnosis.cabal`.
+- No callers; the build proves the module compiles.
+
+**Acceptance**: `nix build .#tx-deep-diagnosis` succeeds.
+
+## T2 — `Render.Names`: hash → label
+
+- Add `Render/Names.hs` with `PartyName`, `PartySource`,
+  `resolveScript`, `resolveAddress`.
+- Pure functions. Reuse `TxDeepDiagnosisHost.Registry.identifyByHash`
+  and `findScopeByOwner` (no new IO).
+- Unit tests: a tiny `test/Spec/Names.hs` covers
+  hit-via-validator, hit-via-instance, hit-via-amaru-scope, miss with
+  truncation. Tests run inside the existing project, no new test
+  dependencies — use the `tasty` entrypoint introduced in T5.
+
+**Acceptance**: name resolution covered by tests; build is green.
+
+## T3 — `Render.Report`: markdown report
+
+- Add `Render/Report.hs` with `renderMarkdown`.
+- Render: title, subtitle, claims table, effects table, signer
+  perspective table, validation verdict + failures table, warnings.
+- Drive layout from `intent.sections[]` rows where present so wording
+  stays in sync with the inspector library.
+
+**Acceptance**: snapshot test (T6) passes for the passing-tx fixture.
+
+## T4 — `Render.Diagram`: mermaid diagram
+
+- Add `Render/Diagram.hs` with `DiagramOptions`, `defaultDiagramOptions`,
+  `renderMermaid`.
+- Emit a `flowchart TD` document. Include classDef styles for
+  `bodyFail`, `signerFail`, `inputFail`. Apply via the failure mapping
+  in `plan.md`.
+
+**Acceptance**: snapshot tests (T6) pass for all four fixtures.
+
+## T5 — `tasty` test suite skeleton
+
+- Add `apps/tx-deep-diagnosis/test/Main.hs` (tasty entrypoint).
+- Add `test-suite tx-deep-diagnosis-test` stanza to the cabal file.
+- Wire into nix via `nix/host/tx-deep-diagnosis-native/default.nix`.
+- Test suite is initially empty (one trivial passing test) so the
+  scaffold lands separately from the snapshot fixtures.
+
+**Acceptance**: `nix build .#packages.x86_64-linux.tx-deep-diagnosis-test`
+succeeds and the test runs.
+
+## T6 — Snapshot fixtures + golden tests
+
+- Commit four fixture envelopes under `apps/tx-deep-diagnosis/test/golden/`:
+  - `passing/input.json` — a minimal passing tx (synthesised; no
+    network calls). Output expectations: empty failures, no overlays.
+  - `value-not-conserved/input.json` — derived from the user's
+    `result.json` (the SundaeSwap/USDM mainnet tx).
+  - `missing-witness/input.json` — derived from the same tx (single
+    fixture covers both via the failures it carries).
+  - `multi-redeemer/input.json` — same tx; the report exercises the
+    multi-redeemer rendering.
+- For each, commit `diagram.mmd` and `report.md` snapshots.
+- Test suite reads `input.json`, runs renderers, asserts byte equality
+  against `diagram.mmd` / `report.md`. On mismatch, print a unified diff.
+
+**Acceptance**: `nix run .#tx-explain-render-smoke` is green.
+
+## T7 — CLI flags
+
+- Add `--emit-mermaid` and `--emit-report` to `Options`.
+- After the JSON envelope is printed to stdout, if either flag is set,
+  parse the in-memory envelope and write the artifact to disk.
+- Help text quotes the spec's behaviour.
+
+**Acceptance**: integration test in `Main.hs` (or a separate smoke)
+runs the binary with both flags and inspects the produced files exist
+and match the snapshots.
+
+## T8 — Nix check `tx-explain-render-smoke`
+
+- Add `tx-explain-render-smoke = pkgs.runCommand …` to `flake.nix`.
+- Expose as `apps/x86_64-linux/tx-explain-render-smoke` (mkApp).
+- Add to the `Build Gate` job and create a per-job CI step mirroring
+  `tx-intent-smoke`.
+
+**Acceptance**: `nix run .#tx-explain-render-smoke` exits 0 locally;
+green CI.
+
+## T9 — Update issue + PR
+
+- Update PR body with: motivation (link #54), what changed, file tour
+  per module, snapshot strategy, follow-ups.
+- Add `enhancement` label, assign to `paolino`.
+
+## Bisect plan
+
+After each commit:
+
+```sh
+nix build .#packages.x86_64-linux.tx-deep-diagnosis    # T1, T2, T3, T4, T7
+nix build .#packages.x86_64-linux.tx-deep-diagnosis-test  # T5
+nix run .#tx-explain-render-smoke                       # T6, T8
+```
+
+If a commit fails to build, fix it via `stg goto N && stg refresh` —
+never append a fixup commit.

--- a/specs/005-tx-explain-artifacts/tasks.md
+++ b/specs/005-tx-explain-artifacts/tasks.md
@@ -6,9 +6,8 @@ compiles and passes tests with no `sorry`-equivalent.
 ## T1 — `Render.Doc`: parse the envelope
 
 - Add `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Doc.hs`
-  with `DiagnosisDoc` and `parseDiagnosisDoc`. Expose nothing else yet.
+  with `DiagnosisDoc` and `parseDiagnosisDoc`.
 - Wire the new module into `tx-deep-diagnosis.cabal`.
-- No callers; the build proves the module compiles.
 
 **Acceptance**: `nix build .#tx-deep-diagnosis` succeeds.
 
@@ -16,98 +15,87 @@ compiles and passes tests with no `sorry`-equivalent.
 
 - Add `Render/Names.hs` with `PartyName`, `PartySource`,
   `resolveScript`, `resolveAddress`.
-- Pure functions. Reuse `TxDeepDiagnosisHost.Registry.identifyByHash`
-  and `findScopeByOwner` (no new IO).
-- Unit tests: a tiny `test/Spec/Names.hs` covers
-  hit-via-validator, hit-via-instance, hit-via-amaru-scope, miss with
-  truncation. Tests run inside the existing project, no new test
-  dependencies — use the `tasty` entrypoint introduced in T5.
+- Pure functions reusing `Registry.identifyByHash` and
+  `findScopeByOwner`.
 
-**Acceptance**: name resolution covered by tests; build is green.
+**Acceptance**: build green; tests added in T5.
 
-## T3 — `Render.Report`: markdown report
+## T3 — `tasty` test suite skeleton
 
-- Add `Render/Report.hs` with `renderMarkdown`.
-- Render: title, subtitle, claims table, effects table, signer
-  perspective table, validation verdict + failures table, warnings.
-- Drive layout from `intent.sections[]` rows where present so wording
-  stays in sync with the inspector library.
-
-**Acceptance**: snapshot test (T6) passes for the passing-tx fixture.
-
-## T4 — `Render.Diagram`: mermaid diagram
-
-- Add `Render/Diagram.hs` with `DiagramOptions`, `defaultDiagramOptions`,
-  `renderMermaid`.
-- Emit a `flowchart TD` document. Include classDef styles for
-  `bodyFail`, `signerFail`, `inputFail`. Apply via the failure mapping
-  in `plan.md`.
-
-**Acceptance**: snapshot tests (T6) pass for all four fixtures.
-
-## T5 — `tasty` test suite skeleton
-
-- Add `apps/tx-deep-diagnosis/test/Main.hs` (tasty entrypoint).
+- Add `apps/tx-deep-diagnosis/test/Main.hs` with one trivial passing
+  test.
 - Add `test-suite tx-deep-diagnosis-test` stanza to the cabal file.
-- Wire into nix via `nix/host/tx-deep-diagnosis-native/default.nix`.
-- Test suite is initially empty (one trivial passing test) so the
-  scaffold lands separately from the snapshot fixtures.
+- Wire into `nix/host/tx-deep-diagnosis-native/default.nix` so the
+  test executable is buildable via nix.
 
 **Acceptance**: `nix build .#packages.x86_64-linux.tx-deep-diagnosis-test`
 succeeds and the test runs.
 
-## T6 — Snapshot fixtures + golden tests
+## T4 — `Render.Parties`: L1 cut
 
-- Commit four fixture envelopes under `apps/tx-deep-diagnosis/test/golden/`:
-  - `passing/input.json` — a minimal passing tx (synthesised; no
-    network calls). Output expectations: empty failures, no overlays.
-  - `value-not-conserved/input.json` — derived from the user's
-    `result.json` (the SundaeSwap/USDM mainnet tx).
-  - `missing-witness/input.json` — derived from the same tx (single
-    fixture covers both via the failures it carries).
-  - `multi-redeemer/input.json` — same tx; the report exercises the
-    multi-redeemer rendering.
-- For each, commit `diagram.mmd` and `report.md` snapshots.
-- Test suite reads `input.json`, runs renderers, asserts byte equality
-  against `diagram.mmd` / `report.md`. On mismatch, print a unified diff.
+- Add `Render/Parties.hs` exporting `renderPartiesMermaid`.
+- Mermaid `flowchart LR`. One node per distinct party (signer hash,
+  output payment credential, script bucket).
 
-**Acceptance**: `nix run .#tx-explain-render-smoke` is green.
+**Acceptance**: snapshot fixture for `parties.mmd` lands in T6 covering
+the SundaeSwap mainnet tx.
 
-## T7 — CLI flags
+## T5 — `Render.ValueFlow`: L2 cut
 
-- Add `--emit-mermaid` and `--emit-report` to `Options`.
-- After the JSON envelope is printed to stdout, if either flag is set,
-  parse the in-memory envelope and write the artifact to disk.
-- Help text quotes the spec's behaviour.
+- Add `Render/ValueFlow.hs` exporting `renderValueFlowTsv`.
+- TSV with header `source\ttarget\tlovelace\tlabel`. Empty body when
+  inputs are unresolved. No reformatting of decimal strings.
 
-**Acceptance**: integration test in `Main.hs` (or a separate smoke)
-runs the binary with both flags and inspects the produced files exist
-and match the snapshots.
+**Acceptance**: snapshot fixture for `value-flow.tsv` lands in T6.
 
-## T8 — Nix check `tx-explain-render-smoke`
+## T6 — `Render.Topology`: L3 cut
 
-- Add `tx-explain-render-smoke = pkgs.runCommand …` to `flake.nix`.
-- Expose as `apps/x86_64-linux/tx-explain-render-smoke` (mkApp).
-- Add to the `Build Gate` job and create a per-job CI step mirroring
-  `tx-intent-smoke`.
+- Add `Render/Topology.hs` exporting `renderTopologyMermaid`.
+- Mermaid `flowchart TD` of every input, output, reference input,
+  collateral, body, and synthetic signer node. Apply failure overlays
+  via `classDef` per the mapping in `plan.md`.
+- Land all four golden fixtures and unit tests in this commit (the
+  tests for T2/T4/T5 ride along, gated on the topology snapshot).
 
-**Acceptance**: `nix run .#tx-explain-render-smoke` exits 0 locally;
-green CI.
+**Acceptance**: `nix run .#tx-explain-render-smoke` is green
+(scaffolded in T8).
 
-## T9 — Update issue + PR
+## T7 — `Render.Failures` + `Render.Summary`
 
-- Update PR body with: motivation (link #54), what changed, file tour
-  per module, snapshot strategy, follow-ups.
-- Add `enhancement` label, assign to `paolino`.
+- Add `Render/Failures.hs` exporting `renderFailuresMermaid` (returns
+  `Maybe Text`).
+- Add `Render/Summary.hs` exporting `renderSummaryMarkdown`. The
+  summary's "diagrams" footer links only to files that exist in
+  `EmittedFiles`.
+
+**Acceptance**: snapshots include `summary.md` for all four fixtures
+and `failures.mmd` for the three invalid ones.
+
+## T8 — CLI flag + emit IO
+
+- Add `Render/Emit.hs` with `emitExplain :: FilePath -> ... -> IO ()`.
+- Add `--emit-explain` to `Options` and call `emitExplain` after the
+  JSON envelope is written.
+- Add `tx-explain-render-smoke = pkgs.runCommand …` in `flake.nix`,
+  exposed via `mkApp`. Adds CI Build Gate + per-job step.
+
+**Acceptance**: green CI, `nix run .#tx-explain-render-smoke` passes.
+
+## T9 — Update PR + docs
+
+- Update PR body: motivation (link #54), what changed, file tour per
+  module, snapshot strategy, follow-ups.
+- Add a short note to `apps/tx-deep-diagnosis/`-level README (or
+  inline in `--help`) pointing at the four cuts and the summary.
 
 ## Bisect plan
 
 After each commit:
 
 ```sh
-nix build .#packages.x86_64-linux.tx-deep-diagnosis    # T1, T2, T3, T4, T7
-nix build .#packages.x86_64-linux.tx-deep-diagnosis-test  # T5
-nix run .#tx-explain-render-smoke                       # T6, T8
+nix build .#packages.x86_64-linux.tx-deep-diagnosis        # T1, T2, T4-T8
+nix build .#packages.x86_64-linux.tx-deep-diagnosis-test   # T3
+nix run .#tx-explain-render-smoke                          # T6, T7, T8
 ```
 
 If a commit fails to build, fix it via `stg goto N && stg refresh` —


### PR DESCRIPTION
Closes #54.

Draft. Currently spec-only — three documents under `specs/005-tx-explain-artifacts/`. No code yet; opening early for visibility and to lock the scope before implementation.

## Scope

Two deterministic artifacts emitted by the `tx-deep-diagnosis` host CLI alongside the existing JSON envelope:

- a Mermaid `flowchart TD` of inputs → body → outputs (bucketed external_key/script), with reference + collateral side rails and a per-failure red overlay
- a Markdown report: title, claims, effects, signer perspective, validation verdict + failures, warnings

Renderers consume only the envelope (`intent` + `validate` + `summary`) and the existing `ProtocolRegistry`. **No new ledger op**, no extra ledger calls, no LLM. Hash → label resolution reuses `TxDeepDiagnosisHost.Registry.identifyByHash`. Unknown hashes truncate to `first8…last8` rather than fabricate a label.

## Documents

- spec: `specs/005-tx-explain-artifacts/spec.md`
- plan: `specs/005-tx-explain-artifacts/plan.md`
- tasks: `specs/005-tx-explain-artifacts/tasks.md`

## Implementation outline

Host-side modules under `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/`:

- `Doc` — parse the envelope into a typed view
- `Names` — registry-driven hash → human label
- `Report` — markdown
- `Diagram` — mermaid

Two new CLI flags: `--emit-mermaid <PATH>`, `--emit-report <PATH>`. Either or both may be passed; default behaviour unchanged. JSON envelope still goes to stdout.

Snapshot tests under `apps/tx-deep-diagnosis/test/golden/` for: passing tx; `ValueNotConservedUTxO`; missing-witness; multi-redeemer. Tasty test suite, byte-equality assertions. New nix check `tx-explain-render-smoke` exposed via `nix run .#tx-explain-render-smoke` and added to the CI Build Gate.

## Out of scope

- Cross-checking metadata claims against destinations
- Free-form prose narrative
- New `tx.explain` ledger op (deferrable; the host CLI suffices)
- Surge preview integration of the rendered diagram

## Plan checkpoints (T1..T9 in tasks.md)

Vertical, bisect-safe commits. Each builds and tests green before the next.

## Reviewer guidance

The relevant context for reviewing the spec:
- existing envelope contract: `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Report.hs`
- existing registry contract: `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Registry.hs`
- existing CLI: `apps/tx-deep-diagnosis/app/Main.hs`

If the host-CLI placement is wrong (e.g. you'd rather see this as a ledger op), please flag before T1 lands.