### PR TITLE
fix: split datum groups by destination

### DIFF
--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -654,8 +654,8 @@ which compresses better than JSON in the markdown view.
 
 Outputs whose datum is a hash-only reference, or a @no_datum@, are
 omitted. Identical datums (same hex string) are deduplicated — a
-SundaeSwap order with N identical outputs only shows the datum
-once with a count.
+SundaeSwap order with N identical outputs to the same destination
+only shows the datum once with a count.
 -}
 datumsSection :: ProtocolRegistry -> DiagnosisDoc -> Text
 datumsSection reg doc =
@@ -664,7 +664,7 @@ datumsSection reg doc =
             Just (Array xs) -> V.toList xs
             _ -> []
         decoded = mapMaybeDecoded reg items
-        groups = groupByCbor decoded
+        groups = groupByDatumBlock decoded
      in if null groups
             then ""
             else
@@ -714,12 +714,18 @@ data DecodedDatum = DecodedDatum
     , ddSchema :: !(Maybe DatumSchema)
     }
 
-groupByCbor :: [DecodedDatum] -> [(DecodedDatum, [Int])]
-groupByCbor = foldr add []
+groupByDatumBlock :: [DecodedDatum] -> [(DecodedDatum, [Int])]
+groupByDatumBlock = foldr add []
   where
-    add d acc = case partitionBy (\(rep, _) -> ddCbor rep == ddCbor d) acc of
-        (Just (rep, idxs), rest) -> (rep, ddIndex d : idxs) : rest
-        (Nothing, _) -> (d, [ddIndex d]) : acc
+    add d acc =
+        case partitionBy (\(rep, _) -> sameDatumBlock rep d) acc of
+            (Just (rep, idxs), rest) -> (rep, ddIndex d : idxs) : rest
+            (Nothing, _) -> (d, [ddIndex d]) : acc
+
+sameDatumBlock :: DecodedDatum -> DecodedDatum -> Bool
+sameDatumBlock a b =
+    ddCbor a == ddCbor b
+        && ddDestination a == ddDestination b
 
 partitionBy :: (a -> Bool) -> [a] -> (Maybe a, [a])
 partitionBy _ [] = (Nothing, [])

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -158,7 +158,56 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Datums
 
-<details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
+<details><summary>Output #0 — Amaru Network Compliance treasury (0baa0d)</summary>
+
+_Field names interpreted from manual analysis (no upstream typed source): observed on the Amaru Network Compliance treasury change output; the pinned SundaeSwap treasury validator accepts opaque Data, so these field names mirror the shared order-shaped commitment rather than an upstream treasury datum declaration._
+
+```
+TreasuryCommitmentDatum (= Commitment)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 12500000000
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 3062500000
+    )
+  extension: _(Data, untyped)_
+    Constr 0
+```
+
+</details>
+
+<details><summary>Outputs #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (8 identical)</summary>
 
 _Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -158,7 +158,56 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Datums
 
-<details><summary>Outputs #0, #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (9 identical)</summary>
+<details><summary>Output #0 — Amaru Network Compliance treasury (0baa0d)</summary>
+
+_Field names interpreted from manual analysis (no upstream typed source): observed on the Amaru Network Compliance treasury change output; the pinned SundaeSwap treasury validator accepts opaque Data, so these field names mirror the shared order-shaped commitment rather than an upstream treasury datum declaration._
+
+```
+TreasuryCommitmentDatum (= Commitment)
+  pool_ident: Some
+    value: Bytes 28B 64f35d26b237ad58…6e2540ef  // PoolIdent
+  owner: AllOf
+    scripts: List 4
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 7095faf3d48d582f…2bbdeffb
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B f3ab64b0f97dcf0f…04d23e2e
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 8bd03209d227956a…b24fb1c1
+      - _(Data, untyped)_
+        Constr 0
+          Bytes 28B 97e0f6d6c86dbebf…edd49df2
+  max_protocol_fee: Int 1280000  // Lovelace
+  destination: Fixed
+    address: Address
+      payment_credential: Script
+        hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+      stake_credential: Some
+        value: Inline
+          credential: Script
+            hash: Bytes 28B 32201dc1e8270836…a10baa0d  // ScriptHash
+    datum: NoDatum
+  details: Swap
+    offer: (
+      policy: Bytes 0B   // PolicyId
+      asset_name: Bytes 0B   // AssetName
+      quantity: Int 12500000000
+    )
+    min_received: (
+      policy: Bytes 28B c48cbb3d5e57ed56…02da47ad  // PolicyId
+      asset_name: Bytes 8B 0014df105553444d  // AssetName
+      quantity: Int 3062500000
+    )
+  extension: _(Data, untyped)_
+    Constr 0
+```
+
+</details>
+
+<details><summary>Outputs #1, #2, #3, #4, #5, #6, #7, #8 — SundaeSwap V3 order (8 identical)</summary>
 
 _Field names interpreted from the upstream Aiken source: [SundaeSwap-finance/sundae-contracts@be33466b7d](https://github.com/SundaeSwap-finance/sundae-contracts/blob/be33466b7dbe0f8e6c0e0f46ff23737897f45835/lib/types/order.ak#L8-L33) — MultisigScript variants follow KtorZ/aicone @ a9ae9ef8 lib/sundae/multisig.ak; Address/Credential/Referenced follow aiken-lang/stdlib v3.0.0 lib/cardano/address.ak._
 

--- a/docs/inspector/protocols/registry.json
+++ b/docs/inspector/protocols/registry.json
@@ -338,7 +338,517 @@
       "parameterized": true,
       "parameters_known": false,
       "label": "Amaru Network Compliance treasury",
-      "labelled_by": "amaru-treasury/journal-2026.json#treasuries.network_compliance"
+      "labelled_by": "amaru-treasury/journal-2026.json#treasuries.network_compliance",
+      "datum_schema": {
+        "source": {
+          "kind": "manual",
+          "note": "observed on the Amaru Network Compliance treasury change output; the pinned SundaeSwap treasury validator accepts opaque Data, so these field names mirror the shared order-shaped commitment rather than an upstream treasury datum declaration"
+        },
+        "name": "TreasuryCommitmentDatum",
+        "constructors": [
+          {
+            "index": 0,
+            "name": "Commitment",
+            "fields": [
+              {
+                "name": "pool_ident",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Some",
+                      "fields": [
+                        {
+                          "name": "value",
+                          "type": {
+                            "kind": "bytes",
+                            "semantic": "PoolIdent"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "None",
+                      "fields": []
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "owner",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Signature",
+                      "fields": [
+                        {
+                          "name": "key_hash",
+                          "type": {
+                            "kind": "bytes",
+                            "semantic": "VerificationKeyHash"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "AllOf",
+                      "fields": [
+                        {
+                          "name": "scripts",
+                          "type": {
+                            "kind": "list",
+                            "element": {
+                              "kind": "data"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 2,
+                      "name": "AnyOf",
+                      "fields": [
+                        {
+                          "name": "scripts",
+                          "type": {
+                            "kind": "list",
+                            "element": {
+                              "kind": "data"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 3,
+                      "name": "AtLeast",
+                      "fields": [
+                        {
+                          "name": "required",
+                          "type": {
+                            "kind": "int"
+                          }
+                        },
+                        {
+                          "name": "scripts",
+                          "type": {
+                            "kind": "list",
+                            "element": {
+                              "kind": "data"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 4,
+                      "name": "Before",
+                      "fields": [
+                        {
+                          "name": "time",
+                          "type": {
+                            "kind": "int",
+                            "semantic": "POSIXTime"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 5,
+                      "name": "After",
+                      "fields": [
+                        {
+                          "name": "time",
+                          "type": {
+                            "kind": "int",
+                            "semantic": "POSIXTime"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 6,
+                      "name": "Script",
+                      "fields": [
+                        {
+                          "name": "script_hash",
+                          "type": {
+                            "kind": "bytes",
+                            "semantic": "ScriptHash"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "max_protocol_fee",
+                "type": {
+                  "kind": "int",
+                  "semantic": "Lovelace"
+                }
+              },
+              {
+                "name": "destination",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Fixed",
+                      "fields": [
+                        {
+                          "name": "address",
+                          "type": {
+                            "kind": "constr",
+                            "of": {
+                              "index": 0,
+                              "name": "Address",
+                              "fields": [
+                                {
+                                  "name": "payment_credential",
+                                  "type": {
+                                    "kind": "sum",
+                                    "variants": [
+                                      {
+                                        "index": 0,
+                                        "name": "VerificationKey",
+                                        "fields": [
+                                          {
+                                            "name": "hash",
+                                            "type": {
+                                              "kind": "bytes",
+                                              "semantic": "VerificationKeyHash"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "index": 1,
+                                        "name": "Script",
+                                        "fields": [
+                                          {
+                                            "name": "hash",
+                                            "type": {
+                                              "kind": "bytes",
+                                              "semantic": "ScriptHash"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "name": "stake_credential",
+                                  "type": {
+                                    "kind": "sum",
+                                    "variants": [
+                                      {
+                                        "index": 0,
+                                        "name": "Some",
+                                        "fields": [
+                                          {
+                                            "name": "value",
+                                            "type": {
+                                              "kind": "sum",
+                                              "variants": [
+                                                {
+                                                  "index": 0,
+                                                  "name": "Inline",
+                                                  "fields": [
+                                                    {
+                                                      "name": "credential",
+                                                      "type": {
+                                                        "kind": "sum",
+                                                        "variants": [
+                                                          {
+                                                            "index": 0,
+                                                            "name": "VerificationKey",
+                                                            "fields": [
+                                                              {
+                                                                "name": "hash",
+                                                                "type": {
+                                                                  "kind": "bytes",
+                                                                  "semantic": "VerificationKeyHash"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "index": 1,
+                                                            "name": "Script",
+                                                            "fields": [
+                                                              {
+                                                                "name": "hash",
+                                                                "type": {
+                                                                  "kind": "bytes",
+                                                                  "semantic": "ScriptHash"
+                                                                }
+                                                              }
+                                                            ]
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "index": 1,
+                                                  "name": "Pointer",
+                                                  "fields": [
+                                                    {
+                                                      "name": "slot_number",
+                                                      "type": {
+                                                        "kind": "int"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "transaction_index",
+                                                      "type": {
+                                                        "kind": "int"
+                                                      }
+                                                    },
+                                                    {
+                                                      "name": "certificate_index",
+                                                      "type": {
+                                                        "kind": "int"
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "index": 1,
+                                        "name": "None",
+                                        "fields": []
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "name": "datum",
+                          "type": {
+                            "kind": "sum",
+                            "variants": [
+                              {
+                                "index": 0,
+                                "name": "NoDatum",
+                                "fields": []
+                              },
+                              {
+                                "index": 1,
+                                "name": "DatumHash",
+                                "fields": [
+                                  {
+                                    "name": "hash",
+                                    "type": {
+                                      "kind": "bytes"
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "index": 2,
+                                "name": "InlineDatum",
+                                "fields": [
+                                  {
+                                    "name": "data",
+                                    "type": {
+                                      "kind": "data"
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "Self",
+                      "fields": []
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "details",
+                "type": {
+                  "kind": "sum",
+                  "variants": [
+                    {
+                      "index": 0,
+                      "name": "Strategy",
+                      "fields": [
+                        {
+                          "name": "auth",
+                          "type": {
+                            "kind": "data"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 1,
+                      "name": "Swap",
+                      "fields": [
+                        {
+                          "name": "offer",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              {
+                                "name": "policy",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "PolicyId"
+                                }
+                              },
+                              {
+                                "name": "asset_name",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "AssetName"
+                                }
+                              },
+                              {
+                                "name": "quantity",
+                                "type": {
+                                  "kind": "int"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "name": "min_received",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              {
+                                "name": "policy",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "PolicyId"
+                                }
+                              },
+                              {
+                                "name": "asset_name",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "AssetName"
+                                }
+                              },
+                              {
+                                "name": "quantity",
+                                "type": {
+                                  "kind": "int"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 2,
+                      "name": "Deposit",
+                      "fields": [
+                        {
+                          "name": "assets",
+                          "type": {
+                            "kind": "data"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 3,
+                      "name": "Withdrawal",
+                      "fields": [
+                        {
+                          "name": "amount",
+                          "type": {
+                            "kind": "tuple",
+                            "slots": [
+                              {
+                                "name": "policy",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "PolicyId"
+                                }
+                              },
+                              {
+                                "name": "asset_name",
+                                "type": {
+                                  "kind": "bytes",
+                                  "semantic": "AssetName"
+                                }
+                              },
+                              {
+                                "name": "quantity",
+                                "type": {
+                                  "kind": "int"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 4,
+                      "name": "Donation",
+                      "fields": [
+                        {
+                          "name": "assets",
+                          "type": {
+                            "kind": "data"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "index": 5,
+                      "name": "Record",
+                      "fields": [
+                        {
+                          "name": "policy",
+                          "type": {
+                            "kind": "data"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "name": "extension",
+                "type": {
+                  "kind": "data"
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   ],
   "deployment_registries": [

--- a/specs/010-datum-grouping-treasury-schema/data-model.md
+++ b/specs/010-datum-grouping-treasury-schema/data-model.md
@@ -1,0 +1,28 @@
+# Data Model: Datum Grouping and Explicit Amaru Treasury Schema
+
+## Datum Group Key
+
+- `cbor_hex`: the exact inline datum bytes rendered in the output
+- `destination_label`: the resolved destination label already used in datum
+  block titles
+
+Two outputs belong to the same rendered datum block only when both values are
+equal.
+
+## Decoded Datum
+
+- `index`: output index in the tx intent view
+- `destination`: resolved destination label
+- `cbor`: inline datum hex
+- `ast`: decoded Plutus Data tree
+- `schema`: optional datum schema resolved from the payment script hash
+
+## Treasury Instance Schema
+
+- `scope`: the Amaru Network Compliance treasury instance
+  (`32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d`)
+- `source`: `manual`
+- `purpose`: make the treasury change output's observed commitment shape
+  explicit at the instance level
+- `fallback`: if the AST diverges from the vendored schema, the renderer keeps
+  its existing untyped mismatch fallback

--- a/specs/010-datum-grouping-treasury-schema/plan.md
+++ b/specs/010-datum-grouping-treasury-schema/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Datum Grouping and Explicit Amaru Treasury Schema
+
+**Branch**: `010-datum-grouping-treasury-schema` | **Date**: 2026-05-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-datum-grouping-treasury-schema/spec.md`
+
+## Status
+
+- **Completed**: Issue analysis, upstream treasury-source check, baseline
+  `tx-explain-render-smoke`.
+- **Current**: Add the issue-66 docs, fix the datum grouping key, vendor the
+  explicit treasury instance schema, and refresh the goldens.
+- **Blockers**: None. The design correction is already resolved: upstream
+  treasury datum provenance must be manual, not Aiken-derived.
+
+## Summary
+
+Fix the Datums section so identical inline datum bytes only collapse when they
+also share the same destination label, then make the Amaru treasury output use
+an explicit instance-level datum schema. The schema will intentionally use the
+existing manual-provenance path because the pinned upstream treasury validator
+accepts opaque `Data` and does not define the typed datum requested in the
+issue body.
+
+## Technical Context
+
+**Language/Version**: Haskell2010 via the repository's existing GHC/Nix setup
+
+**Primary Dependencies**: existing `tx-deep-diagnosis` summary/single-file
+renderers, registry loader, `aeson`, `text`, committed protocol registry JSON
+
+**Storage**: none beyond the committed `registry.json` and golden markdown
+fixtures
+
+**Testing**: `tx-explain-render-smoke` and `just format-check`
+
+**Constraints**: keep renderer behavior deterministic; preserve the existing
+order-schema rendering; disclose manual provenance truthfully; do not claim an
+upstream typed treasury datum that does not exist in the pinned source
+
+## Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. No ledger decoding/validation logic
+  changes.
+- **Transaction Documents Own State**: PASS. The change only affects rendering
+  of the existing diagnosis envelope and the vendored registry.
+- **JSON Control Plane, CBOR Data Plane**: PASS. No JSON-envelope changes.
+- **Explicit Context Only**: PASS. No hidden provider state or chain fetches.
+- **The Library Is the Canonical Artifact**: PASS. The behavior stays in the
+  host renderer and registry layer.
+- **Quality Gates**: PASS. Golden-render smoke plus formatting will verify the
+  slice.
+
+## Project Structure
+
+```text
+specs/010-datum-grouping-treasury-schema/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+
+apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+docs/inspector/protocols/registry.json
+```
+
+## Phase Plan
+
+1. Add the speckit slice documenting the issue-66 design correction.
+2. Change the Datums-section grouping key from `cbor` to
+   `(cbor, destination_label)`.
+3. Vendor an explicit instance-level schema on the Amaru treasury instance
+   using `manual` provenance.
+4. Re-render the golden markdown outputs and verify the renderer smoke and
+   formatting gates.
+
+## Post-Design Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. Renderer-only change.
+- **Transaction Documents Own State**: PASS. Datums are still derived solely
+  from the envelope.
+- **JSON Control Plane, CBOR Data Plane**: PASS. No contract drift.
+- **Explicit Context Only**: PASS. Registry data remains explicit and committed.
+- **The Library Is the Canonical Artifact**: PASS. No duplicated logic.
+- **Quality Gates**: PASS. Existing Nix smoke and formatting checks remain the
+  relevant proof points.

--- a/specs/010-datum-grouping-treasury-schema/quickstart.md
+++ b/specs/010-datum-grouping-treasury-schema/quickstart.md
@@ -1,0 +1,28 @@
+# Quickstart: Datum Grouping and Explicit Amaru Treasury Schema
+
+## Run the renderer smoke
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke
+```
+
+## Refresh the committed golden markdown files
+
+```bash
+nix build .#packages.x86_64-linux.tx-deep-diagnosis-render-snapshot -o result-render-snapshot
+./result-render-snapshot/bin/tx-deep-diagnosis-render-snapshot \
+  --write apps/tx-deep-diagnosis/test/golden
+```
+
+Expected result:
+
+- `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md`
+  shows a separate treasury datum block
+- `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md`
+  shows the same split
+
+## Verify formatting
+
+```bash
+just format-check
+```

--- a/specs/010-datum-grouping-treasury-schema/research.md
+++ b/specs/010-datum-grouping-treasury-schema/research.md
@@ -1,0 +1,39 @@
+# Research: Datum Grouping and Explicit Amaru Treasury Schema
+
+## Findings
+
+1. `Render.Summary.groupByCbor` currently groups only by `ddCbor`, so the
+   representative output can leak both destination label and schema across
+   unrelated destinations that happen to share identical datum bytes.
+2. In the committed SundaeSwap/USDM fixture, output `#0` (Amaru treasury
+   change) and the SundaeSwap order outputs share identical inline datum bytes.
+   The current renderer therefore shows the treasury output inside the order
+   block.
+3. The issue body's wording about order outputs `#1-#9` being identical is
+   slightly too broad. In the committed fixture, outputs `#1-#8` share one
+   inline datum body, while output `#9` has different bytes near the tail and
+   therefore remains its own order block even after the grouping fix.
+4. The registry layer already supports instance-level datum schemas via
+   `riDatumSchema`, and the renderer already supports `manual` schema
+   provenance through `SourceManual`.
+5. The pinned upstream `SundaeSwap-finance/treasury-contracts` source at
+   `dea9e52671f7a696f0ec6a0f475c7fbe52689c9b` does not define a typed treasury
+   datum for `treasury.treasury.spend`; the validator treats the datum as
+   opaque `Data`.
+6. The fixture's treasury change datum is still order-shaped. That makes an
+   explicit instance-level manual schema the truthful way to keep the output
+   typed without pretending the upstream treasury validator supplied those field
+   names.
+
+## Decision
+
+Implement the issue in two parts:
+
+- change datum grouping to `(ddCbor, ddDestination)`
+- vendor a manual datum schema on the Amaru treasury instance that reuses the
+  observed order-shaped field structure but carries explicit “manual analysis,
+  no upstream typed source” provenance
+
+This preserves the useful typed rendering while making the provenance auditable
+and preventing grouping order from smuggling the SundaeSwap order schema onto
+the treasury change output.

--- a/specs/010-datum-grouping-treasury-schema/spec.md
+++ b/specs/010-datum-grouping-treasury-schema/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Datum Grouping and Explicit Amaru Treasury Schema
+
+**Feature Branch**: `010-datum-grouping-treasury-schema`
+**Created**: 2026-05-04
+**Status**: Draft
+**Input**: GitHub issue #66: "Datums section: group by (cbor, destination) and vendor Amaru treasury schema"
+
+## Context
+
+`tx-deep-diagnosis` currently groups decoded inline datums only by their
+`cbor_hex`. In the committed SundaeSwap/USDM fixture, that collapses the Amaru
+treasury change output together with the SundaeSwap order outputs because they
+happen to share the same inline datum bytes even though their destinations are
+different.
+
+The fixture also exposes a provenance problem. The treasury change output is
+currently rendered with the SundaeSwap order schema only because it was grouped
+into the order block. The pinned upstream `treasury-contracts` source does not
+actually expose a typed treasury datum in `validators/treasury.ak`; the spend
+validator treats the datum as opaque `Data`. This slice therefore needs an
+explicit instance-level schema with honest provenance instead of a false claim
+that the upstream treasury validator provided those field names.
+
+## User Scenarios & Testing
+
+### User Story 1 — Separate identical datums by destination (Priority: P1)
+
+A reviewer reading the Datums section sees separate blocks when the same inline
+datum bytes are sent to different destinations.
+
+**Why this priority**: the current grouping is actively misleading because it
+shows the treasury change output as if it belonged to the SundaeSwap order
+destination.
+
+**Independent Test**: render the committed fixture and verify that output `#0`
+has its own datum block while the order outputs remain grouped together.
+
+**Acceptance Scenarios**:
+
+1. **Given** two outputs share identical `cbor_hex` but resolve to different
+   destination labels, **When** the Datums section renders, **Then** they
+   appear in separate `<details>` blocks.
+2. **Given** multiple outputs share identical `cbor_hex` and the same
+   destination label, **When** the Datums section renders, **Then** they remain
+   collapsed into one block with the output index list.
+
+### User Story 2 — Treasury datum interpretation is explicit (Priority: P1)
+
+A reviewer reading the treasury change datum sees a typed rendering that is
+bound to the Amaru treasury instance intentionally, with provenance that states
+the shape was manually interpreted because the upstream treasury validator does
+not publish a typed datum.
+
+**Why this priority**: the current treasury rendering inherits the order schema
+accidentally from grouping. The output needs an explicit, auditable
+interpretation path of its own.
+
+**Independent Test**: render the committed fixture and verify that the treasury
+block uses a treasury-instance schema provenance line instead of the generic
+untyped fallback or the order-schema disclaimer.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Amaru treasury change output, **When** the Datums section
+   renders, **Then** it uses the schema vendored on the matching
+   `instances[]` entry in `registry.json`.
+2. **Given** that vendored schema is manually curated, **When** the typed datum
+   renders, **Then** the provenance line states that no upstream typed treasury
+   source exists and that the field names come from manual analysis.
+
+### User Story 3 — Group representatives cannot leak labels or schema (Priority: P2)
+
+A reviewer can trust that the destination label and schema used in each datum
+block belong to that block's actual grouping key, not to whichever equal-CBOR
+output happened to win the fold order.
+
+**Why this priority**: the current representative-selection behavior is the
+mechanism that leaks the order label and schema onto the treasury output.
+
+**Independent Test**: inspect the rendered block titles and provenance lines in
+both `summary.md` and `explain.md`; each block must match its own destination.
+
+## Functional Requirements
+
+- **FR-001**: The Datums section MUST group inline datums by the pair
+  `(cbor_hex, destination_label)`, not by `cbor_hex` alone.
+- **FR-002**: Outputs that share the same grouping key MUST remain collapsed
+  into one datum block with the sorted output index list.
+- **FR-003**: Outputs that share `cbor_hex` but differ in destination label
+  MUST render as separate datum blocks.
+- **FR-004**: The Amaru Network Compliance treasury instance
+  (`32201dc1…0baa0d`) in `docs/inspector/protocols/registry.json` MUST carry an
+  explicit datum schema under `instances[]`.
+- **FR-005**: The treasury instance datum schema MUST use provenance that does
+  not claim an upstream typed treasury datum when the pinned upstream source
+  exposes only opaque `Data`.
+- **FR-006**: The treasury change output in the committed SundaeSwap/USDM
+  fixture MUST render against the treasury instance schema rather than
+  inheriting the order schema through grouping.
+- **FR-007**: The SundaeSwap order outputs in the same fixture MUST keep their
+  existing typed order rendering and Aiken provenance.
+- **FR-008**: If a datum AST stops matching the vendored treasury schema, the
+  renderer MUST keep its existing schema-mismatch fallback instead of emitting
+  misleading typed fields.
+
+## Edge Cases
+
+- Identical datum bytes sent to two different script addresses that resolve to
+  different labels.
+- Multiple outputs sent to the same destination with identical datum bytes;
+  these should still collapse into one block.
+- The manually curated treasury schema drifts from the observed datum shape;
+  the renderer must fall back to untyped rather than invent fields.
+
+## Out of Scope
+
+- Changing the fixture transaction itself.
+- Changing the order schema provenance or the generic typed-datum renderer.
+- Claiming a typed upstream treasury datum where the pinned source exposes only
+  opaque `Data`.
+
+## Acceptance
+
+- The Datums section renders one separate block for treasury change output `#0`
+  and separate order blocks according to the actual `(cbor, destination)` keys
+  in the committed fixture.
+- The treasury block uses an explicit treasury-instance schema provenance line,
+  not the order schema by accident.
+- `summary.md` and `explain.md` show the same grouping split.

--- a/specs/010-datum-grouping-treasury-schema/tasks.md
+++ b/specs/010-datum-grouping-treasury-schema/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Datum Grouping and Explicit Amaru Treasury Schema
+
+**Input**: Design documents from
+`/specs/010-datum-grouping-treasury-schema/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+**Tests**: Included because this slice changes user-visible markdown output and
+must keep the committed render goldens stable.
+
+## Phase 1: Renderer grouping
+
+- [X] T001 Change the Datums-section grouping key in `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs` from `cbor` to `(cbor, destination)`
+- [X] T002 Keep datum-block titles and schema provenance bound to the
+      representative chosen for that full grouping key in
+      `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+
+## Phase 2: Registry provenance
+
+- [X] T003 Add an explicit datum schema to the Amaru treasury `instances[]`
+      entry in `docs/inspector/protocols/registry.json`
+- [X] T004 Mark that treasury schema with manual provenance that states the
+      pinned upstream treasury validator does not expose a typed datum source
+
+## Phase 3: Goldens and verification
+
+- [X] T005 Refresh
+      `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md`
+- [X] T006 Refresh
+      `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md`
+- [X] T007 Run `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
+- [X] T008 Run `just format-check`


### PR DESCRIPTION
Refs #66.

## Summary

- group rendered datums by `(cbor_hex, destination_label)` instead of `cbor_hex` alone
- vendor an explicit datum schema on the Amaru treasury instance so the treasury change output no longer inherits the SundaeSwap order schema by accident
- refresh the committed markdown goldens and add the speckit slice for this issue

## Provenance note

The issue body asked for Aiken provenance on the treasury datum. The pinned upstream `SundaeSwap-finance/treasury-contracts` source at `dea9e52671f7a696f0ec6a0f475c7fbe52689c9b` does not expose a typed treasury datum for `treasury.treasury.spend`; it accepts opaque `Data`.

This PR therefore uses the existing `manual` provenance path for the Amaru treasury instance. The field names are explicit and auditable, but the renderer no longer claims they came from an upstream typed treasury datum when that source does not exist.

## Verification

- `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
- `just format-check`
