### PR TITLE
feat(tx-deep-diagnosis): make explain report reader-first

### DIFF
--- a/apps/tx-deep-diagnosis/README.md
+++ b/apps/tx-deep-diagnosis/README.md
@@ -1,0 +1,39 @@
+# tx-deep-diagnosis
+
+`tx-deep-diagnosis` renders a layered markdown explanation for one diagnosis
+JSON envelope. The reader-first contract for the top of the report is:
+
+1. Title and tx id
+2. Headline action summary
+3. Verdict
+4. Validation failures
+5. Balance
+6. Fees & resources
+7. Observations
+8. Claims
+9. Effects
+10. Smart-contract calls
+11. Outputs
+12. Datums
+13. Warnings
+14. Diagrams
+
+`summary.md` uses that order directly. `explain.md` uses the same summary and
+then embeds the Mermaid diagrams at the end inside collapsed `<details>` blocks.
+
+## Snapshot verification
+
+Compare the current renderers against the committed golden files:
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke -o result-explain-smoke
+cat result-explain-smoke/snapshot.log
+```
+
+Regenerate the expected markdown files intentionally:
+
+```bash
+nix build .#packages.x86_64-linux.tx-deep-diagnosis-render-snapshot -o result-render-snapshot
+./result-render-snapshot/bin/tx-deep-diagnosis-render-snapshot \
+  --write apps/tx-deep-diagnosis/test/golden
+```

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs
@@ -2,38 +2,23 @@
 
 {- |
 Module      : TxDeepDiagnosisHost.Render.Single
-Description : Single-file markdown with all cuts embedded as fenced
-              Mermaid (and Sankey-beta) blocks.
+Description : Single-file markdown with all cuts embedded inline.
 
-Same content as the four directory artifacts, assembled into one
-self-contained document. GitHub renders Mermaid fences inline, so a
-reader gets the parties / topology / failures diagrams without
-opening separate files. Value flow uses @sankey-beta@ for the same
-reason; it is documented as experimental but produces visibly richer
-output than a TSV table when it works, and the renderer continues to
-emit byte-stable text either way.
-
-The directory-shaped renderers (parties.mmd, value-flow.tsv,
-topology.mmd, failures.mmd, summary.md) are unchanged; this is an
-alternative assembly that consumers can prefer.
+Same content as the directory-shaped explain artifacts, assembled into one
+self-contained document. The summary stays reader-first; the Mermaid diagrams
+follow at the end behind collapsed @<details>@ blocks so they are available
+without dominating the first screen.
 -}
 module TxDeepDiagnosisHost.Render.Single (
     renderSingleMarkdown,
 ) where
 
-import Data.Aeson (Value (..))
-import qualified Data.Aeson.Key as Key
-import qualified Data.Aeson.KeyMap as KeyMap
-import Data.List (foldl')
-import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
-import qualified Data.Vector as V
 
 import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
-import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
+import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc)
 import TxDeepDiagnosisHost.Render.Failures (renderFailuresMermaid)
-import TxDeepDiagnosisHost.Render.Names (pnLabel, resolveAddress)
 import TxDeepDiagnosisHost.Render.Parties (renderPartiesMermaid)
 import TxDeepDiagnosisHost.Render.Summary (
     EmittedFiles (..),
@@ -42,24 +27,20 @@ import TxDeepDiagnosisHost.Render.Summary (
 import TxDeepDiagnosisHost.Render.Topology (renderTopologyMermaid)
 
 {- | Render the whole explain bundle into a single markdown document.
-The diagrams footer in the inlined summary is replaced with a "see
-sections below" pointer rather than relative file links.
+The diagrams footer in the shared summary is suppressed because the diagrams
+follow inline in collapsed blocks.
 -}
 renderSingleMarkdown :: ProtocolRegistry -> DiagnosisDoc -> Text
 renderSingleMarkdown reg doc =
     Text.concat
         [ summaryWithoutFooter reg doc
         , partiesBlock reg doc
-        , balanceBlock reg doc
         , topologyBlock reg doc
         , failuresBlock reg doc
         ]
 
--- | The summary minus its diagrams footer (the diagrams follow inline).
 summaryWithoutFooter :: ProtocolRegistry -> DiagnosisDoc -> Text
 summaryWithoutFooter reg doc =
-    -- 'noFiles' suppresses the diagrams footer; the summary detects no
-    -- emitted files and skips the section.
     renderSummaryMarkdown reg doc emptyFiles
   where
     emptyFiles =
@@ -70,218 +51,23 @@ summaryWithoutFooter reg doc =
             , efFailures = Nothing
             }
 
--- ---------------------------------------------------------------- --
--- Inline blocks
--- ---------------------------------------------------------------- --
-
 partiesBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
 partiesBlock reg doc =
-    "## Parties\n\n```mermaid\n"
-        <> renderPartiesMermaid reg doc
-        <> "```\n\n"
+    detailsMermaidBlock "Parties" (renderPartiesMermaid reg doc)
 
 topologyBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
 topologyBlock reg doc =
-    "## Topology\n\n```mermaid\n"
-        <> renderTopologyMermaid reg doc
-        <> "```\n\n"
+    detailsMermaidBlock "Topology" (renderTopologyMermaid reg doc)
 
 failuresBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
 failuresBlock reg doc = case renderFailuresMermaid reg doc of
     Nothing -> ""
-    Just t -> "## Failure overlay\n\n```mermaid\n" <> t <> "```\n\n"
+    Just body -> detailsMermaidBlock "Failure overlay" body
 
-{- | Balance section: two ADA-denominated tables (inputs / outputs+fee)
-plus a one-line conservation check.
-
-Sankey was tried but is misleading at this resolution: we know
-aggregate input totals and aggregate bucket totals but not per-output
-addresses, so any "input → output" edge in a Sankey is an
-illustration, not a fact. Two side-by-side balance sheets read
-cleanly, denominate large numbers in ADA so disparities don't drown
-small rows, and end with the @ValueNotConservedUTxO@ delta as a
-single bottom-line.
--}
-balanceBlock :: ProtocolRegistry -> DiagnosisDoc -> Text
-balanceBlock reg doc =
-    let inputs = resolvedInputs doc
-        outBuckets = outputBuckets doc
-        feeLov = parseLov (feeLovelace doc)
-        inTotal = sum (map (parseLov . riLovelace) inputs)
-        outTotal = sum (map (parseLov . obLovelace) outBuckets) + feeLov
-        delta = inTotal - outTotal
-        inputsTable =
-            "### Inputs\n\n"
-                <> "| Source | ADA |\n"
-                <> "|--------|----:|\n"
-                <> Text.concat
-                    [ "| "
-                        <> escapeTable
-                            ( "input #"
-                                <> Text.pack (show i)
-                                <> " — "
-                                <> pnLabel (resolveAddress reg (riAddress ri))
-                            )
-                        <> " | "
-                        <> formatAda (parseLov (riLovelace ri))
-                        <> " |\n"
-                    | (i, ri) <- zip [0 :: Int ..] inputs
-                    ]
-                <> "| **Total inputs** | **"
-                <> formatAda inTotal
-                <> "** |\n\n"
-        outputsTable =
-            "### Outputs + fee\n\n"
-                <> "| Destination | ADA |\n"
-                <> "|-------------|----:|\n"
-                <> Text.concat
-                    [ "| "
-                        <> escapeTable
-                            ( obLabel b
-                                <> " bucket"
-                            )
-                        <> " | "
-                        <> formatAda (parseLov (obLovelace b))
-                        <> " |\n"
-                    | b <- outBuckets
-                    ]
-                <> "| fee | "
-                <> formatAda feeLov
-                <> " |\n"
-                <> "| **Total outputs + fee** | **"
-                <> formatAda outTotal
-                <> "** |\n\n"
-        balanceLine
-            | delta == 0 =
-                "_Balance: inputs = outputs + fee_\n\n"
-            | delta > 0 =
-                "**Unaccounted: "
-                    <> formatAda delta
-                    <> " missing — `ValueNotConservedUTxO`**\n\n"
-            | otherwise =
-                "**Over-spent: "
-                    <> formatAda (negate delta)
-                    <> " more in outputs+fee than inputs — "
-                    <> "`ValueNotConservedUTxO`**\n\n"
-     in "## Balance\n\n"
-            <> inputsTable
-            <> outputsTable
-            <> balanceLine
-
--- ---------------------------------------------------------------- --
--- ADA formatting
--- ---------------------------------------------------------------- --
-
-{- | Format an integer lovelace amount as ADA with 6 decimals and
-thousands separators on the whole part.
--}
-formatAda :: Integer -> Text
-formatAda n =
-    let sign = if n < 0 then "-" else ""
-        m = abs n
-        whole = m `div` 1000000
-        frac = m `mod` 1000000
-        wholeT = withThousandsSeparators (Text.pack (show whole))
-        fracT = Text.justifyRight 6 '0' (Text.pack (show frac))
-     in sign <> wholeT <> "." <> fracT
-
-withThousandsSeparators :: Text -> Text
-withThousandsSeparators t =
-    let chars = Text.unpack t
-        len = length chars
-        (head', tailGroups) = splitAt ((len - 1) `mod` 3 + 1) chars
-        groups
-            | null tailGroups = [head']
-            | otherwise = head' : chunksOf 3 tailGroups
-     in Text.pack (concatMap (\g -> if g == head' then g else "," <> g) groups)
-  where
-    chunksOf k xs = case splitAt k xs of
-        (h, []) -> [h]
-        (h, rest) -> h : chunksOf k rest
-
--- ---------------------------------------------------------------- --
--- Local copies of the parsing structs (kept here to avoid a
--- circular re-export from Render.ValueFlow / Render.Topology)
--- ---------------------------------------------------------------- --
-
-data ResolvedInput = ResolvedInput
-    { riAddress :: !Text
-    , riLovelace :: !Text
-    }
-
-resolvedInputs :: DiagnosisDoc -> [ResolvedInput]
-resolvedInputs doc =
-    let path = ["result", "validation", "resolved_inputs"]
-        items = case lookupPath (ddValidate doc) path of
-            Just (Array xs) -> V.toList xs
-            _ -> []
-     in mapMaybe parseInput items
-  where
-    parseInput (Object o) = case KeyMap.lookup "tx_out" o of
-        Just (Object txOut) -> do
-            addr <- case KeyMap.lookup "address_hex" txOut of
-                Just (String s) -> Just s
-                _ -> Nothing
-            let lov = case KeyMap.lookup "coin_lovelace" txOut of
-                    Just (String s) -> s
-                    _ -> "0"
-            Just ResolvedInput{riAddress = addr, riLovelace = lov}
-        _ -> Nothing
-    parseInput _ = Nothing
-
-data OutputBucket = OutputBucket
-    { obLabel :: !Text
-    , obLovelace :: !Text
-    }
-
-outputBuckets :: DiagnosisDoc -> [OutputBucket]
-outputBuckets doc =
-    let path = ["result", "intent", "value", "output_buckets"]
-        items = case lookupPath (ddIntent doc) path of
-            Just (Array xs) -> V.toList xs
-            _ -> []
-     in mapMaybe parseBucket items
-  where
-    parseBucket (Object o) = do
-        lab <- case KeyMap.lookup "label" o of
-            Just (String s) -> Just s
-            _ -> Nothing
-        let lov = case KeyMap.lookup "lovelace" o of
-                Just (String s) -> s
-                _ -> "0"
-        Just OutputBucket{obLabel = lab, obLovelace = lov}
-    parseBucket _ = Nothing
-
--- ---------------------------------------------------------------- --
--- Helpers
--- ---------------------------------------------------------------- --
-
-csvRow :: [Text] -> Text
-csvRow xs = Text.intercalate "," (map sanitiseCsv xs) <> "\n"
-
--- Mermaid sankey-beta uses comma as separator; values containing a
--- comma break the row. Replace commas with U+2024 ONE DOT LEADER so
--- labels remain readable without escaping.
-sanitiseCsv :: Text -> Text
-sanitiseCsv = Text.replace "," "\x2024"
-
-parseLov :: Text -> Integer
-parseLov t = case reads (Text.unpack t) of
-    [(n, "")] -> n
-    _ -> 0
-
-feeLovelace :: DiagnosisDoc -> Text
-feeLovelace doc = case lookupPath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
-    Just (String s) -> s
-    _ -> "0"
-
-escapeTable :: Text -> Text
-escapeTable =
-    Text.replace "\n" " "
-        . Text.replace "|" "\\|"
-
-lookupPath :: Value -> [Text] -> Maybe Value
-lookupPath = foldl' step . Just
-  where
-    step (Just (Object o)) k = KeyMap.lookup (Key.fromText k) o
-    step _ _ = Nothing
+detailsMermaidBlock :: Text -> Text -> Text
+detailsMermaidBlock label body =
+    "<details><summary>"
+        <> label
+        <> "</summary>\n\n```mermaid\n"
+        <> body
+        <> "```\n\n</details>\n\n"

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -4,18 +4,19 @@
 Module      : TxDeepDiagnosisHost.Render.Summary
 Description : Top-level summary.md tying the cuts together with prose.
 
-Sections, in fixed order so the file diffs cleanly:
+Sections, in fixed order so the file diffs cleanly and the first
+screen stays reader-first:
 
-* Title — from @intent.title@
-* Verdict paragraph — combines @summary@, @valid_for_supplied_context@,
-  and the failure count
-* Claims — @intent.metadata_claims@ as a table
-* Effects — @intent.sections[]@ rows (already pre-rendered for display
-  by the inspector library)
-* Signer perspective — @intent.signing@ + signer-perspective rows
-* Validation failures — one row per failure
-* Warnings — @intent.warnings@
-* Diagrams — relative links to whatever cuts were emitted
+* Title / tx id
+* Headline action summary
+* Verdict
+* Validation failures
+* Balance
+* Fees & resources
+* Observations / claims / effects
+* Smart-contract calls / outputs / datums
+* Warnings
+* Diagrams
 -}
 module TxDeepDiagnosisHost.Render.Summary (
     EmittedFiles (..),
@@ -68,14 +69,17 @@ renderSummaryMarkdown ::
 renderSummaryMarkdown reg doc files =
     Text.concat
         [ titleSection doc
+        , headlineSection doc
         , verdictSection doc
+        , failuresSection doc
+        , balanceSection reg doc
+        , feesResourcesSection doc
         , observationsSection reg doc
+        , claimsSection doc
+        , effectsSection doc
         , scriptsSection reg doc
         , outputsSection reg doc
         , datumsSection reg doc
-        , claimsSection doc
-        , effectsSection doc
-        , failuresSection doc
         , warningsSection doc
         , diagramsSection files
         ]
@@ -103,20 +107,27 @@ titleSection doc =
             <> textPath doc ["result", "intent", "tx_id"] ""
             <> "`\n\n"
 
+headlineSection :: DiagnosisDoc -> Text
+headlineSection doc =
+    let subject = headlineSubject doc
+        outcome = headlineOutcomePhrase (validationStatus doc)
+        dominantBucket = case dominantOutputBucketLabel doc of
+            Nothing -> ""
+            Just bucket ->
+                " and sends most value to the **"
+                    <> bucket
+                    <> "** bucket"
+     in "**Headline:** "
+            <> subject
+            <> " "
+            <> outcome
+            <> dominantBucket
+            <> ".\n\n"
+
 verdictSection :: DiagnosisDoc -> Text
 verdictSection doc =
     let topSummary = ddSummary doc
-        valid =
-            valuePath
-                (ddValidate doc)
-                [ "result"
-                , "validation"
-                , "valid_for_supplied_context"
-                ]
-        verdict = case valid of
-            Just (Bool True) -> "valid"
-            Just (Bool False) -> "invalid"
-            _ -> "unknown"
+        verdict = validationStatus doc
      in "## Verdict\n\n"
             <> "- "
             <> topSummary
@@ -124,6 +135,62 @@ verdictSection doc =
             <> "- ledger validation: **"
             <> verdict
             <> "**\n\n"
+
+validationStatus :: DiagnosisDoc -> Text
+validationStatus doc =
+    case valuePath
+        (ddValidate doc)
+        ["result", "validation", "status"] of
+        Just (String s) -> s
+        _ -> case valuePath
+            (ddValidate doc)
+            [ "result"
+            , "validation"
+            , "valid_for_supplied_context"
+            ] of
+            Just (Bool True) -> "valid"
+            Just (Bool False) -> "invalid"
+            _ -> "unknown"
+
+headlineSubject :: DiagnosisDoc -> Text
+headlineSubject doc =
+    case firstClaimLabel doc of
+        Just label | not (Text.null label) -> "Claimed **" <> label <> "**"
+        _ ->
+            let title = textPath doc ["result", "intent", "title"] "Transaction"
+             in case title of
+                    "Signing summary" -> "This transaction"
+                    "Transaction" -> "This transaction"
+                    _ -> "**" <> title <> "**"
+
+headlineOutcomePhrase :: Text -> Text
+headlineOutcomePhrase status = case status of
+    "valid" -> "is **valid**"
+    "invalid" -> "is **invalid**"
+    "incomplete" -> "is **incomplete** for the supplied context"
+    "rejected" -> "was **rejected** for the supplied context"
+    _ -> "has an **unknown** verdict"
+
+firstClaimLabel :: DiagnosisDoc -> Maybe Text
+firstClaimLabel doc =
+    case valuePath (ddIntent doc) ["result", "intent", "claims"] of
+        Just (Array xs) ->
+            case [textOf "label" o "" | Object o <- V.toList xs] of
+                (lab : _) | not (Text.null lab) -> Just lab
+                _ -> Nothing
+        _ -> Nothing
+
+dominantOutputBucketLabel :: DiagnosisDoc -> Maybe Text
+dominantOutputBucketLabel doc =
+    case outputBuckets doc of
+        [] -> Nothing
+        (x : xs) ->
+            let best = foldl' maxBucket (obLabel x, parseLov (obLovelace x)) xs
+             in Just (fst best)
+  where
+    maxBucket best bucket =
+        let current = (obLabel bucket, parseLov (obLovelace bucket))
+         in if snd current > snd best then current else best
 
 {- | Lists the facts that drive flow understanding: who owns the
 inputs (per registry), what the metadata declares as the destination
@@ -159,8 +226,12 @@ observationsSection reg doc =
   where
     metaSection [] = ""
     metaSection ds =
-        "Metadata-declared destination(s) (`self_declared`):\n\n"
-            <> bulletList (map (\d -> "_" <> d <> "_") ds)
+        "Metadata-declared destination(s):\n\n"
+            <> bulletList
+                ( map
+                    (\d -> "_" <> d <> "_ (self-declared, not verified)")
+                    ds
+                )
             <> "\n"
     crossoverSection [] = ""
     crossoverSection ms =
@@ -270,6 +341,29 @@ inputParties reg doc =
         _ -> Nothing
     mkParty _ _ = Nothing
 
+data OutputBucket = OutputBucket
+    { obLabel :: !Text
+    , obLovelace :: !Text
+    }
+
+outputBuckets :: DiagnosisDoc -> [OutputBucket]
+outputBuckets doc =
+    let path = ["result", "intent", "value", "output_buckets"]
+        items = case valuePath (ddIntent doc) path of
+            Just (Array xs) -> V.toList xs
+            _ -> []
+     in mapMaybe parseBucket items
+  where
+    parseBucket (Object o) = do
+        label <- case KeyMap.lookup "label" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        let lov = case KeyMap.lookup "lovelace" o of
+                Just (String s) -> s
+                _ -> "0"
+        Just OutputBucket{obLabel = label, obLovelace = lov}
+    parseBucket _ = Nothing
+
 metadataDestinations :: DiagnosisDoc -> [Text]
 metadataDestinations doc =
     let path = ["result", "intent", "metadata_claims"]
@@ -284,6 +378,173 @@ countOutputs doc = case valuePath
     ["result", "intent", "features", "output_count"] of
     Just (Number n) -> Just (floor n)
     _ -> Nothing
+
+balanceSection :: ProtocolRegistry -> DiagnosisDoc -> Text
+balanceSection reg doc =
+    let inputs = inputParties reg doc
+        outBuckets = outputBuckets doc
+        feeLov = feeLovelace doc
+        inTotal = sum [parseLov lov | (_, lov, _) <- inputs]
+        outTotal = sum [parseLov lov | b <- outBuckets, let { lov = obLovelace b }] + parseLov feeLov
+        delta = inTotal - outTotal
+        inputsTable =
+            "### Inputs\n\n"
+                <> "| Source | ADA |\n"
+                <> "|--------|----:|\n"
+                <> Text.concat
+                    [ "| "
+                        <> escapeTable
+                            ( "input #"
+                                <> Text.pack (show i)
+                                <> " — "
+                                <> pnLabel pn
+                            )
+                        <> " | "
+                        <> formatAdaSimple (parseLov lov)
+                        <> " |\n"
+                    | (i, lov, pn) <- inputs
+                    ]
+                <> "| **Total inputs** | **"
+                <> formatAdaSimple inTotal
+                <> "** |\n\n"
+        outputsTable =
+            "### Outputs + fee\n\n"
+                <> "| Destination | ADA |\n"
+                <> "|-------------|----:|\n"
+                <> Text.concat
+                    [ "| "
+                        <> escapeTable (obLabel bucket <> " bucket")
+                        <> " | "
+                        <> formatAdaSimple (parseLov (obLovelace bucket))
+                        <> " |\n"
+                    | bucket <- outBuckets
+                    ]
+                <> "| fee | "
+                <> formatAdaSimple (parseLov feeLov)
+                <> " |\n"
+                <> "| **Total outputs + fee** | **"
+                <> formatAdaSimple outTotal
+                <> "** |\n\n"
+        balanceLine
+            | delta == 0 =
+                "_Balance: inputs = outputs + fee_\n\n"
+            | delta > 0 =
+                "**Unaccounted: "
+                    <> formatAdaSimple delta
+                    <> " missing — `ValueNotConservedUTxO`**\n\n"
+            | otherwise =
+                "**Over-spent: "
+                    <> formatAdaSimple (negate delta)
+                    <> " more in outputs + fee than inputs — `ValueNotConservedUTxO`**\n\n"
+     in if null inputs && null outBuckets && parseLov feeLov == 0
+            then ""
+            else
+                "## Balance\n\n"
+                    <> inputsTable
+                    <> outputsTable
+                    <> balanceLine
+
+feesResourcesSection :: DiagnosisDoc -> Text
+feesResourcesSection doc =
+    let feeRow =
+            Just
+                ( "Fee"
+                , formatAdaSimple (parseLov (feeLovelace doc)) <> " ADA"
+                , feeLovelace doc <> " lovelace"
+                )
+        txSizeRow = case txSizeBytes doc of
+            Just n ->
+                Just
+                    ( "Tx size"
+                    , formatCount n <> " bytes"
+                    , "from the intent envelope"
+                    )
+            Nothing -> Nothing
+        redeemerRow =
+            Just
+                ( "Redeemers"
+                , Text.pack (show (redeemerCount doc))
+                , "committed redeemers in the current intent view"
+                )
+        exUnitsRow = case committedExUnits doc of
+            Just (mem, steps) ->
+                Just
+                    ( "Committed ex-units"
+                    , formatCount mem <> " memory / " <> formatCount steps <> " steps"
+                    , "summed from per-redeemer committed budgets"
+                    )
+            Nothing -> Nothing
+        rows = mapMaybe id [feeRow, txSizeRow, redeemerRow, exUnitsRow]
+     in if null rows
+            then ""
+            else
+                "## Fees & resources\n\n"
+                    <> "| Label | Value | Detail |\n"
+                    <> "|-------|-------|--------|\n"
+                    <> Text.concat
+                        [ "| "
+                            <> escapeTable label
+                            <> " | "
+                            <> escapeTable value
+                            <> " | "
+                            <> escapeTable detail
+                            <> " |\n"
+                        | (label, value, detail) <- rows
+                        ]
+                    <> "\n"
+
+feeLovelace :: DiagnosisDoc -> Text
+feeLovelace doc = case valuePath (ddIntent doc) ["result", "intent", "fee_lovelace"] of
+    Just (String s) -> s
+    _ -> "0"
+
+txSizeBytes :: DiagnosisDoc -> Maybe Integer
+txSizeBytes doc = case valuePath (ddIntent doc) ["result", "intent", "tx_size_bytes"] of
+    Just (Number n) -> Just (floor n)
+    Just (String s) -> case reads (Text.unpack s) of
+        [(n, "")] -> Just n
+        _ -> Nothing
+    _ -> Nothing
+
+redeemerCount :: DiagnosisDoc -> Int
+redeemerCount doc =
+    case valuePath (ddIntent doc) ["result", "intent", "features", "redeemer_count"] of
+        Just (Number n) -> floor n
+        _ -> length (scriptRows doc)
+
+committedExUnits :: DiagnosisDoc -> Maybe (Integer, Integer)
+committedExUnits doc =
+    let units =
+            [ (mem, steps)
+            | Object o <- scriptRows doc
+            , Just (Object ex) <- [KeyMap.lookup "ex_units_committed" o]
+            , Just mem <- [stringNumber "memory" ex]
+            , Just steps <- [stringNumber "steps" ex]
+            ]
+     in case units of
+            [] -> Nothing
+            _ ->
+                Just
+                    ( sum [mem | (mem, _) <- units]
+                    , sum [steps | (_, steps) <- units]
+                    )
+
+scriptRows :: DiagnosisDoc -> [Value]
+scriptRows doc =
+    case valuePath (ddIntent doc) ["result", "intent", "scripts"] of
+        Just (Array xs) -> V.toList xs
+        _ -> []
+
+stringNumber :: Text -> KeyMap.KeyMap Value -> Maybe Integer
+stringNumber key o = case KeyMap.lookup (Key.fromText key) o of
+    Just (String s) -> case reads (Text.unpack s) of
+        [(n, "")] -> Just n
+        _ -> Nothing
+    Just (Number n) -> Just (floor n)
+    _ -> Nothing
+
+formatCount :: Integer -> Text
+formatCount = withThousandsSeparators . Text.pack . show
 
 scriptOutputCount :: DiagnosisDoc -> Maybe Int
 scriptOutputCount doc =
@@ -656,9 +917,16 @@ claimsSection doc =
                 <> " | "
                 <> escapeTable val
                 <> " | "
-                <> escapeTable det
+                <> escapeTable (selfDeclaredDetail det)
                 <> " |\n"
     renderClaim _ = ""
+
+selfDeclaredDetail :: Text -> Text
+selfDeclaredDetail det =
+    let stripped = Text.replace " / self-declared" "" det
+     in if Text.null stripped
+            then "self-declared, not verified"
+            else "self-declared, not verified / " <> stripped
 
 effectsSection :: DiagnosisDoc -> Text
 effectsSection doc =
@@ -719,13 +987,41 @@ failuresSection doc =
             predicate = textOf "predicate" o ""
             msg = textOf "message" o ""
          in "### "
+                <> failureLead predicate msg
+                <> "\n\n"
+                <> "_Raw rule:_ `"
                 <> rule
                 <> " — "
                 <> shortName predicate
-                <> "\n\n"
+                <> "`\n\n"
                 <> humanise predicate msg
                 <> "\n"
     renderFail _ = ""
+
+failureLead :: Text -> Text -> Text
+failureLead predicate _msg
+    | "ValueNotConservedUTxO" `Text.isInfixOf` predicate =
+        let supplied = extractCoin "supplied: MaryValue (Coin " predicate
+            expected = extractCoin "expected: MaryValue (Coin " predicate
+            delta = supplied - expected
+         in if delta > 0
+                then
+                    "Inputs and outputs do not conserve value: "
+                        <> formatAdaSimple delta
+                        <> " ADA missing"
+                else
+                    "Inputs and outputs do not conserve value: "
+                        <> formatAdaSimple (abs delta)
+                        <> " ADA over-spent"
+    | "MissingVKeyWitnessesUTXOW" `Text.isInfixOf` predicate =
+        let missing = length (extractKeyHashes predicate)
+            noun = if missing == 1 then "required signer witness is" else "required signer witnesses are"
+         in Text.pack (show missing) <> " " <> noun <> " missing"
+    | "BadInputsUTxO" `Text.isInfixOf` predicate =
+        "One or more declared inputs are missing from the supplied context"
+    | "OutsideValidityIntervalUTxO" `Text.isInfixOf` predicate =
+        "The transaction falls outside its validity interval"
+    | otherwise = shortName predicate
 
 {- | Convert a verbose ledger predicate into one human-readable name
 that the reader can grep for. Falls back to the first 60 chars of the

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -4,10 +4,63 @@ _1 metadata claim / 2 missing required signers / 2 redeemers_
 
 Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
 
+**Headline:** Claimed **Swap ADA<->USDM** is **invalid** and sends most value to the **Script** bucket.
+
 ## Verdict
 
 - 6/6 producer txs resolved, network=mainnet
 - ledger validation: **invalid**
+
+## Validation failures
+
+### Inputs and outputs do not conserve value: 287,575.440000 ADA missing
+
+_Raw rule:_ `UTXOW — ValueNotConservedUTxO`
+
+- supplied (inputs): **1,500,007.239276 ADA**
+- expected (outputs + fee): **1,212,431.799276 ADA**
+- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
+
+### 3 required signer witnesses are missing
+
+_Raw rule:_ `UTXOW — MissingVKeyWitnessesUTXOW`
+
+The following payment-key hashes are listed as required signers but are missing from the witness set:
+
+- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
+- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
+- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
+
+_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
+
+## Balance
+
+### Inputs
+
+| Source | ADA |
+|--------|----:|
+| input #0 — key d2626d | 50,007.239276 |
+| input #1 — Amaru Network Compliance treasury (0baa0d) | 1,450,000.000000 |
+| **Total inputs** | **1,500,007.239276** |
+
+### Outputs + fee
+
+| Destination | ADA |
+|-------------|----:|
+| External key bucket | 49,897.955481 |
+| Script bucket | 1,162,532.800000 |
+| fee | 1.043795 |
+| **Total outputs + fee** | **1,212,431.799276** |
+
+**Unaccounted: 287,575.440000 missing — `ValueNotConservedUTxO`**
+
+## Fees & resources
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Fee | 1.043795 ADA | 1043795 lovelace |
+| Redeemers | 2 | committed redeemers in the current intent view |
+| Committed ex-units | 815,780 memory / 308,746,487 steps | summed from per-redeemer committed budgets |
 
 ## Observations
 
@@ -22,13 +75,49 @@ Output parties (registry-resolved, from `intent.value.output_buckets[].addresses
 - Script bucket → **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`)
 - Script bucket → **SundaeSwap V3 order** (`FromValidator`)
 
-Metadata-declared destination(s) (`self_declared`):
+Metadata-declared destination(s):
 
-- _Network Compliance's treasury_
+- _Network Compliance's treasury_ (self-declared, not verified)
 
 Inputs that also receive outputs (same payment credential on both sides):
 
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
+
+## Claims
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | self-declared, not verified / Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 |
+
+## Signer value perspective
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
+| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
+| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
+| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
+
+## Critical effects
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Consumes inputs | 2 inputs | source outputs not supplied |
+| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
+| Pays fee | 1043795 lovelace |  |
+| Required signatures | 2 signers | 2 declared signers missing from witnesses |
+| Scripts | 2 redeemers | 0 script witnesses |
+| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
+| Withdrawals | 1 withdrawal |  |
+| Mint/burn | No mint/burn |  |
+| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
+
+## Missing required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
 
 ## Smart-contract calls
 
@@ -136,66 +225,12 @@ Constr 0
 
 </details>
 
-## Claims
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 / self-declared |
-
-## Signer value perspective
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
-| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
-| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
-| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
-
-## Critical effects
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Consumes inputs | 2 inputs | source outputs not supplied |
-| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
-| Pays fee | 1043795 lovelace |  |
-| Required signatures | 2 signers | 2 declared signers missing from witnesses |
-| Scripts | 2 redeemers | 0 script witnesses |
-| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
-| Withdrawals | 1 withdrawal |  |
-| Mint/burn | No mint/burn |  |
-| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
-
-## Missing required signers
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
-| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
-
-## Validation failures
-
-### UTXOW — ValueNotConservedUTxO
-
-- supplied (inputs): **1,500,007.239276 ADA**
-- expected (outputs + fee): **1,212,431.799276 ADA**
-- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
-
-### UTXOW — MissingVKeyWitnessesUTXOW
-
-The following payment-key hashes are listed as required signers but are missing from the witness set:
-
-- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
-- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
-- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
-
-_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
-
 ## Warnings
 
 - Metadata describes intent but is self-declared; verify it against the destination addresses and contract policy.
 - Declared required signer hashes are absent from the witness set.
 
-## Parties
+<details><summary>Parties</summary>
 
 ```mermaid
 %% L1 — parties involved in tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
@@ -219,28 +254,9 @@ flowchart LR
     S1 -. required .-> tx
 ```
 
-## Balance
+</details>
 
-### Inputs
-
-| Source | ADA |
-|--------|----:|
-| input #0 — key d2626d | 50,007.239276 |
-| input #1 — Amaru Network Compliance treasury (0baa0d) | 1,450,000.000000 |
-| **Total inputs** | **1,500,007.239276** |
-
-### Outputs + fee
-
-| Destination | ADA |
-|-------------|----:|
-| External key bucket | 49,897.955481 |
-| Script bucket | 1,162,532.800000 |
-| fee | 1.043795 |
-| **Total outputs + fee** | **1,212,431.799276** |
-
-**Unaccounted: 287,575.440000 missing — `ValueNotConservedUTxO`**
-
-## Topology
+<details><summary>Topology</summary>
 
 ```mermaid
 %% L3 — full topology for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
@@ -281,7 +297,9 @@ flowchart TD
     sig1 -. required .-> body
 ```
 
-## Failure overlay
+</details>
+
+<details><summary>Failure overlay</summary>
 
 ```mermaid
 %% L4 — failures for tx 30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f
@@ -302,4 +320,6 @@ flowchart TD
     f1_s2["missing signer f3ab64b0…04d23e2e"]:::signerFail
     f1 --> f1_s2
 ```
+
+</details>
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -4,10 +4,63 @@ _1 metadata claim / 2 missing required signers / 2 redeemers_
 
 Tx id: `30723408902f540c29e2e0ec7cb0dc89a0024d00506b564e326b8fe10fd2a00f`
 
+**Headline:** Claimed **Swap ADA<->USDM** is **invalid** and sends most value to the **Script** bucket.
+
 ## Verdict
 
 - 6/6 producer txs resolved, network=mainnet
 - ledger validation: **invalid**
+
+## Validation failures
+
+### Inputs and outputs do not conserve value: 287,575.440000 ADA missing
+
+_Raw rule:_ `UTXOW — ValueNotConservedUTxO`
+
+- supplied (inputs): **1,500,007.239276 ADA**
+- expected (outputs + fee): **1,212,431.799276 ADA**
+- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
+
+### 3 required signer witnesses are missing
+
+_Raw rule:_ `UTXOW — MissingVKeyWitnessesUTXOW`
+
+The following payment-key hashes are listed as required signers but are missing from the witness set:
+
+- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
+- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
+- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
+
+_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
+
+## Balance
+
+### Inputs
+
+| Source | ADA |
+|--------|----:|
+| input #0 — key d2626d | 50,007.239276 |
+| input #1 — Amaru Network Compliance treasury (0baa0d) | 1,450,000.000000 |
+| **Total inputs** | **1,500,007.239276** |
+
+### Outputs + fee
+
+| Destination | ADA |
+|-------------|----:|
+| External key bucket | 49,897.955481 |
+| Script bucket | 1,162,532.800000 |
+| fee | 1.043795 |
+| **Total outputs + fee** | **1,212,431.799276** |
+
+**Unaccounted: 287,575.440000 missing — `ValueNotConservedUTxO`**
+
+## Fees & resources
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Fee | 1.043795 ADA | 1043795 lovelace |
+| Redeemers | 2 | committed redeemers in the current intent view |
+| Committed ex-units | 815,780 memory / 308,746,487 steps | summed from per-redeemer committed budgets |
 
 ## Observations
 
@@ -22,13 +75,49 @@ Output parties (registry-resolved, from `intent.value.output_buckets[].addresses
 - Script bucket → **Amaru Network Compliance treasury (0baa0d)** (`FromInstance`)
 - Script bucket → **SundaeSwap V3 order** (`FromValidator`)
 
-Metadata-declared destination(s) (`self_declared`):
+Metadata-declared destination(s):
 
-- _Network Compliance's treasury_
+- _Network Compliance's treasury_ (self-declared, not verified)
 
 Inputs that also receive outputs (same payment credential on both sides):
 
 - input #1 — **Amaru Network Compliance treasury (0baa0d)** also appears as a destination in the **Script** output bucket
+
+## Claims
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | self-declared, not verified / Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 |
+
+## Signer value perspective
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
+| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
+| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
+| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
+
+## Critical effects
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| Consumes inputs | 2 inputs | source outputs not supplied |
+| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
+| Pays fee | 1043795 lovelace |  |
+| Required signatures | 2 signers | 2 declared signers missing from witnesses |
+| Scripts | 2 redeemers | 0 script witnesses |
+| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
+| Withdrawals | 1 withdrawal |  |
+| Mint/burn | No mint/burn |  |
+| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
+
+## Missing required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
 
 ## Smart-contract calls
 
@@ -135,60 +224,6 @@ Constr 0
 ```
 
 </details>
-
-## Claims
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Swap ADA<->USDM | Swapping ADA for $100k at a rate of $0.245 per ADA | Required to pay Antithesis as vendor / destination Network Compliance's treasury / metadata label 1694 / self-declared |
-
-## Signer value perspective
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Net signer ADA | unknown | producer transaction CBOR must resolve every regular input before signer net can be known |
-| Signer-controlled inputs | unknown | 0 resolved source outputs matched signer payment key hashes out of 0 resolved inputs |
-| Signer-controlled outputs | 0 ADA | 0 outputs matched signer payment key hashes out of 12 outputs |
-| External/script outputs | 1212430.755481 ADA | outputs not controlled by declared or witnessed signer payment key hashes |
-
-## Critical effects
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| Consumes inputs | 2 inputs | source outputs not supplied |
-| Creates outputs | 12 outputs | 1212430755481 lovelace total across all outputs |
-| Pays fee | 1043795 lovelace |  |
-| Required signatures | 2 signers | 2 declared signers missing from witnesses |
-| Scripts | 2 redeemers | 0 script witnesses |
-| Reference inputs | 4 read-only inputs | reference inputs are available to scripts but are not spent |
-| Withdrawals | 1 withdrawal |  |
-| Mint/burn | No mint/burn |  |
-| Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
-
-## Missing required signers
-
-| Label | Value | Detail |
-|-------|-------|--------|
-| declared required signer not present in vkey or bootstrap witnesses | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
-| declared required signer not present in vkey or bootstrap witnesses | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
-
-## Validation failures
-
-### UTXOW — ValueNotConservedUTxO
-
-- supplied (inputs): **1,500,007.239276 ADA**
-- expected (outputs + fee): **1,212,431.799276 ADA**
-- Inputs supply **287,575.440000 ADA** more than outputs + fee — that ADA is unaccounted for.
-
-### UTXOW — MissingVKeyWitnessesUTXOW
-
-The following payment-key hashes are listed as required signers but are missing from the witness set:
-
-- `8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1`
-- `dea7197ac235d73e7f7b1a249bace6a833722415d88e91dec5d2626d`
-- `f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e`
-
-_Tip:_ each hash above is the `payment_key_hash` of one of the resolved inputs (or an explicitly declared required signer in the tx body). Compare with the `Observations` section above to see which party each hash belongs to.
 
 ## Warnings
 

--- a/specs/006-explain-parity/checklists/requirements.md
+++ b/specs/006-explain-parity/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Explain Markdown Parity Phase 1
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Scope is intentionally limited to issue #58 items that are unblocked on the
+  current `main` branch.

--- a/specs/006-explain-parity/data-model.md
+++ b/specs/006-explain-parity/data-model.md
@@ -1,0 +1,85 @@
+# Data Model: Explain Markdown Parity Phase 1
+
+## Explain Layout
+
+- **Purpose**: Ordered view of the single transaction explanation as read by a
+  human.
+- **Core fields**:
+  - `headline`
+  - `verdict`
+  - `validation_failures`
+  - `balance`
+  - `fees_resources`
+  - `observations`
+  - `smart_contract_calls`
+  - `outputs`
+  - `datums`
+  - `claims`
+  - `effects`
+  - `warnings`
+  - `diagrams`
+- **Validation rules**:
+  - Headline, verdict, and balance must appear before secondary narrative
+    sections.
+  - Diagram sections may be collapsed, but their content must remain present.
+
+## Headline Action Summary
+
+- **Purpose**: One-line statement answering "what appears to be happening and
+  what was the outcome?"
+- **Core fields**:
+  - `action_text`
+  - `outcome_text`
+  - `dominant_destination_hint`
+  - `confidence_source` (`claim`, `title`, or `fallback`)
+- **Validation rules**:
+  - Must degrade gracefully when claims are absent.
+  - Must never claim more certainty than the current envelope supports.
+
+## Fees & Resources Panel
+
+- **Purpose**: Compact operational summary shown near the top of the report.
+- **Core fields**:
+  - `fee_lovelace`
+  - `tx_size_bytes`
+  - `redeemer_count`
+  - `committed_memory`
+  - `committed_steps`
+- **Validation rules**:
+  - Unknown values may be omitted, but known values must remain deterministic.
+  - Resource totals must be derived from committed redeemer data already in the
+    envelope.
+
+## Failure Lead
+
+- **Purpose**: Reader-facing summary of one validation failure.
+- **Core fields**:
+  - `summary_sentence`
+  - `raw_rule_name`
+  - `supporting_detail`
+- **Validation rules**:
+  - The summary sentence is the primary visual cue.
+  - The raw rule name remains available for audit/debug context.
+
+## Claim Provenance Badge
+
+- **Purpose**: Mark content that comes from metadata rather than verified ledger
+  evidence.
+- **Core fields**:
+  - `label_text`
+  - `provenance` (`self_declared`)
+  - `warning_text`
+- **Validation rules**:
+  - Self-declared badges must appear inline where the claim is rendered.
+  - Registry-derived parties must not be mislabeled as self-declared.
+
+## Diagram Fold
+
+- **Purpose**: Collapsed wrapper around an inline Mermaid block in `explain.md`.
+- **Core fields**:
+  - `summary_label`
+  - `diagram_body`
+  - `default_state` (`collapsed`)
+- **Validation rules**:
+  - Collapsing must not remove or rewrite the underlying diagram text.
+  - Summary labels must stay readable in plain markdown view.

--- a/specs/006-explain-parity/plan.md
+++ b/specs/006-explain-parity/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Explain Markdown Parity Phase 1
+
+**Branch**: `006-explain-parity` | **Date**: 2026-05-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/006-explain-parity/spec.md`
+
+## Status
+
+- **Completed**: Feature specification, checklist, research, data model,
+  quickstart, and task plan are written. `Render.Summary` now renders a
+  headline, reader-first failure/balance/resources order, and explicit
+  self-declared badges. `Render.Single` now collapses inline Mermaid sections.
+  The app README documents the explain artifact contract, the golden snapshots
+  were refreshed, `tx-explain-render-smoke` passes, and `just format-check`
+  passes.
+- **Current**: Prepare the branch for push and PR review without merging.
+- **Blockers**: Issue #57-dependent additions remain out of scope for this
+  branch. Passing/governance-specific snapshot coverage is still deferred.
+
+## Summary
+
+Tighten the `tx-deep-diagnosis` markdown explain report so its first screen
+matches the reader-first patterns seen in mainstream transaction inspectors,
+without adding any new ledger fields. The implementation stays in the report
+layer: reorder the summary sections, derive a headline from already available
+intent data, add a compact fees/resources panel, make self-declared claims
+explicitly unverified, collapse Mermaid blocks in the single-file explain
+render, and lock the behavior with the existing golden snapshot harness.
+
+## Technical Context
+
+**Language/Version**: Haskell2010 sources compiled via the repo's existing GHC
+and Nix setup; markdown output rendered by the native `tx-deep-diagnosis` host
+
+**Primary Dependencies**: `aeson`, `text`, `vector`, existing
+`TxDeepDiagnosisHost.Render.*` modules, current `cardano-ledger-inspector`
+intent/validate envelope fields, Nix flake checks
+
+**Storage**: None. The feature is a pure transformation from an existing
+diagnosis JSON envelope to markdown text.
+
+**Testing**: Golden snapshot verification through
+`tx-deep-diagnosis-render-snapshot` and
+`checks.x86_64-linux.tx-explain-render-smoke`, plus `just format-check`
+
+**Target Platform**: Single-file and directory-shaped markdown explain artifacts
+emitted by the native `tx-deep-diagnosis` CLI and reviewed on GitHub
+
+**Project Type**: Native Haskell CLI/report renderer with pure text artifacts
+and snapshot-based regression coverage
+
+**Performance Goals**: Keep rendering deterministic and pure; no new network
+calls, no new ledger execution, and no measurable slowdown beyond a small
+amount of extra text formatting
+
+**Constraints**: Use only fields already present on current `main`; preserve the
+directory-shaped artifacts; keep markdown diffs reviewable; do not reimplement
+ledger semantics or add hidden state
+
+**Scale/Scope**: One explain report per diagnosis document, initially verified
+against the existing invalid golden fixture; the branch targets issue #58 items
+`A1` to `A5` plus `C3`, and explicitly excludes issue #57-dependent additions
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Ledger Code Is Authoritative**: PASS. No new ledger behavior is introduced;
+  the feature only re-renders already produced intent/validate output.
+- **Transaction Documents Own State**: PASS. Rendering remains a pure function
+  of one diagnosis JSON envelope with no cross-call state.
+- **JSON Control Plane, CBOR Data Plane**: PASS. The report consumes existing
+  JSON summaries and does not alter transaction or datum CBOR authority.
+- **Explicit Context Only**: PASS. The branch does not fetch or infer new chain
+  state; it only presents what the current envelope already says.
+- **The Library Is the Canonical Artifact**: PASS. The host renderer remains a
+  consumer of library output rather than a new ledger interpreter.
+- **Quality Gates**: PASS. The change is designed around deterministic snapshot
+  regression tests and limited documentation updates before any UI divergence.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-explain-parity/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+apps/tx-deep-diagnosis/
+├── src/TxDeepDiagnosisHost/Render/
+│   ├── Single.hs
+│   └── Summary.hs
+├── snapshot/Main.hs
+├── test/golden/value-not-conserved/
+│   ├── input.json
+│   └── expected/
+│       ├── explain.md
+│       └── summary.md
+└── README.md
+
+flake.nix
+README.md
+```
+
+**Structure Decision**: Keep the implementation entirely inside the
+`tx-deep-diagnosis` host renderer and its snapshot fixtures. No library schema
+changes or browser code changes are needed for this first parity branch.
+
+## Phase Plan
+
+1. **Reader-first summary layout**: Refactor `Render.Summary` so the headline,
+   verdict, failure summary, balance, and fees/resources appear before lower-
+   priority narrative sections.
+2. **Truth labeling**: Add explicit self-declared badges to metadata-derived
+   destinations and claims without weakening the distinction between registry-
+   resolved evidence and metadata assertions.
+3. **Single-file readability**: Wrap inline Mermaid sections in collapsed
+   details blocks in `Render.Single` while keeping the same underlying content.
+4. **Contract hardening**: Update the golden fixtures, add app-level explain
+   report docs, and verify the branch with the dedicated snapshot smoke plus
+   formatting checks.
+
+## Post-Design Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. The branch changes only wording,
+  ordering, and visibility controls in the renderer.
+- **Transaction Documents Own State**: PASS. The rendered headline/resources
+  summary is computed from the current envelope only.
+- **JSON Control Plane, CBOR Data Plane**: PASS. New text uses existing JSON
+  fields such as `claims`, `fee_lovelace`, `tx_size_bytes`, and per-redeemer
+  committed ex-units.
+- **Explicit Context Only**: PASS. No new external context is introduced.
+- **The Library Is the Canonical Artifact**: PASS. The host report remains a
+  consumer of existing library output.
+- **Quality Gates**: PASS. Snapshot smoke and formatting checks are sufficient
+  for this renderer-only branch.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required.

--- a/specs/006-explain-parity/quickstart.md
+++ b/specs/006-explain-parity/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Explain Markdown Parity Phase 1
+
+## 1. Compare the Current Golden Renderer Output
+
+Run the dedicated snapshot smoke check:
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke -o result-explain-smoke
+cat result-explain-smoke/snapshot.log
+```
+
+This verifies every file under `apps/tx-deep-diagnosis/test/golden/<case>/expected/`
+against the current pure renderers.
+
+## 2. Regenerate Golden Files Intentionally
+
+Build the snapshot executable and write fresh expected artifacts:
+
+```bash
+nix build .#packages.x86_64-linux.tx-deep-diagnosis-render-snapshot -o result-render-snapshot
+./result-render-snapshot/bin/tx-deep-diagnosis-render-snapshot \
+  --write apps/tx-deep-diagnosis/test/golden
+```
+
+Then inspect the markdown diff:
+
+```bash
+git diff -- apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+git diff -- apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+```
+
+## 3. Re-run the Explain Smoke After Code Changes
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke -o result-explain-smoke
+cat result-explain-smoke/snapshot.log
+```
+
+Success means the renderer and the committed golden artifacts agree again.
+
+## 4. Run Formatting
+
+```bash
+just format-check
+```
+
+## 5. Review the Reader-Facing Contract
+
+Check the top of the generated `explain.md` for the scoped goals of this
+feature:
+
+- headline before verdict
+- failures and balance above secondary sections
+- fees/resources near the top
+- self-declared claims visibly marked
+- Mermaid diagrams collapsed in the single-file report

--- a/specs/006-explain-parity/research.md
+++ b/specs/006-explain-parity/research.md
@@ -1,0 +1,103 @@
+# Research: Explain Markdown Parity Phase 1
+
+## Decision: Scope the Branch to the Current `main` Delta, Not the Original Issue Baseline
+
+The issue text was written before several explain-report improvements had
+already landed on `main`. Current `main` already includes parsed failure bodies,
+smart-contract call tables, outputs, datums, and the single-file explain
+renderer.
+
+**Rationale**: Planning against the stale baseline would duplicate work and
+mis-state the remaining gap. This branch should only target what is still
+missing on current `main`.
+
+**Alternatives considered**:
+
+- Implement the issue literally from the older baseline: rejected because it
+  would restate already-shipped sections and create noisy diffs.
+- Wait for a rewritten issue body: rejected because the current code makes the
+  remaining scope clear enough to proceed independently.
+
+## Decision: Derive the Headline from Existing Intent Content
+
+The headline will be synthesized only from fields already present in the
+current diagnosis envelope: existing claim summaries, the report title/subtitle,
+verdict state, and output-bucket evidence.
+
+**Rationale**: The issue explicitly allows an initial heuristic version before
+issue #57 lands. Current intent data is sufficient to produce a better
+above-the-fold line than the generic "Signing summary" title alone.
+
+**Alternatives considered**:
+
+- Wait for new `tx.intent` fields from issue #57: rejected because it blocks an
+  otherwise useful first parity branch.
+- Use only the existing title field: rejected because it is too generic to act
+  as a mainstream-inspector-style action line.
+
+## Decision: Build the Fees & Resources Panel from Existing Envelope Fields
+
+The new panel will use the fields already present on current `main`:
+`fee_lovelace`, `tx_size_bytes`, redeemer count, and the committed ex-units
+already exposed per script row.
+
+**Rationale**: The issue says partial data is acceptable. Summing committed
+per-redeemer ex-units in the renderer is enough for a first reader-facing panel
+without waiting for a new top-level intent field.
+
+**Alternatives considered**:
+
+- Add a new top-level total resource field in the ledger layer: rejected for
+  this branch because the renderer can compute the summary from current data.
+- Omit ex-units until issue #57: rejected because committed ex-units are already
+  present today.
+
+## Decision: Promote Human Failure Language Above the Raw Rule Name
+
+The current renderer already generates human-readable failure prose, but the
+raw ledger rule name remains the heading. This branch will invert that emphasis:
+lead with the reader-facing failure sentence and keep the raw rule as supporting
+detail.
+
+**Rationale**: That matches the issue's explicit parity goal and keeps the raw
+predicate available for grep/debug use.
+
+**Alternatives considered**:
+
+- Leave the raw rule name as the heading: rejected because it still forces the
+  reader to decode ledger jargon before they know what went wrong.
+- Drop the raw rule name completely: rejected because reviewers still need a
+  stable low-level anchor.
+
+## Decision: Collapse Mermaid Blocks Only in the Single-File Explain Renderer
+
+The directory-shaped artifact set (`summary.md`, `parties.mmd`, `topology.mmd`,
+`failures.mmd`, `value-flow.tsv`) remains unchanged. Only `Render.Single` will
+wrap its inline Mermaid sections in collapsed details blocks.
+
+**Rationale**: The issue's complaint is about the readability of the single-file
+`explain.md`. The directory artifacts are already opt-in by file.
+
+**Alternatives considered**:
+
+- Collapse or suppress the directory artifacts: rejected because they are meant
+  for consumers who explicitly want the raw cut files.
+- Collapse non-diagram sections like Balance: rejected because the survey only
+  demotes visualizations, not tabular truth.
+
+## Decision: Use the Existing Snapshot Harness as the Main Regression Contract
+
+Verification will continue to rely on the existing
+`tx-deep-diagnosis-render-snapshot` harness and the flake check
+`tx-explain-render-smoke`.
+
+**Rationale**: The renderer is pure, the golden input is already committed, and
+the snapshot artifacts directly capture the user-visible contract of this
+feature.
+
+**Alternatives considered**:
+
+- Add bespoke unit tests for string fragments only: rejected because they would
+  miss ordering regressions across the whole document.
+- Rely on manual markdown inspection: rejected because the feature is precisely
+  about presentation ordering and wording.

--- a/specs/006-explain-parity/spec.md
+++ b/specs/006-explain-parity/spec.md
@@ -1,0 +1,157 @@
+# Feature Specification: Explain Markdown Parity Phase 1
+
+**Feature Branch**: `006-explain-parity`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: GitHub issue #58: "explain.md: feature parity with mainstream tx inspectors (Cardanoscan / Cexplorer / Pool.pm / Etherscan / Solscan / Mempool.space / Starkscan)", scoped to the unblocked work on the current `main` branch
+
+## User Scenarios & Testing
+
+### User Story 1 - Triage a Transaction at First Glance (Priority: P1)
+
+A reader opens the generated `explain.md` and can understand the main action,
+overall verdict, failure summary, and balance impact without scrolling through
+raw sections or diagrams.
+
+**Why this priority**: The explain document exists to answer "what happened and
+why did it fail?" quickly. If the first screen does not do that, the report
+loses its primary value.
+
+**Independent Test**: Generate `explain.md` for the committed invalid fixture
+and verify the first visible sections are headline, verdict, parsed failures,
+balance, and fees/resources before secondary detail sections.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction with a meaningful title and a validation outcome,
+   **When** the explain document is rendered, **Then** it begins with a
+   one-line headline action summary above the verdict section.
+2. **Given** a transaction with one or more validation failures, **When** the
+   explain document is rendered, **Then** the failure section appears before
+   lower-priority narrative sections and each failure is introduced by a
+   human-readable sentence rather than a raw rule name alone.
+3. **Given** a transaction with known input/output totals, **When** the explain
+   document is rendered, **Then** the balance section appears before the
+   observations, claims, and effects sections.
+
+### User Story 2 - Distinguish Derived Facts from Self-Declared Claims (Priority: P2)
+
+A reader can tell which parts of the report come from decoded ledger evidence
+and which parts come only from transaction metadata.
+
+**Why this priority**: Mainstream inspectors consistently warn when an
+explanation is unverified. This report should not present metadata claims with
+the same visual authority as ledger-derived facts.
+
+**Independent Test**: Generate the invalid fixture report and verify that
+metadata-declared destinations and similar self-declared content are visibly
+flagged inline at the point where they are shown.
+
+**Acceptance Scenarios**:
+
+1. **Given** metadata-derived destinations or labels, **When** they are shown in
+   the explain document, **Then** each is visibly marked as self-declared and
+   not verified.
+2. **Given** registry-resolved parties and ledger-derived sections, **When** the
+   explain document is rendered, **Then** those sections remain distinct from
+   self-declared claims rather than being blended into one undifferentiated
+   list.
+
+### User Story 3 - Expand Visual Detail Only When Needed (Priority: P3)
+
+A reader can inspect topology and party diagrams on demand without having the
+default reading flow dominated by Mermaid blocks.
+
+**Why this priority**: The issue survey shows that diagrams are secondary to
+the textual verdict and tables. The default document should optimize for fast
+reading, not visual bulk.
+
+**Independent Test**: Generate `explain.md` and verify the embedded Mermaid
+sections are wrapped in collapsed detail blocks with readable summaries while
+the main text remains fully visible without expanding them.
+
+**Acceptance Scenarios**:
+
+1. **Given** a rendered explain document with inline diagrams, **When** the file
+   is opened, **Then** the diagram sections are collapsed by default behind
+   explicit summaries.
+2. **Given** a reader who wants the diagrams, **When** they expand a detail
+   block, **Then** the same Mermaid content remains available without loss.
+
+### Edge Cases
+
+- Transactions may be valid, invalid, incomplete, or rejected for the supplied
+  context; the headline and verdict must still read coherently.
+- Some transactions may have no metadata claims, no scripts, or no execution
+  units; the report must omit or simplify those sections without leaving broken
+  placeholders.
+- A failure summary may be absent even when the verdict is not valid; the
+  report must still prioritize verdict and balance information.
+- Multiple failures may be present; the section must keep them scannable rather
+  than collapsing them into one paragraph.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The explain document MUST render a one-line headline action
+  summary above the verdict section.
+- **FR-002**: The explain document MUST prioritize its section order so that
+  headline, verdict, failure summary, balance, and fees/resources appear before
+  lower-priority narrative or diagram sections.
+- **FR-003**: Validation failures in the explain document MUST be introduced by
+  human-readable failure sentences, while still preserving the raw rule name as
+  supporting detail.
+- **FR-004**: The explain document MUST include a fees/resources section showing
+  the fee, transaction size, redeemer count, and committed execution-unit totals
+  whenever those values are available in the current envelope.
+- **FR-005**: Any self-declared metadata-derived destination or claim shown in
+  the explain document MUST carry a visible self-declared warning at the point
+  of display.
+- **FR-006**: The single-file explain document MUST wrap embedded Mermaid
+  sections in collapsed detail blocks by default.
+- **FR-007**: The rendered markdown contract MUST remain deterministic for the
+  same diagnosis input so that snapshot tests continue to be meaningful.
+- **FR-008**: The repository documentation for `tx-deep-diagnosis` MUST describe
+  the intended top-level section order so reviewers can tell whether future
+  changes are accidental.
+
+### Key Entities
+
+- **Explain Document**: The single markdown report produced from one diagnosis
+  result, intended for human reading.
+- **Headline Action Summary**: The topmost one-line explanation of what the
+  transaction appears to do and how it ended.
+- **Failure Summary**: The ordered list of validation failures rendered in
+  reader-friendly language with raw rule names retained as supporting detail.
+- **Fees & Resources Panel**: The compact top-level summary of fee, size,
+  redeemer count, and execution-unit totals.
+- **Self-Declared Claim**: Any explanation element that comes from transaction
+  metadata rather than verified ledger evidence.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: In the committed invalid golden fixture, `explain.md` begins with
+  headline, verdict, validation failures, balance, and fees/resources before
+  observations, claims, effects, warnings, and diagrams.
+- **SC-002**: The same golden fixture shows a visible self-declared warning
+  wherever metadata-derived destinations or labels are displayed.
+- **SC-003**: All inline Mermaid sections in `explain.md` are collapsed behind
+  detail summaries in the generated snapshot output.
+- **SC-004**: Repository snapshot coverage detects the new ordering and wording
+  changes without requiring manual post-processing.
+- **SC-005**: The renderer change does not require new ledger fields beyond what
+  is already present on the current `main` branch.
+
+## Assumptions
+
+- This phase only covers the work that is unblocked on the current `main`
+  branch; features that require new `tx.intent` fields from issue #57 remain
+  out of scope.
+- The current envelope's existing title, validation failures, tx size, fee,
+  redeemer details, and execution-unit data are sufficient for the scoped
+  parity improvements.
+- The directory-shaped explain artifacts remain supported; this feature focuses
+  on the single-file markdown reading experience and shared section renderer.

--- a/specs/006-explain-parity/tasks.md
+++ b/specs/006-explain-parity/tasks.md
@@ -1,0 +1,147 @@
+# Tasks: Explain Markdown Parity Phase 1
+
+**Input**: Design documents from `/specs/006-explain-parity/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+**Tests**: Included because the feature is defined by deterministic markdown
+artifacts and the existing snapshot smoke is the primary contract.
+**Organization**: Tasks are grouped by user story so each report-level parity
+improvement can be implemented and verified independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel with other marked tasks in the same phase.
+- **[Story]**: Which user story this task belongs to.
+- Every task includes the main file path it changes or verifies.
+
+## Phase 1: Setup (Shared Documentation Surface)
+
+**Purpose**: Establish the app-local documentation that explains the report
+contract being changed in this branch.
+
+- [X] T001 Create `apps/tx-deep-diagnosis/README.md` with the explain artifact purpose, intended top-level section order, and snapshot verification commands
+
+---
+
+## Phase 2: Foundational (Blocking Renderer Prerequisites)
+
+**Purpose**: Add the shared renderer helpers and ordering structure used by all
+three user stories.
+
+- [X] T002 Add shared headline/resource extraction helpers in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T003 Add a reusable collapsed-diagram wrapper in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs`
+- [X] T004 Reorder `renderSummaryMarkdown` in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs` so reader-first sections can be inserted without duplicate passes
+
+**Checkpoint**: The renderer has a stable scaffold for headline/resources,
+claim-badge rendering, and collapsed single-file diagrams.
+
+---
+
+## Phase 3: User Story 1 - Triage a Transaction at First Glance (Priority: P1) 🎯 MVP
+
+**Goal**: A reader sees the action headline, verdict, failure summary, balance,
+and fees/resources before lower-priority sections.
+
+**Independent Test**: Regenerate the invalid golden fixture and confirm the top
+of both `summary.md` and `explain.md` now presents headline, verdict,
+validation failures, balance, and fees/resources before the narrative sections.
+
+### Tests for User Story 1
+
+- [X] T005 [US1] Update `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md` for the new top-of-file ordering and headline/resources content
+- [X] T006 [US1] Update `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md` for the same ordering and wording changes
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Render a one-line headline action summary in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T008 [US1] Promote human-readable failure summaries ahead of raw rule names in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T009 [US1] Add a fees/resources section using current envelope fields in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T010 [US1] Verify the scoped renderer contract with `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
+
+**Checkpoint**: The explain report is usable as a first-screen triage tool even
+before the reader expands diagrams or reads claims.
+
+---
+
+## Phase 4: User Story 2 - Distinguish Derived Facts from Self-Declared Claims (Priority: P2)
+
+**Goal**: Metadata-derived destinations and claims are clearly marked as
+unverified without weakening the distinction from registry-resolved evidence.
+
+**Independent Test**: Generate the invalid fixture report and confirm every
+metadata-derived destination or claim shown in the report carries visible
+self-declared warning text inline.
+
+### Tests for User Story 2
+
+- [X] T011 [US2] Refresh `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md` for self-declared badges in observations and claims
+- [X] T012 [US2] Refresh `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md` for the same badge behavior
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Add inline self-declared warning text to metadata destination rendering in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T014 [US2] Add equivalent self-declared provenance treatment to metadata-driven claims in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T015 [US2] Re-run `nix build .#checks.x86_64-linux.tx-explain-render-smoke` after the badge changes
+
+**Checkpoint**: Readers can visually separate metadata assertions from
+ledger-derived facts.
+
+---
+
+## Phase 5: User Story 3 - Expand Visual Detail Only When Needed (Priority: P3)
+
+**Goal**: Inline Mermaid sections remain available in `explain.md` but are
+collapsed by default so the report reads like a document first.
+
+**Independent Test**: Regenerate `explain.md` and confirm the Parties, Topology,
+and Failure overlay sections appear under collapsed detail summaries while the
+rest of the report remains directly readable.
+
+### Tests for User Story 3
+
+- [X] T016 [US3] Update `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md` to assert collapsed diagram sections
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Wrap inline Parties, Topology, and Failure overlay blocks with collapsed details in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs`
+- [X] T018 [US3] Re-run `nix build .#checks.x86_64-linux.tx-explain-render-smoke` after the single-file diagram changes
+
+**Checkpoint**: The single-file explain report keeps the same visual data while
+defaulting to a cleaner reading flow.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finish documentation and repository-level verification for the PR.
+
+- [X] T019 [P] Update the app-local explain contract notes in `apps/tx-deep-diagnosis/README.md` to match the final implementation
+- [X] T020 [P] Run `just format-check`
+- [X] T021 Run a final `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (Phase 1)** starts immediately and establishes the local docs target.
+- **Foundational (Phase 2)** depends on Setup and blocks all user stories
+  because the same renderer files are shared by every story.
+- **User Story 1 (Phase 3)** depends on Foundational and delivers the MVP.
+- **User Story 2 (Phase 4)** depends on Foundational and should be applied after
+  the reader-first ordering because it edits the same summary renderer.
+- **User Story 3 (Phase 5)** depends on Foundational and is isolated to the
+  single-file renderer plus explain snapshot.
+- **Polish (Phase 6)** depends on the selected story work being complete.
+
+## Parallel Opportunities
+
+- T019 and T020 can run in parallel after the renderer behavior is stable.
+- The summary and explain golden file refresh tasks within each story should be
+  done sequentially because they update the same fixture set.
+
+## Implementation Strategy
+
+1. Establish the README target and the shared renderer scaffolding.
+2. Implement the P1 reader-first ordering and resource summary first.
+3. Add self-declared claim badges.
+4. Collapse inline diagrams in the single-file renderer.
+5. Refresh the golden outputs and finish with snapshot plus formatting checks.


### PR DESCRIPTION
Part of #58.

## What changed

- reordered the explain report around reader-first triage using only fields already present on current `main`
- added a one-line headline action summary, promoted parsed failures ahead of lower-level detail, and surfaced a compact fees/resources panel near the top
- moved balance into the shared summary renderer so `summary.md` and `explain.md` stay aligned instead of burying balance deep in the single-file output
- marked metadata-derived destinations and claims inline as self-declared / not verified
- collapsed the inline Mermaid sections in `explain.md` while leaving the directory-shaped artifacts unchanged
- added `apps/tx-deep-diagnosis/README.md` plus the full speckit artifact set under `specs/006-explain-parity/`

## Why this scope

Issue #58 was written against an older explain baseline. Current `main` already had smart-contract calls, outputs, datums, and parsed failure bodies, so this PR focuses on the remaining unblocked work:

- `A1` headline action line
- `A2` section reordering
- `A3` collapsed inline diagrams
- `A4` self-declared badges
- `A5` fees/resources panel
- `C3` documented section order

The issue #57-dependent additions stay out of this branch.

## Main files to review

- `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
- `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Single.hs`
- `apps/tx-deep-diagnosis/README.md`
- `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md`
- `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md`
- `specs/006-explain-parity/`

## Verification

- `nix build .#checks.x86_64-linux.tx-explain-render-smoke -o result-explain-smoke`
- `cat result-explain-smoke/snapshot.log`
- `just format-check`

## Outcome

- both markdown reports now open with title/tx id, headline, verdict, validation failures, balance, and fees/resources
- the single-file explain report no longer forces Mermaid blocks into the default reading flow
- the self-declared metadata path is called out explicitly where it is rendered
