### PR TITLE
feat: formalize tx.intent output rows

### DIFF
--- a/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+++ b/apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
@@ -27,7 +27,7 @@ module TxDeepDiagnosisHost.Render.Summary (
 import Data.Aeson (Value (..))
 import qualified Data.Aeson.Key as Key
 import qualified Data.Aeson.KeyMap as KeyMap
-import Data.List (foldl')
+import Data.List (foldl', sortOn)
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -592,8 +592,8 @@ outputsSection reg doc =
             then ""
             else
                 "## Outputs\n\n"
-                    <> "| # | Bucket | Destination | ADA | Datum |\n"
-                    <> "|---|--------|-------------|----:|-------|\n"
+                    <> "| # | Bucket | Destination | ADA | Assets | Datum |\n"
+                    <> "|---|--------|-------------|----:|--------|-------|\n"
                     <> Text.concat (map (renderOutputRow reg) items)
                     <> "\n"
 
@@ -614,6 +614,9 @@ renderOutputRow reg v = case v of
                 Just (String s) -> s
                 _ -> "0"
             ada = formatAdaSimple (parseLov lov)
+            assetsCell = case KeyMap.lookup "assets" o of
+                Just assets -> renderAssetsCell assets
+                Nothing -> "—"
             datumCell = case KeyMap.lookup "datum" o of
                 Just (Object d) -> renderDatumCell d
                 _ -> ""
@@ -626,9 +629,39 @@ renderOutputRow reg v = case v of
                 <> " | "
                 <> ada
                 <> " | "
+                <> escapeTable assetsCell
+                <> " | "
                 <> escapeTable datumCell
                 <> " |\n"
     _ -> ""
+
+renderAssetsCell :: Value -> Text
+renderAssetsCell (Object policies) =
+    let rows =
+            sortOn
+                (\(policy, assetName, _) -> (policy, assetName))
+                [ (Key.toText policy, Key.toText assetName, qty)
+                | (policy, Object assetMap) <- KeyMap.toList policies
+                , (assetName, String qty) <- KeyMap.toList assetMap
+                ]
+     in if null rows
+            then "—"
+            else Text.intercalate ", " (map renderAssetPreview rows)
+renderAssetsCell _ = "—"
+
+renderAssetPreview :: (Text, Text, Text) -> Text
+renderAssetPreview (policy, assetName, qty) =
+    shortHex policy <> "." <> assetLabel assetName <> "=" <> qty
+
+assetLabel :: Text -> Text
+assetLabel "" =
+    "[empty]"
+assetLabel assetName = shortHex assetName
+
+shortHex :: Text -> Text
+shortHex h
+    | Text.length h <= 16 = h
+    | otherwise = Text.take 8 h <> "…" <> Text.takeEnd 6 h
 
 renderDatumCell :: KeyMap.KeyMap Value -> Text
 renderDatumCell d = case KeyMap.lookup "kind" d of

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
@@ -141,20 +141,20 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Outputs
 
-| # | Bucket | Destination | ADA | Datum |
-|---|--------|-------------|----:|-------|
-| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | inline `d8799fd8799f58…` (338B) |
-| 1 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 2 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 3 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 4 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 5 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 6 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 7 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 8 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 9 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
-| 11 | external_key | key d2626d | 49,897.955481 | — |
+| # | Bucket | Destination | ADA | Assets | Datum |
+|---|--------|-------------|----:|--------|-------|
+| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | — | inline `d8799fd8799f58…` (338B) |
+| 1 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 2 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 3 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 4 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 5 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 6 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 7 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 8 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 9 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 10 | script | SundaeSwap V3 order | 8,166.545306 | — | — |
+| 11 | external_key | key d2626d | 49,897.955481 | — | — |
 
 ## Datums
 

--- a/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+++ b/apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
@@ -141,20 +141,20 @@ Inputs that also receive outputs (same payment credential on both sides):
 
 ## Outputs
 
-| # | Bucket | Destination | ADA | Datum |
-|---|--------|-------------|----:|-------|
-| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | inline `d8799fd8799f58…` (338B) |
-| 1 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 2 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 3 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 4 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 5 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 6 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 7 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 8 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 9 | script | SundaeSwap V3 order | 12,503.280000 | inline `d8799fd8799f58…` (338B) |
-| 10 | script | SundaeSwap V3 order | 8,166.545306 | — |
-| 11 | external_key | key d2626d | 49,897.955481 | — |
+| # | Bucket | Destination | ADA | Assets | Datum |
+|---|--------|-------------|----:|--------|-------|
+| 0 | script | Amaru Network Compliance treasury (0baa0d) | 1,041,836.734694 | — | inline `d8799fd8799f58…` (338B) |
+| 1 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 2 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 3 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 4 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 5 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 6 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 7 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 8 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 9 | script | SundaeSwap V3 order | 12,503.280000 | — | inline `d8799fd8799f58…` (338B) |
+| 10 | script | SundaeSwap V3 order | 8,166.545306 | — | — |
+| 11 | external_key | key d2626d | 49,897.955481 | — | — |
 
 ## Datums
 

--- a/flake.nix
+++ b/flake.nix
@@ -241,6 +241,13 @@
               and any(.result.intent.value.resolved_input_buckets[]; .bucket == "signer_controlled" and .lovelace == "7015148761")
               and any(.result.intent.value.output_buckets[]; .bucket == "signer_controlled" and .lovelace == "7009247848")
               and any(.result.intent.value.output_buckets[]; .bucket == "script" and .tx_out_count == 4)
+              and (.result.intent.value.outputs | type) == "array"
+              and (.result.intent.value.outputs | length) > 0
+              and any(.result.intent.value.outputs[]; .assets != {})
+              and any(
+                .result.intent.value.outputs[];
+                .assets["193ee65211bb3b4e0ea5f751f415269355a650e2e3706f625cdf1a4b"][""] == "1"
+              )
             ' response.json
             cp request.json response.json $out/
           '';

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -508,6 +508,24 @@ it does not sign, validate, submit, balance, patch, or mutate the transaction.
           "lovelace": "1162532800000",
           "asset_class_count": 0
         }
+      ],
+      "outputs": [
+        {
+          "index": 0,
+          "bucket": "script",
+          "address_hex": "71193ee65211bb3b4e0ea5f751f415269355a650e2e3706f625cdf1a4b",
+          "coin_lovelace": "1400750",
+          "assets": {
+            "193ee65211bb3b4e0ea5f751f415269355a650e2e3706f625cdf1a4b": {
+              "": "1"
+            }
+          },
+          "datum": {
+            "kind": "inline_datum",
+            "cbor_hex": "d8799fd8799f4e4345522f4144412d555344412f331b0000019dc5b5da20d8799f1a94ab3f2d1b00000002540be400ffffd8799f581c3c12f6735ef87655c5b27bced3f828d857d0a27fd20f2cda18ebf2fbffff",
+            "decoded": { "kind": "constr" }
+          }
+        }
       ]
     },
     "warnings": [
@@ -525,7 +543,9 @@ consumers. Each `withdrawals[]` row exposes the serialized reward-account hex,
 its network and staking credential, and the withdrawn lovelace amount. Each
 `signing.required_signers[]` row exposes the declared signer hash, its source,
 and whether that signer is already covered by a vkey witness, a bootstrap
-witness, or still missing.
+witness, or still missing. Each `value.outputs[]` row exposes the exact output
+address, its lovelace amount, its native-asset map (`policy_id -> asset_name ->
+quantity`), and its datum state (`no_datum`, `datum_hash`, or `inline_datum`).
 When `context.producer_txs` resolves every regular input, `value.signer_lovelace`
 reports a known net ADA amount from resolved signer-controlled inputs minus
 signer-controlled outputs. Ownership is intentionally conservative: only output

--- a/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
@@ -51,6 +51,10 @@
         "output_buckets": {
           "type": "array",
           "items": { "$ref": "#/$defs/valueBucket" }
+        },
+        "outputs": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/intentOutput" }
         }
       },
       "additionalProperties": true
@@ -240,6 +244,44 @@
         "tx_out_count": { "type": "integer", "minimum": 0 },
         "lovelace": { "type": "string" },
         "asset_class_count": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "assetMap": {
+      "type": "object",
+      "description": "Nested policy-id -> asset-name -> quantity map. Policy ids and asset names are hex strings; quantities are decimal strings.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      }
+    },
+    "datumState": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["no_datum", "datum_hash", "inline_datum"]
+        },
+        "hash": { "type": "string" },
+        "cbor_hex": { "type": "string" },
+        "decoded": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    },
+    "intentOutput": {
+      "type": "object",
+      "required": ["index", "bucket", "address_hex", "coin_lovelace", "assets", "datum"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "bucket": {
+          "type": "string",
+          "enum": ["signer_controlled", "external_key", "script", "bootstrap"]
+        },
+        "address_hex": { "type": "string" },
+        "coin_lovelace": { "type": "string" },
+        "assets": { "$ref": "#/$defs/assetMap" },
+        "datum": { "$ref": "#/$defs/datumState" }
       },
       "additionalProperties": true
     }

--- a/specs/011-intent-output-values-assets/data-model.md
+++ b/specs/011-intent-output-values-assets/data-model.md
@@ -1,0 +1,20 @@
+# Data Model: Formalize tx.intent Output Rows and Asset Detail
+
+## Intent Output Row
+
+- `index`: output index in transaction order
+- `bucket`: signer/control bucket label already used by the value summary
+- `address_hex`: serialized output address
+- `coin_lovelace`: lovelace amount for this exact output
+- `assets`: nested policy-id → asset-name → quantity map
+- `datum`: datum state (`no_datum`, `datum_hash`, or `inline_datum`)
+
+## Asset Preview
+
+- `empty`: render `—`
+- `single asset`: render one compact `policy.asset = qty` preview
+- `multiple assets`: render a deterministic comma-separated preview in sorted
+  order
+
+The preview is purely for report readability. The JSON contract remains the raw
+`assets` object.

--- a/specs/011-intent-output-values-assets/plan.md
+++ b/specs/011-intent-output-values-assets/plan.md
@@ -1,0 +1,88 @@
+# Implementation Plan: Formalize tx.intent Output Rows and Asset Detail
+
+**Branch**: `011-intent-output-values-assets` | **Date**: 2026-05-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/011-intent-output-values-assets/spec.md`
+
+## Status
+
+- **Completed**: issue-57 worktree setup, baseline `tx-intent-smoke`, and
+  discovery that `value.outputs[]` already exists in the live implementation.
+- **Current**: encode that output row in the public contract and use it in the
+  renderer.
+- **Blockers**: None.
+
+## Summary
+
+This slice fixes contract drift around `tx.intent.value.outputs[]`. The live
+implementation already returns per-output address, lovelace, assets, and datum,
+but the public schema/docs do not describe it and the markdown Outputs table
+does not show assets. The implementation will formalize the row shape in the
+schema/docs/OpenAPI, extend `tx-intent-smoke` to assert output-level assets on
+the existing Conway fixture, and add an Assets column to the report table.
+
+## Technical Context
+
+**Language/Version**: Haskell2010 plus JSON/OpenAPI artifacts via the existing
+Nix generation flow
+
+**Primary Dependencies**: existing `tx.intent` implementation in
+`libs/cardano-ledger-inspector`, `tx-deep-diagnosis` summary renderer, committed
+JSON schema, generated OpenAPI, and Nix smoke checks
+
+**Storage**: committed schema/docs/OpenAPI files and markdown goldens
+
+**Testing**: `tx-intent-smoke`, `tx-explain-render-smoke`, `just format-check`,
+and `ledger-functional-openapi-check`
+
+**Constraints**: preserve existing wire values; avoid inventing semantics that
+the live JSON does not already carry; keep asset previews deterministic
+
+## Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. No new ledger decoding logic needed.
+- **Transaction Documents Own State**: PASS. Renderer output is derived from the
+  existing response document.
+- **JSON Control Plane, CBOR Data Plane**: PASS. This slice strengthens the
+  JSON contract without changing CBOR fidelity.
+- **Explicit Context Only**: PASS. No provider or chain lookups added.
+- **The Library Is the Canonical Artifact**: PASS. We are documenting and
+  rendering fields the library already emits.
+- **Quality Gates**: PASS. Smoke, OpenAPI, render smoke, and format-check cover
+  the slice.
+
+## Project Structure
+
+```text
+specs/011-intent-output-values-assets/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md
+
+apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs
+apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md
+apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md
+flake.nix
+specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json
+```
+
+## Phase Plan
+
+1. Add the speckit slice documenting the contract drift and the chosen scope.
+2. Extend the `tx.intent` schema/docs/OpenAPI to describe `value.outputs[]`.
+3. Strengthen `tx-intent-smoke` with output-row and non-empty-asset assertions.
+4. Add an Assets column to the markdown Outputs table and refresh goldens.
+5. Re-run the contract, renderer, and format gates.
+
+## Post-Design Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS.
+- **Transaction Documents Own State**: PASS.
+- **JSON Control Plane, CBOR Data Plane**: PASS.
+- **Explicit Context Only**: PASS.
+- **The Library Is the Canonical Artifact**: PASS.
+- **Quality Gates**: PASS.

--- a/specs/011-intent-output-values-assets/quickstart.md
+++ b/specs/011-intent-output-values-assets/quickstart.md
@@ -1,0 +1,20 @@
+# Quickstart: Formalize tx.intent Output Rows and Asset Detail
+
+## Verify the tx.intent contract
+
+```bash
+nix build .#checks.x86_64-linux.tx-intent-smoke
+nix build .#checks.x86_64-linux.ledger-functional-openapi-check
+```
+
+## Verify the renderer
+
+```bash
+nix build .#checks.x86_64-linux.tx-explain-render-smoke
+```
+
+## Verify formatting
+
+```bash
+just format-check
+```

--- a/specs/011-intent-output-values-assets/research.md
+++ b/specs/011-intent-output-values-assets/research.md
@@ -1,0 +1,25 @@
+# Research: Formalize tx.intent Output Rows and Asset Detail
+
+## Findings
+
+1. The live `tx.intent` implementation already emits `value.outputs[]` through
+   `intentOutputJson`, and each row already includes `index`, `bucket`,
+   `address_hex`, `coin_lovelace`, `assets`, and `datum`.
+2. The committed schema for `tx.intent` does not describe `value.outputs[]`, so
+   contract consumers only see it today through `additionalProperties`.
+3. The current markdown Outputs table already reads `value.outputs[]`, but it
+   only shows output index, bucket, destination, ADA, and datum preview. Asset
+   detail is hidden.
+4. The existing `conway-mainnet-tx.hex` fixture already produces non-empty
+   `value.outputs[].assets` rows under `tx.intent`, so no new chain fixture is
+   required to verify asset-bearing outputs.
+
+## Decision
+
+Use the existing `value.outputs[]` payload as the source of truth:
+
+- formalize it in the schema/docs/OpenAPI
+- strengthen the `tx-intent-smoke` assertions around it
+- surface its `assets` field in the human-readable Outputs table
+
+No library-level wire-format expansion is needed for this slice.

--- a/specs/011-intent-output-values-assets/spec.md
+++ b/specs/011-intent-output-values-assets/spec.md
@@ -1,0 +1,105 @@
+# Feature Specification: Formalize tx.intent Output Rows and Asset Detail
+
+**Feature Branch**: `011-intent-output-values-assets`
+**Created**: 2026-05-04
+**Status**: Draft
+**Input**: GitHub issue #57: "tx.intent: information audit — fields decoded by the ledger but dropped from the envelope"
+
+## Context
+
+During issue-57 triage, the current code showed an important drift: the live
+`tx.intent` implementation already emits `value.outputs[]` with per-output
+`address_hex`, `coin_lovelace`, `assets`, and `datum`, but the committed JSON
+schema and public contract text do not describe that structure as part of the
+supported result. The markdown report also shows only ADA and datum preview in
+its Outputs table, so asset-bearing outputs remain hidden from the default
+reader view.
+
+This slice fixes that drift. It does not invent new ledger decoding. It makes
+the existing per-output rows contractual, verifies them in smoke tests, and
+surfaces per-output asset detail in the markdown report.
+
+## User Scenarios & Testing
+
+### User Story 1 — API consumers can rely on value.outputs[] (Priority: P1)
+
+An API consumer reading the `tx.intent` contract can treat `value.outputs[]` as
+part of the supported result, rather than an undocumented extra field.
+
+**Why this priority**: contract drift is the main risk here. Consumers cannot
+depend on a field that the schema and docs do not admit exists.
+
+**Independent Test**: validate the updated schema/docs and extend the smoke
+check to assert that `value.outputs[]` exists with non-empty asset maps on the
+existing Conway fixture.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `tx.intent` response, **When** the consumer validates it against
+   the committed schema, **Then** `value.outputs[]` is an explicitly described
+   field rather than an undocumented extra.
+2. **Given** the asset-bearing Conway fixture, **When** `tx-intent-smoke`
+   runs, **Then** it proves at least one output row carries a non-empty
+   `assets` object.
+
+### User Story 2 — Report readers can see per-output assets (Priority: P1)
+
+A report reader scanning the Outputs table can see which outputs carry native
+assets without opening raw JSON.
+
+**Why this priority**: this is the human-facing payoff of surfacing
+per-output rows. ADA alone is not enough to verify swaps or NFT-bearing
+outputs.
+
+**Independent Test**: re-render the existing markdown goldens and verify the
+Outputs table gains an Assets column with stable formatting.
+
+**Acceptance Scenarios**:
+
+1. **Given** an output has no assets, **When** the Outputs table renders,
+   **Then** the Assets cell shows `—`.
+2. **Given** an output has one or more assets, **When** the Outputs table
+   renders, **Then** the Assets cell shows a compact preview derived from the
+   output's `assets` map.
+
+## Functional Requirements
+
+- **FR-001**: The committed `tx.intent` schema MUST describe
+  `value.outputs[]` explicitly.
+- **FR-002**: Each documented output row MUST include at least:
+  `index`, `bucket`, `address_hex`, `coin_lovelace`, `assets`, and `datum`.
+- **FR-003**: The public `ledger-functional-api.md` contract text MUST mention
+  `value.outputs[]` as part of the supported `tx.intent` result.
+- **FR-004**: The generated OpenAPI artifact MUST stay in sync with that
+  contract update.
+- **FR-005**: `tx-intent-smoke` MUST assert that `value.outputs[]` is an array
+  and that the existing Conway fixture includes at least one row whose `assets`
+  map is non-empty.
+- **FR-006**: The markdown Outputs table in `tx-deep-diagnosis` MUST include an
+  Assets column derived from `value.outputs[].assets`.
+- **FR-007**: Assetless outputs MUST render `—` in that Assets column.
+- **FR-008**: Asset-bearing outputs MUST render a deterministic compact preview
+  from the `assets` map without hiding the ADA or datum columns.
+
+## Edge Cases
+
+- Outputs with an empty `assets` object.
+- Outputs with one policy id and one empty asset name (NFT-style marker
+  assets).
+- Outputs with multiple policies and multiple asset names; the preview must
+  remain deterministic and compact.
+
+## Out of Scope
+
+- Computing per-asset transfer edges between inputs and outputs.
+- Resolving policy IDs or asset names to registry labels.
+- Adding new ledger-decoded output fields beyond the ones already present in
+  the live implementation.
+
+## Acceptance
+
+- The committed schema/docs/OpenAPI explicitly describe `value.outputs[]`.
+- `tx-intent-smoke` proves output rows and non-empty assets on the existing
+  Conway fixture.
+- The markdown Outputs table shows an Assets column in both `summary.md` and
+  `explain.md`.

--- a/specs/011-intent-output-values-assets/tasks.md
+++ b/specs/011-intent-output-values-assets/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Formalize tx.intent Output Rows and Asset Detail
+
+**Input**: Design documents from `/specs/011-intent-output-values-assets/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+**Tests**: Included because this slice changes both the public contract and the
+human-facing report.
+
+## Phase 1: Contract surface
+
+- [X] T001 Add an explicit `value.outputs[]` definition to `specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json`
+- [X] T002 Update `specs/001-ledger-functional-layer/contracts/ledger-functional-api.md` to describe `value.outputs[]`
+- [X] T003 Refresh `specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json`
+
+## Phase 2: Verification of live payload
+
+- [X] T004 Extend `tx-intent-smoke` in `flake.nix` to assert that
+      `value.outputs[]` exists and that the existing Conway fixture has at
+      least one non-empty `assets` map
+
+## Phase 3: Renderer
+
+- [X] T005 Add an Assets column to
+      `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs`
+- [X] T006 Refresh
+      `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/summary.md`
+- [X] T007 Refresh
+      `apps/tx-deep-diagnosis/test/golden/value-not-conserved/expected/explain.md`
+
+## Phase 4: Verification
+
+- [X] T008 Run `nix build .#checks.x86_64-linux.tx-intent-smoke`
+- [X] T009 Run `nix build .#checks.x86_64-linux.ledger-functional-openapi-check`
+- [X] T010 Run `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
+- [X] T011 Run `just format-check`


### PR DESCRIPTION
## Summary
- formalize `tx.intent.value.outputs[]` in the public JSON schema and contract docs
- strengthen `tx-intent-smoke` to assert live output asset detail on the existing Conway fixture
- surface per-output asset detail in the markdown Outputs table and refresh the render goldens

## Context
This is a focused slice of #57, not a full close. The implementation already emitted `value.outputs[]`; this PR makes the contract and human-facing report catch up.

## Verification
- `nix build .#checks.x86_64-linux.tx-intent-smoke`
- `nix build .#checks.x86_64-linux.ledger-functional-openapi-check`
- `nix build .#checks.x86_64-linux.tx-explain-render-smoke`
- `just format-check`