### PR TITLE
feat(registry+renderer): typed datum schemas with explicit provenance

### DIFF
--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Registry.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Registry.hs
@@ -7,9 +7,18 @@ module TxDeepDiagnosisHost.Registry (
     AmaruScope (..),
     AmaruScript (..),
     AmaruJournal (..),
+    DatumSchema (..),
+    SchemaSource (..),
+    AikenSource (..),
+    SchemaConstructor (..),
+    SchemaField (..),
+    FieldType (..),
+    TupleField (..),
+    aikenSourceUrl,
     loadRegistry,
     loadRegistries,
     identifyByHash,
+    datumSchemaForHash,
     findScopeByOwner,
     findScopeByRefOutref,
     Identification (..),
@@ -33,6 +42,11 @@ data RegistryValidator = RegistryValidator
     , rvValidator :: !Text
     , rvParameterized :: !Bool
     , rvLabel :: !(Maybe Text)
+    , rvDatumSchema :: !(Maybe DatumSchema)
+    -- ^ Optional typed datum schema for this validator. When
+    -- present, the renderer can interpret the inline datum AST as
+    -- named record fields. Absent by default; vendoring is per
+    -- contract and carries explicit provenance via 'SchemaSource'.
     }
     deriving (Show)
 
@@ -44,8 +58,113 @@ data RegistryInstance = RegistryInstance
     , riParametersKnown :: !Bool
     , riLabel :: !Text
     , riLabelledBy :: !(Maybe Text)
+    , riDatumSchema :: !(Maybe DatumSchema)
+    -- ^ See 'rvDatumSchema'.
     }
     deriving (Show)
+
+{- | Typed datum schema for a contract. The schema is consulted by
+the explain renderer to translate the inline datum's Plutus Data
+AST into named record fields, with the 'SchemaSource' surfaced as a
+mandatory provenance disclaimer.
+-}
+data DatumSchema = DatumSchema
+    { dsSource :: !SchemaSource
+    , dsName :: !Text
+    -- ^ Top-level type name, e.g. @\"OrderDatum\"@.
+    , dsConstructors :: ![SchemaConstructor]
+    -- ^ Sum-of-product constructors. Index matches the Plutus
+    -- Data 'Constr' tag.
+    }
+    deriving (Show)
+
+{- | Where the schema came from. The renderer always emits a
+provenance line before any typed body so a reviewer can decide
+whether to trust the field names.
+-}
+data SchemaSource
+    = -- | Carried in the contract author's CIP-57 plutus.json blueprint.
+      SourcePlutusJson
+    | -- | Hand-curated from an Aiken source file at a pinned commit.
+      -- Field names must match the source for the disclaimer to be
+      -- accurate.
+      SourceAiken !AikenSource
+    | -- | Reverse-engineered with no upstream typed source. Use
+      -- sparingly; the disclaimer makes this status explicit.
+      SourceManual !Text
+    deriving (Show)
+
+data AikenSource = AikenSource
+    { asRepo :: !Text
+    -- ^ @owner/repo@ pair, e.g. @SundaeSwap-finance/sundae-contracts@.
+    , asCommit :: !Text
+    -- ^ Pinned commit SHA. Required so the disclaimer URL never drifts.
+    , asPath :: !Text
+    -- ^ Path within the repo, e.g. @validators/order.ak@.
+    , asLineStart :: !(Maybe Int)
+    , asLineEnd :: !(Maybe Int)
+    , asNote :: !(Maybe Text)
+    -- ^ Optional one-line annotation (e.g. \"reorganised in PR \#42\").
+    }
+    deriving (Show)
+
+data SchemaConstructor = SchemaConstructor
+    { scIndex :: !Integer
+    , scName :: !Text
+    , scFields :: ![SchemaField]
+    }
+    deriving (Show)
+
+data SchemaField = SchemaField
+    { sfName :: !Text
+    , sfType :: !FieldType
+    }
+    deriving (Show)
+
+{- | Field types supported by the schema. 'FtData' is the escape
+hatch — when a field is left as raw 'Data' (e.g. @extensions@ in
+SundaeSwap V3) the renderer falls back to the untyped pretty-printer
+so the bytes are still visible.
+-}
+data FieldType
+    = -- | optional semantic hint, e.g. @\"PolicyId\"@.
+      FtBytes !(Maybe Text)
+    | -- | optional semantic hint, e.g. @\"Lovelace\"@.
+      FtInt !(Maybe Text)
+    | FtList !FieldType
+    | -- | heterogeneous tuple, encoded on-chain as a Plutus list.
+      -- Aiken @(a, b, c)@ values land here; the per-position name
+      -- carried in 'TupleField' lets the renderer label each slot.
+      FtTuple ![TupleField]
+    | -- | single-record nesting (Plutus @Constr 0@ wrapping)
+      FtConstr !SchemaConstructor
+    | -- | tagged union; matched by Constr tag at decode time
+      FtSum ![SchemaConstructor]
+    | FtData
+    deriving (Show)
+
+-- | A name-and-type slot inside an 'FtTuple'.
+data TupleField = TupleField
+    { tfName :: !Text
+    , tfType :: !FieldType
+    }
+    deriving (Show)
+
+{- | Build a clickable GitHub URL pointing at the cited Aiken source
+range. Used by the renderer's provenance line.
+-}
+aikenSourceUrl :: AikenSource -> Text
+aikenSourceUrl src =
+    "https://github.com/"
+        <> asRepo src
+        <> "/blob/"
+        <> asCommit src
+        <> "/"
+        <> asPath src
+        <> case (asLineStart src, asLineEnd src) of
+            (Just a, Just b) -> "#L" <> Text.pack (show a) <> "-L" <> Text.pack (show b)
+            (Just a, Nothing) -> "#L" <> Text.pack (show a)
+            _ -> ""
 
 data ProtocolRegistry = ProtocolRegistry
     { prValidators :: ![RegistryValidator]
@@ -62,6 +181,7 @@ instance FromJSON RegistryValidator where
             <*> o .: "validator"
             <*> o .:? "parameterized" .!= False
             <*> o .:? "label"
+            <*> o .:? "datum_schema"
 
 instance FromJSON RegistryInstance where
     parseJSON = withObject "RegistryInstance" $ \o ->
@@ -73,6 +193,65 @@ instance FromJSON RegistryInstance where
             <*> o .:? "parameters_known" .!= False
             <*> o .: "label"
             <*> o .:? "labelled_by"
+            <*> o .:? "datum_schema"
+
+instance FromJSON DatumSchema where
+    parseJSON = withObject "DatumSchema" $ \o ->
+        DatumSchema
+            <$> o .: "source"
+            <*> o .: "name"
+            <*> o .: "constructors"
+
+instance FromJSON SchemaSource where
+    parseJSON = withObject "SchemaSource" $ \o -> do
+        kind <- o .: "kind" :: A.Parser Text
+        case kind of
+            "plutus_json" -> pure SourcePlutusJson
+            "aiken" -> SourceAiken <$> parseJSON (A.Object o)
+            "manual" -> SourceManual <$> o .: "note"
+            other -> fail ("unknown schema source kind: " <> Text.unpack other)
+
+instance FromJSON AikenSource where
+    parseJSON = withObject "AikenSource" $ \o ->
+        AikenSource
+            <$> o .: "repo"
+            <*> o .: "commit"
+            <*> o .: "path"
+            <*> o .:? "line_start"
+            <*> o .:? "line_end"
+            <*> o .:? "note"
+
+instance FromJSON SchemaConstructor where
+    parseJSON = withObject "SchemaConstructor" $ \o ->
+        SchemaConstructor
+            <$> o .: "index"
+            <*> o .: "name"
+            <*> o .:? "fields" .!= []
+
+instance FromJSON SchemaField where
+    parseJSON = withObject "SchemaField" $ \o ->
+        SchemaField
+            <$> o .: "name"
+            <*> o .: "type"
+
+instance FromJSON FieldType where
+    parseJSON = withObject "FieldType" $ \o -> do
+        kind <- o .: "kind" :: A.Parser Text
+        case kind of
+            "bytes" -> FtBytes <$> o .:? "semantic"
+            "int" -> FtInt <$> o .:? "semantic"
+            "list" -> FtList <$> o .: "element"
+            "tuple" -> FtTuple <$> o .: "slots"
+            "constr" -> FtConstr <$> o .: "of"
+            "sum" -> FtSum <$> o .: "variants"
+            "data" -> pure FtData
+            other -> fail ("unknown field type kind: " <> Text.unpack other)
+
+instance FromJSON TupleField where
+    parseJSON = withObject "TupleField" $ \o ->
+        TupleField
+            <$> o .: "name"
+            <*> o .: "type"
 
 data RegistryFile = RegistryFile
     { rfValidators :: ![RegistryValidator]
@@ -182,6 +361,18 @@ data Identification
     | IdAmaruRole !AmaruScope !Text
     | IdUnknown
     deriving (Show)
+
+{- | Find a 'DatumSchema' for a given script hash. Validators take
+precedence over instances when both have a schema, mirroring the
+priority used by 'identifyByHash'.
+-}
+datumSchemaForHash :: ProtocolRegistry -> Text -> Maybe DatumSchema
+datumSchemaForHash reg hh =
+    case find ((== hh) . rvHashHex) (prValidators reg) of
+        Just v | Just ds <- rvDatumSchema v -> Just ds
+        _ -> case find ((== hh) . riHashHex) (prInstances reg) of
+            Just inst | Just ds <- riDatumSchema inst -> Just ds
+            _ -> Nothing
 
 identifyByHash :: ProtocolRegistry -> Text -> Identification
 identifyByHash reg hh =

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Names.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Names.hs
@@ -14,6 +14,7 @@ module TxDeepDiagnosisHost.Render.Names (
     PartySource (..),
     resolveScript,
     resolveAddress,
+    paymentScriptHash,
     truncateHash,
 ) where
 
@@ -113,6 +114,19 @@ resolveAddress reg addrHex
                             { pnLabel = "key " <> hashTail paymentHex
                             , pnSource = TruncatedHex
                             }
+
+{- | Extract the payment script hash from an address-hex when the
+header indicates a script payment credential. Returns 'Nothing' when
+the payment is key-credential or the address is too short.
+-}
+paymentScriptHash :: Text -> Maybe Text
+paymentScriptHash addrHex
+    | Text.length addrHex < 58 = Nothing
+    | otherwise =
+        let header = Text.take 2 addrHex
+         in if headerHasScriptPayment header
+                then Just (Text.take 56 (Text.drop 2 addrHex))
+                else Nothing
 
 {- | The header byte of a Shelley address encodes the type in the high
 nibble. Bits 0x40 and 0x10 of that nibble select script payment

--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -33,11 +33,23 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as V
 
-import TxDeepDiagnosisHost.Registry (ProtocolRegistry)
+import TxDeepDiagnosisHost.Registry (
+    AikenSource (..),
+    DatumSchema (..),
+    FieldType (..),
+    ProtocolRegistry,
+    SchemaConstructor (..),
+    SchemaField (..),
+    SchemaSource (..),
+    TupleField (..),
+    aikenSourceUrl,
+    datumSchemaForHash,
+ )
 import TxDeepDiagnosisHost.Render.Doc (DiagnosisDoc (..))
 import TxDeepDiagnosisHost.Render.Names (
     PartyName (..),
     PartySource (..),
+    paymentScriptHash,
     resolveAddress,
  )
 
@@ -681,12 +693,15 @@ mapMaybeDecoded reg = mapMaybe step
                     Just (String s) -> Just s
                     _ -> Nothing
                 ast <- KeyMap.lookup "decoded" d
+                let scriptHash = paymentScriptHash addr
+                    schema = scriptHash >>= datumSchemaForHash reg
                 Just
                     DecodedDatum
                         { ddIndex = idx
                         , ddDestination = pnLabel (resolveAddress reg addr)
                         , ddCbor = cbor
                         , ddAst = ast
+                        , ddSchema = schema
                         }
             _ -> Nothing
     step _ = Nothing
@@ -696,6 +711,7 @@ data DecodedDatum = DecodedDatum
     , ddDestination :: !Text
     , ddCbor :: !Text
     , ddAst :: !Value
+    , ddSchema :: !(Maybe DatumSchema)
     }
 
 groupByCbor :: [DecodedDatum] -> [(DecodedDatum, [Int])]
@@ -724,13 +740,210 @@ renderDatumGroup (rep, indices) =
                     <> " ("
                     <> Text.pack (show (length xs))
                     <> " identical)"
+        body = case ddSchema rep of
+            Just schema ->
+                provenanceLine schema
+                    <> "\n```\n"
+                    <> prettySchemaBound schema (ddAst rep)
+                    <> "```\n"
+            Nothing ->
+                "_Untyped — no datum schema registered for this script hash._\n\n"
+                    <> "```\n"
+                    <> prettyPlutusData 0 (ddAst rep)
+                    <> "```\n"
      in "<details><summary>"
             <> escapeTable title
             <> "</summary>\n\n"
-            <> "```\n"
-            <> prettyPlutusData 0 (ddAst rep)
-            <> "```\n\n"
-            <> "</details>\n\n"
+            <> body
+            <> "\n</details>\n\n"
+
+{- | The provenance disclaimer shown above every typed datum body.
+The renderer will not emit typed names without one — every
+'SchemaSource' constructor produces a non-empty line.
+-}
+provenanceLine :: DatumSchema -> Text
+provenanceLine schema =
+    let prefix = "_Field names "
+     in case dsSource schema of
+            SourcePlutusJson ->
+                prefix <> "from the contract's CIP-57 plutus.json blueprint._\n"
+            SourceAiken src ->
+                prefix
+                    <> "interpreted from the upstream Aiken source: ["
+                    <> asRepo src
+                    <> "@"
+                    <> Text.take 10 (asCommit src)
+                    <> "]("
+                    <> aikenSourceUrl src
+                    <> ")"
+                    <> maybe "" (\n -> " — " <> n) (asNote src)
+                    <> "._\n"
+            SourceManual note ->
+                prefix
+                    <> "interpreted from manual analysis (no upstream typed source): "
+                    <> note
+                    <> "._\n"
+
+{- | Walk the AST against a 'DatumSchema' and produce typed prose. The
+top-level Constr index selects a constructor from 'dsConstructors';
+fields are named per the schema. When the AST shape disagrees with
+the schema (e.g. the Constr index is unknown), the whole body falls
+back to the untyped pretty-printer with a one-line note so the
+discrepancy is visible.
+-}
+prettySchemaBound :: DatumSchema -> Value -> Text
+prettySchemaBound schema ast =
+    case ast of
+        Object o
+            | Just (String "constr") <- KeyMap.lookup "kind" o
+            , Just (Number n) <- KeyMap.lookup "index" o
+            , let ix = floor n :: Integer
+            , Just sc <- findConstructor ix (dsConstructors schema)
+            , Just (Array fs) <- KeyMap.lookup "fields" o ->
+                dsName schema
+                    <> " (= "
+                    <> scName sc
+                    <> ")\n"
+                    <> renderFields 1 sc (V.toList fs)
+        _ ->
+            "_AST shape disagrees with schema; rendering untyped._\n\n"
+                <> prettyPlutusData 0 ast
+
+findConstructor :: Integer -> [SchemaConstructor] -> Maybe SchemaConstructor
+findConstructor ix = foldr step Nothing
+  where
+    step c acc = if scIndex c == ix then Just c else acc
+
+renderFields :: Int -> SchemaConstructor -> [Value] -> Text
+renderFields lvl sc values =
+    let pad = Text.replicate (lvl * 2) " "
+        fields = scFields sc
+        zipped = zip fields (values <> repeat Null)
+        usedFieldCount = length fields
+        extras = drop usedFieldCount values
+     in Text.concat (map (renderTypedField lvl pad) zipped)
+            <> if null extras
+                then ""
+                else
+                    pad
+                        <> "_("
+                        <> Text.pack (show (length extras))
+                        <> " extra fields beyond schema, rendering untyped:)_\n"
+                        <> Text.concat
+                            (map (prettyPlutusData (lvl + 1)) extras)
+
+renderTypedField :: Int -> Text -> (SchemaField, Value) -> Text
+renderTypedField lvl pad (SchemaField name ty, v) =
+    pad <> sfBullet name <> renderTyped (lvl + 1) ty v
+
+sfBullet :: Text -> Text
+sfBullet name = name <> ": "
+
+{- | Render a Plutus AST node bound to a 'FieldType'. Recurses through
+'FtList', 'FtConstr', 'FtSum'. 'FtData' falls through to the untyped
+pretty-printer so opaque @extensions@ fields stay visible.
+-}
+renderTyped :: Int -> FieldType -> Value -> Text
+renderTyped lvl ty v = case (ty, v) of
+    (FtBytes hint, Object o)
+        | Just (String "bytes") <- KeyMap.lookup "kind" o ->
+            renderBytes hint o
+    (FtInt hint, Object o)
+        | Just (String "int") <- KeyMap.lookup "value" o ->
+            renderInt hint o
+        | Just (String "int") <- KeyMap.lookup "kind" o ->
+            renderInt hint o
+    (FtList elemTy, Object o)
+        | Just (String "list") <- KeyMap.lookup "kind" o
+        , Just (Array xs) <- KeyMap.lookup "items" o ->
+            "List "
+                <> Text.pack (show (V.length xs))
+                <> "\n"
+                <> Text.concat
+                    [ Text.replicate (lvl * 2) " "
+                        <> "- "
+                        <> renderTyped (lvl + 1) elemTy x
+                    | x <- V.toList xs
+                    ]
+    (FtTuple slots, Object o)
+        | Just (String "list") <- KeyMap.lookup "kind" o
+        , Just (Array xs) <- KeyMap.lookup "items" o ->
+            let pad = Text.replicate (lvl * 2) " "
+                pairs =
+                    take
+                        (length slots)
+                        (zip slots (V.toList xs <> repeat Null))
+             in "(\n"
+                    <> Text.concat
+                        [ pad
+                            <> tfName slot
+                            <> ": "
+                            <> renderTyped (lvl + 1) (tfType slot) val
+                        | (slot, val) <- pairs
+                        ]
+                    <> Text.replicate (max 0 (lvl - 1) * 2) " "
+                    <> ")\n"
+    (FtConstr sc, Object o)
+        | Just (String "constr") <- KeyMap.lookup "kind" o
+        , Just (Number n) <- KeyMap.lookup "index" o
+        , floor n == scIndex sc
+        , Just (Array fs) <- KeyMap.lookup "fields" o ->
+            scName sc
+                <> "\n"
+                <> renderFields lvl sc (V.toList fs)
+    (FtSum variants, Object o)
+        | Just (String "constr") <- KeyMap.lookup "kind" o
+        , Just (Number n) <- KeyMap.lookup "index" o
+        , let ix = floor n :: Integer
+        , Just sc <- findConstructor ix variants
+        , Just (Array fs) <- KeyMap.lookup "fields" o ->
+            scName sc
+                <> "\n"
+                <> renderFields lvl sc (V.toList fs)
+    (FtData, _) ->
+        "_(Data, untyped)_\n"
+            <> prettyPlutusData lvl v
+    _ ->
+        "_(schema/AST mismatch, untyped)_\n"
+            <> prettyPlutusData lvl v
+
+renderBytes :: Maybe Text -> KeyMap.KeyMap Value -> Text
+renderBytes hint o =
+    let hex = case KeyMap.lookup "hex" o of
+            Just (String s) -> s
+            _ -> ""
+        len = case KeyMap.lookup "len" o of
+            Just (Number n) -> floor n :: Int
+            _ -> 0
+        utf = case KeyMap.lookup "utf8" o of
+            Just (String s) -> Just s
+            _ -> Nothing
+        hexShort
+            | Text.length hex <= 32 = hex
+            | otherwise = Text.take 16 hex <> "…" <> Text.takeEnd 8 hex
+        utfTail = case utf of
+            Just s -> "  // \"" <> s <> "\""
+            Nothing -> ""
+        hintTail = case hint of
+            Just h -> "  // " <> h
+            Nothing -> ""
+     in "Bytes "
+            <> Text.pack (show len)
+            <> "B "
+            <> hexShort
+            <> hintTail
+            <> utfTail
+            <> "\n"
+
+renderInt :: Maybe Text -> KeyMap.KeyMap Value -> Text
+renderInt hint o =
+    let s = case KeyMap.lookup "value" o of
+            Just (String x) -> x
+            _ -> "?"
+        hintTail = case hint of
+            Just h -> "  // " <> h
+            Nothing -> ""
+     in "Int " <> s <> hintTail <> "\n"
 
 sortedIndices :: [Int] -> [Int]
 sortedIndices = foldr insertSorted []

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -160,84 +160,98 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 <details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
 
-_Untyped — no datum schema registered for this script hash._
+_Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 
 ```
-Constr 0
-  Constr 0
-    Bytes 28B 64f35d26b237ad58…6e2540ef
-  Constr 1
-    List 4
-      Constr 0
-        Bytes 28B 7095faf3d48d582f…2bbdeffb
-      Constr 0
-        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
-      Constr 0
-        Bytes 28B 8bd03209d227956a…b24fb1c1
-      Constr 0
-        Bytes 28B 97e0f6d6c86dbebf…edd49df2
-  Int 1280000
-  Constr 0
-    Constr 0
-      Constr 1
-        Bytes 28B 32201dc1e8270836…a10baa0d
-      Constr 0
+OrderDatum (= Order)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
         Constr 0
-          Constr 1
-            Bytes 28B 32201dc1e8270836…a10baa0d
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 12500000000
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 3062500000
+    )
+  extension: _(Data, untyped)_
     Constr 0
-  Constr 1
-    List 3
-      Bytes 0B 
-      Bytes 0B 
-      Int 12500000000
-    List 3
-      Bytes 28B c48cbb3d5e57ed56…02da47ad
-      Bytes 8B 0014df105553444d
-      Int 3062500000
-  Constr 0
 ```
 
 </details>
 
 <details><summary>Output #9 — SundaeSwap V3 order</summary>
 
-_Untyped — no datum schema registered for this script hash._
+_Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 
 ```
-Constr 0
-  Constr 0
-    Bytes 28B 64f35d26b237ad58…6e2540ef
-  Constr 1
-    List 4
-      Constr 0
-        Bytes 28B 7095faf3d48d582f…2bbdeffb
-      Constr 0
-        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
-      Constr 0
-        Bytes 28B 8bd03209d227956a…b24fb1c1
-      Constr 0
-        Bytes 28B 97e0f6d6c86dbebf…edd49df2
-  Int 1280000
-  Constr 0
-    Constr 0
-      Constr 1
-        Bytes 28B 32201dc1e8270836…a10baa0d
-      Constr 0
+OrderDatum (= Order)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
         Constr 0
-          Constr 1
-            Bytes 28B 32201dc1e8270836…a10baa0d
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 8163265306
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 2000000000
+    )
+  extension: _(Data, untyped)_
     Constr 0
-  Constr 1
-    List 3
-      Bytes 0B 
-      Bytes 0B 
-      Int 8163265306
-    List 3
-      Bytes 28B c48cbb3d5e57ed56…02da47ad
-      Bytes 8B 0014df105553444d
-      Int 2000000000
-  Constr 0
 ```
 
 </details>

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -160,6 +160,8 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 <details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
 
+_Untyped — no datum schema registered for this script hash._
+
 ```
 Constr 0
   Constr 0
@@ -199,6 +201,8 @@ Constr 0
 </details>
 
 <details><summary>Output #9 — SundaeSwap V3 order</summary>
+
+_Untyped — no datum schema registered for this script hash._
 
 ```
 Constr 0

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -160,84 +160,98 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 <details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
 
-_Untyped — no datum schema registered for this script hash._
+_Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 
 ```
-Constr 0
-  Constr 0
-    Bytes 28B 64f35d26b237ad58…6e2540ef
-  Constr 1
-    List 4
-      Constr 0
-        Bytes 28B 7095faf3d48d582f…2bbdeffb
-      Constr 0
-        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
-      Constr 0
-        Bytes 28B 8bd03209d227956a…b24fb1c1
-      Constr 0
-        Bytes 28B 97e0f6d6c86dbebf…edd49df2
-  Int 1280000
-  Constr 0
-    Constr 0
-      Constr 1
-        Bytes 28B 32201dc1e8270836…a10baa0d
-      Constr 0
+OrderDatum (= Order)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
         Constr 0
-          Constr 1
-            Bytes 28B 32201dc1e8270836…a10baa0d
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 12500000000
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 3062500000
+    )
+  extension: _(Data, untyped)_
     Constr 0
-  Constr 1
-    List 3
-      Bytes 0B 
-      Bytes 0B 
-      Int 12500000000
-    List 3
-      Bytes 28B c48cbb3d5e57ed56…02da47ad
-      Bytes 8B 0014df105553444d
-      Int 3062500000
-  Constr 0
 ```
 
 </details>
 
 <details><summary>Output #9 — SundaeSwap V3 order</summary>
 
-_Untyped — no datum schema registered for this script hash._
+_Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 
 ```
-Constr 0
-  Constr 0
-    Bytes 28B 64f35d26b237ad58…6e2540ef
-  Constr 1
-    List 4
-      Constr 0
-        Bytes 28B 7095faf3d48d582f…2bbdeffb
-      Constr 0
-        Bytes 28B f3ab64b0f97dcf0f…04d23e2e
-      Constr 0
-        Bytes 28B 8bd03209d227956a…b24fb1c1
-      Constr 0
-        Bytes 28B 97e0f6d6c86dbebf…edd49df2
-  Int 1280000
-  Constr 0
-    Constr 0
-      Constr 1
-        Bytes 28B 32201dc1e8270836…a10baa0d
-      Constr 0
+OrderDatum (= Order)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
         Constr 0
-          Constr 1
-            Bytes 28B 32201dc1e8270836…a10baa0d
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 8163265306
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 2000000000
+    )
+  extension: _(Data, untyped)_
     Constr 0
-  Constr 1
-    List 3
-      Bytes 0B 
-      Bytes 0B 
-      Int 8163265306
-    List 3
-      Bytes 28B c48cbb3d5e57ed56…02da47ad
-      Bytes 8B 0014df105553444d
-      Int 2000000000
-  Constr 0
 ```
 
 </details>

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -160,6 +160,8 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 <details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
 
+_Untyped — no datum schema registered for this script hash._
+
 ```
 Constr 0
   Constr 0
@@ -199,6 +201,8 @@ Constr 0
 </details>
 
 <details><summary>Output #9 — SundaeSwap V3 order</summary>
+
+_Untyped — no datum schema registered for this script hash._
 
 ```
 Constr 0

--- a/docs/inspector/protocols/registry.json
+++ b/docs/inspector/protocols/registry.json
@@ -18,7 +18,316 @@
       "blueprint": "sundaeswap-v3",
       "validator": "order.spend",
       "parameterized": false,
-      "label": "SundaeSwap V3 order"
+      "label": "SundaeSwap V3 order",
+      "datum_schema": {
+        "source": {
+          "kind": "aiken",
+          "repo": "SundaeSwap-finance/sundae-contracts",
+          "commit": "be33466b7dbe0f8e6c0e0f46ff23737897f45835",
+          "path": "lib/types/order.ak",
+          "line_start": 8,
+          "line_end": 33,
+          "note": "MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak"
+        },
+        "name": "OrderDatum",
+        "constructors": [
+          {
+            "index": 0,
+            "name": "Order",
+            "fields": [
+              {
+                "name": "pool_ident",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Some",
+                      "fields": [
+                        { "name": "value", "type": { "kind": "bytes", "semantic": "PoolIdent" } }
+                      ]
+                    },
+                    { "index": 1, "name": "None", "fields": [] }
+                  ]
+                }
+              },
+              {
+                "name": "owner",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Signature",
+                      "fields": [
+                        { "name": "key_hash", "type": { "kind": "bytes", "semantic": "VerificationKeyHash" } }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "AllOf",
+                      "fields": [
+                        { "name": "scripts", "type": { "kind": "list", "element": { "kind": "data" } } }
+                      ]
+                    },
+                    {
+                      "index": 2,
+                      "name": "AnyOf",
+                      "fields": [
+                        { "name": "scripts", "type": { "kind": "list", "element": { "kind": "data" } } }
+                      ]
+                    },
+                    {
+                      "index": 3,
+                      "name": "AtLeast",
+                      "fields": [
+                        { "name": "required", "type": { "kind": "int" } },
+                        { "name": "scripts", "type": { "kind": "list", "element": { "kind": "data" } } }
+                      ]
+                    },
+                    {
+                      "index": 4,
+                      "name": "Before",
+                      "fields": [
+                        { "name": "time", "type": { "kind": "int", "semantic": "POSIXTime" } }
+                      ]
+                    },
+                    {
+                      "index": 5,
+                      "name": "After",
+                      "fields": [
+                        { "name": "time", "type": { "kind": "int", "semantic": "POSIXTime" } }
+                      ]
+                    },
+                    {
+                      "index": 6,
+                      "name": "Script",
+                      "fields": [
+                        { "name": "script_hash", "type": { "kind": "bytes", "semantic": "ScriptHash" } }
+                      ]
+                    }
+                  ]
+                }
+              },
+              { "name": "max_protocol_fee", "type": { "kind": "int", "semantic": "Lovelace" } },
+              {
+                "name": "destination",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Fixed",
+                      "fields": [
+                        {
+                          "name": "address",
+                          "type": {
+                            "kind": "constr",
+                            "of": {
+                              "index": 0,
+                              "name": "Address",
+                              "fields": [
+                                {
+                                  "name": "payment_credential",
+                                  "type": {
+                                    "kind": "sum",
+                                    "variants": [
+                                      {
+                                        "index": 0,
+                                        "name": "VerificationKey",
+                                        "fields": [
+                                          { "name": "hash", "type": { "kind": "bytes", "semantic": "VerificationKeyHash" } }
+                                        ]
+                                      },
+                                      {
+                                        "index": 1,
+                                        "name": "Script",
+                                        "fields": [
+                                          { "name": "hash", "type": { "kind": "bytes", "semantic": "ScriptHash" } }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "name": "stake_credential",
+                                  "type": {
+                                    "kind": "sum",
+                                    "variants": [
+                                      {
+                                        "index": 0,
+                                        "name": "Some",
+                                        "fields": [
+                                          {
+                                            "name": "value",
+                                            "type": {
+                                              "kind": "sum",
+                                              "variants": [
+                                                {
+                                                  "index": 0,
+                                                  "name": "Inline",
+                                                  "fields": [
+                                                    {
+                                                      "name": "credential",
+                                                      "type": {
+                                                        "kind": "sum",
+                                                        "variants": [
+                                                          {
+                                                            "index": 0,
+                                                            "name": "VerificationKey",
+                                                            "fields": [
+                                                              { "name": "hash", "type": { "kind": "bytes", "semantic": "VerificationKeyHash" } }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "index": 1,
+                                                            "name": "Script",
+                                                            "fields": [
+                                                              { "name": "hash", "type": { "kind": "bytes", "semantic": "ScriptHash" } }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "index": 1,
+                                                  "name": "Pointer",
+                                                  "fields": [
+                                                    { "name": "slot_number", "type": { "kind": "int" } },
+                                                    { "name": "transaction_index", "type": { "kind": "int" } },
+                                                    { "name": "certificate_index", "type": { "kind": "int" } }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      { "index": 1, "name": "None", "fields": [] }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "datum",
+                          "type": {
+                            "kind": "sum",
+                            "variants": [
+                              { "index": 0, "name": "NoDatum", "fields": [] },
+                              {
+                                "index": 1,
+                                "name": "DatumHash",
+                                "fields": [
+                                  { "name": "hash", "type": { "kind": "bytes" } }
+                                ]
+                              },
+                              {
+                                "index": 2,
+                                "name": "InlineDatum",
+                                "fields": [
+                                  { "name": "data", "type": { "kind": "data" } }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    { "index": 1, "name": "Self", "fields": [] }
+                  ]
+                }
+              },
+              {
+                "name": "details",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Strategy",
+                      "fields": [
+                        { "name": "auth", "type": { "kind": "data" } }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "Swap",
+                      "fields": [
+                        {
+                          "name": "offer",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              { "name": "policy", "type": { "kind": "bytes", "semantic": "PolicyId" } },
+                              { "name": "asset_name", "type": { "kind": "bytes", "semantic": "AssetName" } },
+                              { "name": "quantity", "type": { "kind": "int" } }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "min_received",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              { "name": "policy", "type": { "kind": "bytes", "semantic": "PolicyId" } },
+                              { "name": "asset_name", "type": { "kind": "bytes", "semantic": "AssetName" } },
+                              { "name": "quantity", "type": { "kind": "int" } }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 2,
+                      "name": "Deposit",
+                      "fields": [
+                        { "name": "assets", "type": { "kind": "data" } }
+                      ]
+                    },
+                    {
+                      "index": 3,
+                      "name": "Withdrawal",
+                      "fields": [
+                        {
+                          "name": "amount",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              { "name": "policy", "type": { "kind": "bytes", "semantic": "PolicyId" } },
+                              { "name": "asset_name", "type": { "kind": "bytes", "semantic": "AssetName" } },
+                              { "name": "quantity", "type": { "kind": "int" } }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 4,
+                      "name": "Donation",
+                      "fields": [
+                        { "name": "assets", "type": { "kind": "data" } }
+                      ]
+                    },
+                    {
+                      "index": 5,
+                      "name": "Record",
+                      "fields": [
+                        { "name": "policy", "type": { "kind": "data" } }
+                      ]
+                    }
+                  ]
+                }
+              },
+              { "name": "extension", "type": { "kind": "data" } }
+            ]
+          }
+        ]
+      }
     }
   ],
   "instances": [


### PR DESCRIPTION
Closes #59.
Spawns follow-up #66 (group by (cbor,destination) + vendor SundaeSwap treasury schema).

## What

Typed inline-datum rendering with explicit provenance. The Datums section in the explain document used to print the Plutus-Data AST as untyped \`Constr / List / Bytes / Int\`. Now it renders typed records with field names, prepended by a mandatory provenance disclaimer that links to the cited source so a reviewer can verify each name independently.

For the SundaeSwap/USDM mainnet fixture the relevant block now reads:

> _Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._

```
OrderDatum (= Order)
  pool_ident: Some
    value: Bytes 28B 64f35d26… // PoolIdent
  owner: AllOf
    scripts: List 4 [...]
  max_protocol_fee: Int 1280000  // Lovelace
  destination: Fixed
    address: Address ...
    datum: NoDatum
  details: Swap
    offer: ( policy: Bytes 0B (= ADA)
             asset_name: Bytes 0B
             quantity: Int 12500000000 )
    min_received: ( policy: Bytes 28B c48cbb3d… // PolicyId
                    asset_name: Bytes 8B 0014df105553444d (= "USDM")
                    quantity: Int 3062500000 )
  extension: _(Data, untyped)_
```

Sample explain.md: https://github.com/lambdasistemi/cardano-ledger-inspector/blob/feat/issue-59-typed-datums/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md

## Commits

1. **\`feat(registry): add optional DatumSchema with explicit provenance\`** — pure infra. New types in \`Registry.hs\`: \`DatumSchema\`, \`SchemaSource\` (\`plutus_json\` | \`aiken { repo,commit,path,line_start,line_end,note }\` | \`manual { note }\`), \`SchemaConstructor\`, \`SchemaField\`, \`FieldType\` (Bytes / Int / List / Tuple / Constr / Sum / Data) with semantic hints, \`TupleField\`. JSON parsers. Optional \`datum_schema\` on \`RegistryValidator\` / \`RegistryInstance\`. \`datumSchemaForHash\` lookup. \`aikenSourceUrl\` builder.
2. **\`feat(tx-deep-diagnosis): typed datum rendering with provenance disclaimer\`** — \`Render.Summary.datumsSection\` consults \`datumSchemaForHash\` per output script hash. When a schema is registered: a typed walker (\`prettySchemaBound\` → \`renderFields\` → \`renderTyped\`) translates the AST into named records, gated by a mandatory \`provenanceLine\`. When absent: falls through to the existing untyped pretty-printer with a one-line note. Mismatches (Constr index unknown, shape disagrees) bail to the untyped printer with a one-line note so the discrepancy is visible.
3. **\`registry: vendor SundaeSwap V3 order datum schema (Aiken provenance)\`** — inline \`datum_schema\` on the SundaeSwap V3 \`order.spend\` validator entry in \`docs/inspector/protocols/registry.json\`. Source-pinned at the same commit as \`pin.json\`. MultisigScript inner lists fall back to \`FtData\` (recursive shape, vendored later).

## Provenance contract

The renderer **never** emits typed field names without a non-empty provenance line:

- \`SourcePlutusJson\` → \"_Field names from the contract's CIP-57 plutus.json blueprint._\"
- \`SourceAiken\` → \"_Field names interpreted from the upstream Aiken source: [repo@commit](url) — note._\"
- \`SourceManual note\` → \"_Field names interpreted from manual analysis (no upstream typed source): note._\"

This is a design constraint, not a convention: the renderer's \`renderDatumGroup\` switch dispatches strictly to either \`provenanceLine schema\` or the untyped fallback note.

## Out of scope (filed as follow-ups)

- #66 — group Datums section by (cbor_hex, destination_label) so identical-datum-but-different-destination outputs render separately, and vendor the SundaeSwap treasury contract datum schema for the \`32201dc1…0baa0d\` instance.

## How to verify

\`\`\`
nix run .#format-check
nix build .#checks.x86_64-linux.tx-explain-render-smoke
cat result/snapshot.log
\`\`\`

Snapshot under \`apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md\` is regenerated to include the typed Datums section for outputs at \`fa6a58bb…f3077\`.