### PR TITLE
feat: expose required signer coverage in tx.intent

### DIFF
--- a/apps/tx-deep-diagnosis/README.md
+++ b/apps/tx-deep-diagnosis/README.md
@@ -11,13 +11,16 @@ JSON envelope. The reader-first contract for the top of the report is:
 6. Fees & resources
 7. Observations
 8. Claims
-9. Effects
-10. Smart-contract calls
-11. Withdrawals
-12. Outputs
-13. Datums
-14. Warnings
-15. Diagrams
+9. Signer value perspective
+10. Critical effects
+11. Declared required signers
+12. Missing required signers
+13. Smart-contract calls
+14. Withdrawals
+15. Outputs
+16. Datums
+17. Warnings
+18. Diagrams
 
 `summary.md` uses that order directly. `explain.md` uses the same summary and
 then embeds the Mermaid diagrams at the end inside collapsed `<details>` blocks.

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -112,6 +112,13 @@ Inputs that also receive outputs (same payment credential on both sides):
 | Mint/burn | No mint/burn |  |
 | Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
 
+## Declared required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
+
 ## Missing required signers
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -112,6 +112,13 @@ Inputs that also receive outputs (same payment credential on both sides):
 | Mint/burn | No mint/burn |  |
 | Collateral | 1 collateral input | total 1565693 lovelace / return 50005673583 lovelace |
 
+## Declared required signers
+
+| Label | Value | Detail |
+|-------|-------|--------|
+| declared required signer | 8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1 | declared required signer not present in vkey or bootstrap witnesses |
+| declared required signer | f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e | declared required signer not present in vkey or bootstrap witnesses |
+
 ## Missing required signers
 
 | Label | Value | Detail |

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
@@ -304,6 +304,26 @@
               "title": "Critical effects"
             },
             {
+              "empty": "No declared required signers.",
+              "rows": [
+                {
+                  "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                  "label": "declared required signer",
+                  "path": "[\"intent\",\"signing\",\"required_signers\",\"#0\",\"hash\"]",
+                  "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"
+                },
+                {
+                  "copyValue": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                  "label": "declared required signer",
+                  "path": "[\"intent\",\"signing\",\"required_signers\",\"#1\",\"hash\"]",
+                  "value": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e"
+                }
+              ],
+              "title": "Declared required signers"
+            },
+            {
               "empty": "None missing.",
               "rows": [
                 {
@@ -337,8 +357,22 @@
               }
             ],
             "present_bootstrap_witness_count": 0,
+            "present_bootstrap_witnesses": [],
             "present_vkey_witness_count": 0,
-            "required_signer_count": 2
+            "present_vkey_witnesses": [],
+            "required_signer_count": 2,
+            "required_signers": [
+              {
+                "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                "source": "tx_body.required_signers",
+                "witness_status": "missing"
+              },
+              {
+                "hash": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                "source": "tx_body.required_signers",
+                "witness_status": "missing"
+              }
+            ]
           },
           "subtitle": "1 metadata claim / 2 missing required signers / 2 redeemers",
           "title": "Signing summary",

--- a/flake.nix
+++ b/flake.nix
@@ -226,6 +226,10 @@
               and .result.intent.sections[0].title == "Signer value perspective"
               and (.result.intent.withdrawals | type) == "array"
               and (.result.intent.withdrawals | length) == 0
+              and (.result.intent.signing.required_signers | type) == "array"
+              and (.result.intent.signing.required_signers | length) == 0
+              and (.result.intent.signing.present_vkey_witnesses | type) == "array"
+              and (.result.intent.signing.present_bootstrap_witnesses | type) == "array"
               and .result.intent.value.net_spend_known == true
               and .result.intent.value.signer_lovelace.known == true
               and .result.intent.value.signer_lovelace.net_lovelace == "-5900913"

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
@@ -404,6 +404,10 @@ intentSummaryJson args tx =
         presentBootstrapHexes =
             keyHashHex . Keys.bootstrapWitKeyHash
                 <$> toList (wits ^. Core.bootAddrTxWitsL)
+        presentVKeyHexSet =
+            Set.fromList presentVKeyHexes
+        presentBootstrapHexSet =
+            Set.fromList presentBootstrapHexes
         presentSignerHexSet =
             Set.fromList (presentVKeyHexes <> presentBootstrapHexes)
         signerHexSet =
@@ -461,6 +465,11 @@ intentSummaryJson args tx =
                 (bucketCount SignerControlled outputValueBuckets)
                 (length resolvedInputOutputs)
                 (length outputs)
+        requiredSignerRows =
+            zipWith
+                (requiredSignerCoverageRowJson presentVKeyHexSet presentBootstrapHexSet)
+                [0 :: Int ..]
+                requiredSignerHexes
         intentEffects =
             [
                 ( "Consumes inputs"
@@ -549,6 +558,10 @@ intentSummaryJson args tx =
                         "No transaction effects reported."
                         (zipWith effectRowJson [0 :: Int ..] intentEffects)
                    , sectionJson
+                        "Declared required signers"
+                        "No declared required signers."
+                        requiredSignerRows
+                   , sectionJson
                         "Missing required signers"
                         "None missing."
                         (zipWith missingSignerRowJson [0 :: Int ..] missingSignerHexes)
@@ -557,8 +570,16 @@ intentSummaryJson args tx =
             , "signing"
                 .= Aeson.object
                     [ "required_signer_count" .= length requiredSignerHexes
+                    , "required_signers"
+                        .= map
+                            (requiredSignerCoverageJson presentVKeyHexSet presentBootstrapHexSet)
+                            requiredSignerHexes
                     , "present_vkey_witness_count" .= length presentVKeyHexes
+                    , "present_vkey_witnesses"
+                        .= map presentVKeyWitnessJson presentVKeyHexes
                     , "present_bootstrap_witness_count" .= length presentBootstrapHexes
+                    , "present_bootstrap_witnesses"
+                        .= map presentBootstrapWitnessJson presentBootstrapHexes
                     , "missing_vkey_witness_count" .= length missingSignerHexes
                     , "missing_vkey_witnesses" .= map missingSignerJson missingSignerHexes
                     ]
@@ -676,6 +697,20 @@ missingSignerRowJson index signerHash =
         signerHash
         "declared required signer not present in vkey or bootstrap witnesses"
 
+requiredSignerCoverageRowJson ::
+    Set.Set T.Text ->
+    Set.Set T.Text ->
+    Int ->
+    T.Text ->
+    Aeson.Value
+requiredSignerCoverageRowJson presentVKeyHexSet presentBootstrapHexSet index signerHash =
+    rowJson
+        "declared required signer"
+        signerHash
+        (encodePath ["intent", "signing", "required_signers", T.pack ("#" <> show index), "hash"])
+        signerHash
+        (requiredSignerCoverageDetail (signerWitnessStatus presentVKeyHexSet presentBootstrapHexSet signerHash))
+
 rowJson :: T.Text -> T.Text -> T.Text -> T.Text -> T.Text -> Aeson.Value
 rowJson label value path copyValue detail =
     Aeson.object
@@ -685,6 +720,37 @@ rowJson label value path copyValue detail =
         , "copyValue" .= copyValue
         , "detail" .= detail
         ]
+
+requiredSignerCoverageJson ::
+    Set.Set T.Text ->
+    Set.Set T.Text ->
+    T.Text ->
+    Aeson.Value
+requiredSignerCoverageJson presentVKeyHexSet presentBootstrapHexSet signerHash =
+    Aeson.object
+        [ "hash" .= signerHash
+        , "source" .= ("tx_body.required_signers" :: T.Text)
+        , "witness_status"
+            .= signerWitnessStatus presentVKeyHexSet presentBootstrapHexSet signerHash
+        ]
+
+signerWitnessStatus ::
+    Set.Set T.Text ->
+    Set.Set T.Text ->
+    T.Text ->
+    T.Text
+signerWitnessStatus presentVKeyHexSet presentBootstrapHexSet signerHash
+    | signerHash `Set.member` presentVKeyHexSet = "present_vkey"
+    | signerHash `Set.member` presentBootstrapHexSet = "present_bootstrap"
+    | otherwise = "missing"
+
+requiredSignerCoverageDetail :: T.Text -> T.Text
+requiredSignerCoverageDetail "present_vkey" =
+    "declared required signer already covered by a vkey witness"
+requiredSignerCoverageDetail "present_bootstrap" =
+    "declared required signer already covered by a bootstrap witness"
+requiredSignerCoverageDetail _ =
+    "declared required signer not present in vkey or bootstrap witnesses"
 
 data ValueBucket
     = SignerControlled

--- a/nix/ledger-functional-openapi.nix
+++ b/nix/ledger-functional-openapi.nix
@@ -313,7 +313,59 @@
                               empty = "No transaction effects reported.";
                               rows = [ ];
                             }
+                            {
+                              title = "Declared required signers";
+                              empty = "No declared required signers.";
+                              rows = [
+                                {
+                                  label = "declared required signer";
+                                  value = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                  path = "[\"intent\",\"signing\",\"required_signers\",\"#0\",\"hash\"]";
+                                  copyValue = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                  detail = "declared required signer not present in vkey or bootstrap witnesses";
+                                }
+                              ];
+                            }
+                            {
+                              title = "Missing required signers";
+                              empty = "None missing.";
+                              rows = [
+                                {
+                                  label = "declared required signer not present in vkey or bootstrap witnesses";
+                                  value = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                  path = "[\"intent\",\"signing\",\"missing_vkey_witnesses\",\"#0\",\"hash\"]";
+                                  copyValue = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                  detail = "declared required signer not present in vkey or bootstrap witnesses";
+                                }
+                              ];
+                            }
                           ];
+                          signing = {
+                            missing_vkey_witness_count = 2;
+                            missing_vkey_witnesses = [
+                              {
+                                hash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                reason = "declared required signer not present in vkey or bootstrap witnesses";
+                              }
+                            ];
+                            present_bootstrap_witness_count = 0;
+                            present_bootstrap_witnesses = [ ];
+                            present_vkey_witness_count = 0;
+                            present_vkey_witnesses = [ ];
+                            required_signer_count = 2;
+                            required_signers = [
+                              {
+                                hash = "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1";
+                                source = "tx_body.required_signers";
+                                witness_status = "missing";
+                              }
+                              {
+                                hash = "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e";
+                                source = "tx_body.required_signers";
+                                witness_status = "missing";
+                              }
+                            ];
+                          };
                           withdrawals = [
                             {
                               index = 0;

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -422,8 +422,60 @@ it does not sign, validate, submit, balance, patch, or mutate the transaction.
         "title": "Critical effects",
         "empty": "No transaction effects reported.",
         "rows": []
+      },
+      {
+        "title": "Declared required signers",
+        "empty": "No declared required signers.",
+        "rows": [
+          {
+            "label": "declared required signer",
+            "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+            "path": "[\"intent\",\"signing\",\"required_signers\",\"#0\",\"hash\"]",
+            "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+            "detail": "declared required signer not present in vkey or bootstrap witnesses"
+          }
+        ]
+      },
+      {
+        "title": "Missing required signers",
+        "empty": "None missing.",
+        "rows": [
+          {
+            "label": "declared required signer not present in vkey or bootstrap witnesses",
+            "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+            "path": "[\"intent\",\"signing\",\"missing_vkey_witnesses\",\"#0\",\"hash\"]",
+            "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+            "detail": "declared required signer not present in vkey or bootstrap witnesses"
+          }
+        ]
       }
     ],
+    "signing": {
+      "missing_vkey_witness_count": 2,
+      "missing_vkey_witnesses": [
+        {
+          "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+          "reason": "declared required signer not present in vkey or bootstrap witnesses"
+        }
+      ],
+      "present_bootstrap_witness_count": 0,
+      "present_bootstrap_witnesses": [],
+      "present_vkey_witness_count": 0,
+      "present_vkey_witnesses": [],
+      "required_signer_count": 2,
+      "required_signers": [
+        {
+          "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+          "source": "tx_body.required_signers",
+          "witness_status": "missing"
+        },
+        {
+          "hash": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+          "source": "tx_body.required_signers",
+          "witness_status": "missing"
+        }
+      ]
+    },
     "withdrawals": [
       {
         "index": 0,
@@ -470,7 +522,10 @@ may render `metrics`, `claims`, `sections`, and `warnings` directly, while the
 additional structured fields (`metadata_claims`, `signing`, `value`,
 `features`, `withdrawals`, `effects`, and `context`) remain available for API
 consumers. Each `withdrawals[]` row exposes the serialized reward-account hex,
-its network and staking credential, and the withdrawn lovelace amount.
+its network and staking credential, and the withdrawn lovelace amount. Each
+`signing.required_signers[]` row exposes the declared signer hash, its source,
+and whether that signer is already covered by a vkey witness, a bootstrap
+witness, or still missing.
 When `context.producer_txs` resolves every regular input, `value.signer_lovelace`
 reports a known net ADA amount from resolved signer-controlled inputs minus
 signer-controlled outputs. Ownership is intentionally conservative: only output

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -429,8 +429,60 @@
                               "empty": "No transaction effects reported.",
                               "rows": [],
                               "title": "Critical effects"
+                            },
+                            {
+                              "empty": "No declared required signers.",
+                              "rows": [
+                                {
+                                  "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                                  "label": "declared required signer",
+                                  "path": "[\"intent\",\"signing\",\"required_signers\",\"#0\",\"hash\"]",
+                                  "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"
+                                }
+                              ],
+                              "title": "Declared required signers"
+                            },
+                            {
+                              "empty": "None missing.",
+                              "rows": [
+                                {
+                                  "copyValue": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                  "detail": "declared required signer not present in vkey or bootstrap witnesses",
+                                  "label": "declared required signer not present in vkey or bootstrap witnesses",
+                                  "path": "[\"intent\",\"signing\",\"missing_vkey_witnesses\",\"#0\",\"hash\"]",
+                                  "value": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1"
+                                }
+                              ],
+                              "title": "Missing required signers"
                             }
                           ],
+                          "signing": {
+                            "missing_vkey_witness_count": 2,
+                            "missing_vkey_witnesses": [
+                              {
+                                "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                "reason": "declared required signer not present in vkey or bootstrap witnesses"
+                              }
+                            ],
+                            "present_bootstrap_witness_count": 0,
+                            "present_bootstrap_witnesses": [],
+                            "present_vkey_witness_count": 0,
+                            "present_vkey_witnesses": [],
+                            "required_signer_count": 2,
+                            "required_signers": [
+                              {
+                                "hash": "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+                                "source": "tx_body.required_signers",
+                                "witness_status": "missing"
+                              },
+                              {
+                                "hash": "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+                                "source": "tx_body.required_signers",
+                                "witness_status": "missing"
+                              }
+                            ]
+                          },
                           "subtitle": "1 metadata claim / 2 missing required signers / 2 redeemers",
                           "title": "Signing summary",
                           "tx_id": "0000000000000000000000000000000000000000000000000000000000000000",

--- a/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
@@ -3,7 +3,7 @@
   "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-intent-result.schema.json",
   "title": "Cardano Ledger WASI Transaction Intent Result",
   "type": "object",
-  "required": ["title", "subtitle", "metrics", "claims", "sections", "withdrawals", "warnings"],
+  "required": ["title", "subtitle", "metrics", "claims", "signing", "sections", "withdrawals", "warnings"],
   "properties": {
     "title": { "type": "string" },
     "subtitle": { "type": "string" },
@@ -24,10 +24,7 @@
       "type": "array",
       "items": { "type": "object", "additionalProperties": true }
     },
-    "signing": {
-      "type": "object",
-      "additionalProperties": true
-    },
+    "signing": { "$ref": "#/$defs/signing" },
     "value": {
       "type": "object",
       "properties": {
@@ -94,6 +91,10 @@
       },
       "additionalProperties": true
     },
+    "count": {
+      "type": "integer",
+      "minimum": 0
+    },
     "claim": {
       "type": "object",
       "required": ["label", "value", "detail"],
@@ -101,6 +102,73 @@
         "label": { "type": "string" },
         "value": { "type": "string" },
         "detail": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "signerReference": {
+      "type": "object",
+      "required": ["hash", "source"],
+      "properties": {
+        "hash": { "type": "string" },
+        "source": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "missingSigner": {
+      "type": "object",
+      "required": ["hash", "reason"],
+      "properties": {
+        "hash": { "type": "string" },
+        "reason": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "requiredSignerCoverage": {
+      "type": "object",
+      "required": ["hash", "source", "witness_status"],
+      "properties": {
+        "hash": { "type": "string" },
+        "source": { "type": "string" },
+        "witness_status": {
+          "type": "string",
+          "enum": ["present_vkey", "present_bootstrap", "missing"]
+        }
+      },
+      "additionalProperties": true
+    },
+    "signing": {
+      "type": "object",
+      "required": [
+        "missing_vkey_witness_count",
+        "missing_vkey_witnesses",
+        "present_bootstrap_witness_count",
+        "present_bootstrap_witnesses",
+        "present_vkey_witness_count",
+        "present_vkey_witnesses",
+        "required_signer_count",
+        "required_signers"
+      ],
+      "properties": {
+        "missing_vkey_witness_count": { "$ref": "#/$defs/count" },
+        "missing_vkey_witnesses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/missingSigner" }
+        },
+        "present_bootstrap_witness_count": { "$ref": "#/$defs/count" },
+        "present_bootstrap_witnesses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/signerReference" }
+        },
+        "present_vkey_witness_count": { "$ref": "#/$defs/count" },
+        "present_vkey_witnesses": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/signerReference" }
+        },
+        "required_signer_count": { "$ref": "#/$defs/count" },
+        "required_signers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/requiredSignerCoverage" }
+        }
       },
       "additionalProperties": true
     },

--- a/specs/008-intent-required-signers/data-model.md
+++ b/specs/008-intent-required-signers/data-model.md
@@ -1,0 +1,35 @@
+# Data Model: tx.intent Required Signer Coverage
+
+## Signer Reference
+
+Used for present witness lists.
+
+| Field | Type | Notes |
+|---|---|---|
+| `hash` | string | Signer hash in lowercase hex |
+| `source` | string | `tx_body.required_signers`, `witness_set.vkey`, or `witness_set.bootstrap` |
+
+## Required Signer Row
+
+One element of `result.intent.signing.required_signers[]`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `hash` | string | Declared required signer hash |
+| `source` | string | Always `tx_body.required_signers` |
+| `witness_status` | string | `present_vkey`, `present_bootstrap`, or `missing` |
+
+## Report Projection
+
+The markdown report projects each required signer row to:
+
+| Column | Source |
+|---|---|
+| `Label` | fixed text describing a declared required signer |
+| `Value` | `required_signers[].hash` |
+| `Detail` | human-readable witness coverage from `witness_status` |
+
+## Compatibility Rule
+
+If the new signer arrays are absent in an older diagnosis envelope, the
+renderer behaves as if they were empty and omits the new section.

--- a/specs/008-intent-required-signers/plan.md
+++ b/specs/008-intent-required-signers/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: tx.intent Required Signer Coverage
+
+**Branch**: `008-intent-required-signers` | **Date**: 2026-05-03 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/008-intent-required-signers/spec.md`
+
+## Status
+
+- **Completed**: Scope selection, code-path audit, `tx.intent.signing`
+  expansion, contract/schema updates, golden refresh, and verification.
+- **Current**: Prepare the branch for review and open the issue-57 follow-up
+  PR.
+- **Blockers**: None.
+
+## Summary
+
+Implement the required-signer coverage slice of issue #57. The repo already
+knows the declared required signers and the present witness sets in
+`tx.witness.plan`, but `tx.intent` only exposes missing signer hashes and
+counts. This branch adds the full declared signer list plus witness coverage to
+`tx.intent.signing`, documents the contract change, and surfaces a generic
+`Declared required signers` table in the markdown report.
+
+## Technical Context
+
+**Language/Version**: Haskell2010 via the repository's existing GHC/Nix setup
+
+**Primary Dependencies**: `aeson`, `text`, `containers`, existing
+`tx.intent` / `tx.witness.plan` helpers, `tx-deep-diagnosis` generic section
+renderer, Nix/OpenAPI checks
+
+**Storage**: None. This is a pure transaction-to-JSON and JSON-to-markdown
+transformation.
+
+**Testing**: `tx-intent-smoke`, `tx-explain-render-smoke`,
+`ledger-functional-openapi-check`, and `just format-check`
+
+**Constraints**: Keep the output deterministic; preserve compatibility with
+older diagnosis envelopes; reuse existing generic section/table shapes where
+possible
+
+## Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. Required signer and witness data come
+  directly from the decoded transaction body and witness set.
+- **Transaction Documents Own State**: PASS. No cross-call or cached authority.
+- **JSON Control Plane, CBOR Data Plane**: PASS. The change adds JSON views over
+  already-decoded signer and witness data.
+- **Explicit Context Only**: PASS. No extra provider or chain state.
+- **The Library Is the Canonical Artifact**: PASS. The renderer follows library
+  output.
+- **Quality Gates**: PASS. Contract docs, snapshots, and checks are updated
+  together.
+
+## Project Structure
+
+```text
+specs/008-intent-required-signers/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+
+libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+apps/tx-deep-diagnosis/test/golden/value-not-conserved/
+specs/001-ledger-functional-layer/{contracts,schemas,openapi}/
+nix/ledger-functional-openapi.nix
+flake.nix
+```
+
+## Phase Plan
+
+1. Extend `tx.intent.signing` to emit the full required signer arrays and
+   witness coverage.
+2. Add a generic `Declared required signers` section row set to `intent.sections`.
+3. Update the contract docs, stored diagnosis input, and golden markdown.
+4. Verify smoke, snapshot, OpenAPI, and formatting checks.
+
+## Post-Design Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. Signer coverage is derived entirely
+  from the decoded tx body and witness set.
+- **Transaction Documents Own State**: PASS. Pure deterministic transformation.
+- **JSON Control Plane, CBOR Data Plane**: PASS. The signer arrays are JSON
+  views, not new canonical data.
+- **Explicit Context Only**: PASS. No hidden context.
+- **The Library Is the Canonical Artifact**: PASS. Report changes remain driven
+  by library output.
+- **Quality Gates**: PASS. This branch is bounded by existing deterministic
+  checks.

--- a/specs/008-intent-required-signers/quickstart.md
+++ b/specs/008-intent-required-signers/quickstart.md
@@ -1,0 +1,27 @@
+# Quickstart: tx.intent Required Signer Coverage
+
+## Verify the intent contract
+
+```bash
+nix build .#checks.x86_64-linux.tx-intent-smoke -o result-intent-smoke
+cat result-intent-smoke/response.json | jq '.result.intent.signing'
+```
+
+## Verify the report render
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke -o result-explain-smoke
+cat result-explain-smoke/snapshot.log
+```
+
+## Verify the documented contract
+
+```bash
+nix build .#checks.x86_64-linux.ledger-functional-openapi-check -o result-openapi-check
+```
+
+## Formatting
+
+```bash
+just format-check
+```

--- a/specs/008-intent-required-signers/research.md
+++ b/specs/008-intent-required-signers/research.md
@@ -1,0 +1,23 @@
+# Research: tx.intent Required Signer Coverage
+
+## Findings
+
+- `tx.witness.plan` already emits `required_signers`,
+  `present_vkey_witnesses`, and `present_bootstrap_witnesses`; `tx.intent`
+  computes the same counts but currently drops those arrays.
+- `tx.intent.sections` already feeds the generic markdown section renderer, so
+  adding one more signer coverage table there avoids bespoke renderer logic.
+- The current SundaeSwap diagnosis fixture already contains two declared
+  required signers and zero present witnesses, so it exercises the non-empty
+  missing case without needing a new transaction fixture.
+- The `tx-intent` schema currently treats `signing` as an open object; this
+  branch can make the signer arrays explicit in the contract.
+
+## Rejected Alternatives
+
+- **Renderer-only join against `tx.witness.plan`**: rejected because the issue
+  is specifically about fields missing from `tx.intent`.
+- **Only expose `required_signers[]` without witness arrays**: rejected because
+  the reader still would not know whether each signer is already satisfied.
+- **Replace the existing `Missing required signers` section**: rejected because
+  that table still usefully highlights the failure-specific subset.

--- a/specs/008-intent-required-signers/spec.md
+++ b/specs/008-intent-required-signers/spec.md
@@ -1,0 +1,107 @@
+# Feature Specification: tx.intent Required Signer Coverage
+
+**Feature Branch**: `008-intent-required-signers`
+**Created**: 2026-05-03
+**Status**: Draft
+**Input**: GitHub issue #57: "tx.intent: information audit — fields decoded by the ledger but dropped from the envelope", scoped to the missing full required-signer list on current `main`
+
+## User Scenarios & Testing
+
+### User Story 1 - See Every Declared Required Signer (Priority: P1)
+
+An API consumer calls `tx.intent` and can see every signer hash the
+transaction body declares as required, not only the subset that is missing.
+
+**Why this priority**: The current intent envelope only exposes
+`missing_vkey_witnesses`, so readers cannot see who the transaction claims
+authority from when all signers are present, or even which declared signers are
+already satisfied in partially signed transactions.
+
+**Independent Test**: Run `tx-intent-smoke` and verify the signing object
+always includes explicit signer arrays, then render the committed SundaeSwap
+fixture and verify the non-empty declared required-signer list appears in the
+stored diagnosis envelope.
+
+**Acceptance Scenarios**:
+
+1. **Given** a transaction body with declared required signers, **When**
+   `tx.intent` runs, **Then** the response includes one structured row per
+   declared required signer.
+2. **Given** a transaction body with no declared required signers, **When**
+   `tx.intent` runs, **Then** the response still includes `required_signers: []`
+   rather than omitting the field.
+
+### User Story 2 - Tell Whether Each Required Signer Is Already Witnessed (Priority: P2)
+
+A reader can tell for each declared required signer whether it is already
+covered by a vkey witness, a bootstrap witness, or is still missing.
+
+**Why this priority**: The authorization story is incomplete without coverage
+status. A full signer list with no witnessed/missing distinction still leaves
+the reader to cross-join multiple arrays manually.
+
+**Independent Test**: Render the current invalid golden fixture and verify the
+report includes a `Declared required signers` table whose detail column marks
+each signer as present or missing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a declared required signer whose hash matches a vkey witness,
+   **When** `tx.intent` runs, **Then** its row is marked as present via vkey
+   witness.
+2. **Given** a declared required signer whose hash matches a bootstrap witness,
+   **When** `tx.intent` runs, **Then** its row is marked as present via
+   bootstrap witness.
+3. **Given** a declared required signer whose hash matches neither witness
+   source, **When** `tx.intent` runs, **Then** its row is marked missing.
+
+### Edge Cases
+
+- Transactions with zero declared required signers must keep the response shape
+  deterministic.
+- A signer may be witnessed via bootstrap rather than vkey witness.
+- The renderer must tolerate older diagnosis envelopes that predate the new
+  signer arrays.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `tx.intent.signing` MUST include `required_signers`.
+- **FR-002**: Each `required_signers[]` item MUST include the signer hash, its
+  source, and witness coverage status.
+- **FR-003**: `tx.intent.signing` MUST include explicit
+  `present_vkey_witnesses` and `present_bootstrap_witnesses` arrays.
+- **FR-004**: The `tx.intent` contract documentation and OpenAPI example MUST
+  document the expanded `signing` shape in the same PR.
+- **FR-005**: The explain report MUST surface a `Declared required signers`
+  table derived from the new `tx.intent` data.
+- **FR-006**: Older stored diagnosis envelopes without the new arrays MUST
+  still render successfully.
+
+### Key Entities
+
+- **Declared Required Signer**: One hash listed in `tx_body.required_signers`.
+- **Signer Coverage Status**: Whether a declared signer is already satisfied by
+  a vkey witness, a bootstrap witness, or is currently missing.
+- **Declared Required Signers Section**: The report table that shows every
+  declared signer together with its coverage status.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: `tx-intent-smoke` asserts that the expanded signer arrays are
+  always present, even when empty.
+- **SC-002**: The stored SundaeSwap diagnosis envelope and golden markdown
+  outputs show the full declared required-signer set, not only the missing
+  subset.
+- **SC-003**: Snapshot and OpenAPI checks stay deterministic and pass without
+  manual post-processing.
+
+## Assumptions
+
+- This branch is another focused slice of issue #57, not a full closure.
+- The current SundaeSwap fixture is sufficient to verify the non-empty case.
+- Reusing the existing `sections[]` table shape is preferred over inventing a
+  renderer-only special case.

--- a/specs/008-intent-required-signers/tasks.md
+++ b/specs/008-intent-required-signers/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: tx.intent Required Signer Coverage
+
+**Input**: Design documents from `/specs/008-intent-required-signers/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+**Tests**: Included because this feature changes the public `tx.intent`
+signing contract and the generated report snapshots.
+
+## Phase 1: Library and contract
+
+- [X] T001 Extend `tx.intent.signing` with explicit signer arrays in `libs/cardano-ledger-inspector/src/Conway/Inspector.hs`
+- [X] T002 Add a `Declared required signers` section to `intent.sections` in `libs/cardano-ledger-inspector/src/Conway/Inspector.hs`
+- [X] T003 Update `specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json` for the expanded signing object
+- [X] T004 Update `specs/001-ledger-functional-layer/contracts/ledger-functional-api.md` with the signer coverage shape
+- [X] T005 Update `nix/ledger-functional-openapi.nix` and regenerate `specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json`
+- [X] T006 Strengthen `tx-intent-smoke` in `flake.nix` to assert the signer arrays are always present
+
+## Phase 2: Renderer and fixtures
+
+- [X] T007 Refresh `apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json` with the new signing fields and section rows
+- [X] T008 Refresh `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md`
+- [X] T009 Refresh `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md`
+- [X] T010 Update `apps/tx-deep-diagnosis/README.md` if the visible report section contract changes
+
+## Phase 3: Verification
+
+- [X] T011 Run `nix build .#checks.x86_64-linux.tx-intent-smoke`
+- [X] T012 Run `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
+- [X] T013 Run `nix build .#checks.x86_64-linux.ledger-functional-openapi-check`
+- [X] T014 Run `just format-check`


### PR DESCRIPTION
Refs #57

## Summary

This PR takes the next bounded slice of the tx.intent information-audit issue.
It makes required-signer coverage explicit in `tx.intent`, carries that data into
`tx-deep-diagnosis`, and updates the public contract artifacts so the new fields
are reviewable and stable.

This does not close issue #57. It only lands the required-signer coverage slice.

## What changed

- expand `tx.intent.signing` with `required_signers[]`, `present_vkey_witnesses[]`, and `present_bootstrap_witnesses[]`
- add a `Declared required signers` section to `intent.sections[]` so the markdown report surfaces the full declared signer set, not only the missing subset
- refresh the stored diagnosis input plus `summary.md` and `explain.md` goldens
- document the new signing shape in the tx.intent contract, schema, and generated OpenAPI example
- keep the slice under speckit with dedicated artifacts in `specs/008-intent-required-signers/`

## Review guide

1. Library change: https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
2. Contract and schema surface:
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
3. Report fixture refresh:
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/apps/tx-deep-diagnosis/test/golden/value-not-conserved/input.json
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
   - https://github.com/lambdasistemi/cardano-ledger-inspector/blob/008-intent-required-signers/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
4. Speckit artifacts:
   - https://github.com/lambdasistemi/cardano-ledger-inspector/tree/008-intent-required-signers/specs/008-intent-required-signers

## Verification

- `nix build .#checks.x86_64-linux.tx-intent-smoke`
- `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
- `nix build .#checks.x86_64-linux.ledger-functional-openapi-check`
- `just format-check`
