### PR TITLE
feat: add tx.witness.attach ledger operation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -213,6 +213,116 @@
             cp request.json response.json $out/
           '';
 
+          tx-witness-attach-smoke = pkgs.runCommand "tx-witness-attach-smoke" { } ''
+            mkdir -p $out
+            export HOME="$PWD"
+            export XDG_CACHE_HOME="$PWD/.cache"
+            mkdir -p "$XDG_CACHE_HOME"
+
+            ${pkgs.jq}/bin/jq -n \
+              --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: ($tx | gsub("\\s"; "")),
+                op: "tx.identify",
+                args: {}
+              }' > identify-original-request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < identify-original-request.json > identify-original-response.json
+
+            ${pkgs.jq}/bin/jq -n \
+              --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
+              --arg witness "825820000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f5840202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f" \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: ($tx | gsub("\\s"; "")),
+                op: "tx.witness.attach",
+                args: {
+                  vkey_witness_cbor_hex: ($witness | gsub("\\s"; ""))
+                }
+              }' > attach-request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < attach-request.json > attach-response.json
+
+            ${pkgs.jq}/bin/jq -n \
+              --slurpfile attach attach-response.json \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: $attach[0].result.witness_attachment.signed_tx_cbor_hex,
+                op: "tx.identify",
+                args: {}
+              }' > identify-patched-request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < identify-patched-request.json > identify-patched-response.json
+
+            ${pkgs.jq}/bin/jq -n \
+              --slurpfile attach attach-response.json \
+              --arg witness "825820000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f5840202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f" \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: $attach[0].result.witness_attachment.signed_tx_cbor_hex,
+                op: "tx.witness.attach",
+                args: {
+                  vkey_witness_cbor_hex: ($witness | gsub("\\s"; ""))
+                }
+              }' > reattach-request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < reattach-request.json > reattach-response.json
+
+            ${pkgs.jq}/bin/jq -n \
+              --rawfile tx ${./specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex} \
+              '{
+                ledger_functional_layer: "cardano-ledger-functional/v1",
+                tx_cbor: ($tx | gsub("\\s"; "")),
+                op: "tx.witness.attach",
+                args: {}
+              }' > missing-witness-request.json
+            ${pkgs.wasmtime}/bin/wasmtime \
+              ${wasmTargets.wasm-tx-inspector}/wasm-tx-inspector.wasm \
+              < missing-witness-request.json > missing-witness-response.json
+
+            ${pkgs.jq}/bin/jq -e -s '
+              .[0].result.identification as $before
+              | .[1].result.witness_attachment as $attach
+              | .[2].result.identification as $after
+              | .[3].result.witness_attachment as $reattach
+              | .[4].result.witness_attachment as $missing
+              | .[1].ledger_functional_layer == "cardano-ledger-functional/v1"
+              and .[1].op == "tx.witness.attach"
+              and $attach.status == "applied"
+              and $attach.witness_patch_action == "inserted"
+              and ($attach.signed_tx_cbor_hex | test("^[0-9a-f]+$"))
+              and ($attach.tx_id | test("^[0-9a-f]{64}$"))
+              and ($attach.body_hash | test("^[0-9a-f]{64}$"))
+              and ($attach.errors | length == 0)
+              and ($attach.warnings | type == "array")
+              and $after.tx_id == $before.tx_id
+              and $after.body_hash == $before.body_hash
+              and $after.witness_counts.vkey == ($before.witness_counts.vkey + 1)
+              and $reattach.status == "applied"
+              and $reattach.witness_patch_action == "replaced"
+              and $reattach.signed_tx_cbor_hex == $attach.signed_tx_cbor_hex
+              and $missing.status == "rejected"
+              and ($missing.errors | type == "array")
+              and ([$missing.errors[]? | select(.code == "missing_vkey_witness_cbor_hex")] | length == 1)
+            ' \
+              identify-original-response.json \
+              attach-response.json \
+              identify-patched-response.json \
+              reattach-response.json \
+              missing-witness-response.json
+            cp identify-original-request.json identify-original-response.json \
+              attach-request.json attach-response.json \
+              identify-patched-request.json identify-patched-response.json \
+              reattach-request.json reattach-response.json \
+              missing-witness-request.json missing-witness-response.json \
+              $out/
+          '';
+
           tx-intent-smoke = pkgs.runCommand "tx-intent-smoke" { } ''
             mkdir -p $out
             export HOME="$PWD"
@@ -721,6 +831,7 @@
               ledger-functional-openapi-check
               tx-identify-smoke
               tx-witness-plan-smoke
+              tx-witness-attach-smoke
               tx-intent-smoke
               tx-input-context-smoke
               tx-validate-smoke
@@ -817,6 +928,8 @@
                 mkApp (mkSmokeApp "tx-identify-smoke" tx-identify-smoke);
               tx-witness-plan-smoke =
                 mkApp (mkSmokeApp "tx-witness-plan-smoke" tx-witness-plan-smoke);
+              tx-witness-attach-smoke =
+                mkApp (mkSmokeApp "tx-witness-attach-smoke" tx-witness-attach-smoke);
               tx-intent-smoke =
                 mkApp (mkSmokeApp "tx-intent-smoke" tx-intent-smoke);
               tx-validate-smoke =

--- a/gh-docs/api.md
+++ b/gh-docs/api.md
@@ -73,6 +73,7 @@ Haskell ledger layer derives referenced outputs.
 | `tx.identify` | Return transaction id, body hash, era, byte size, fee, structural counts, and witness counts. |
 | `tx.intent` | Return a signer-focused summary of visible transaction effects, self-declared metadata intent, required signers, scripts, withdrawals, mint/burn, collateral, and context coverage. |
 | `tx.witness.plan` | Return signer, witness, script, redeemer, datum, reference-input, and explicit producer-transaction context coverage data. |
+| `tx.witness.attach` | Attach or replace one vkey witness, preserve all other witness-set content, and return patched transaction CBOR plus stable diagnostics. |
 | `tx.validate` | Decode explicit context, build a Conway ledger environment, run `applyTx` when context is complete, and report ledger failures without mutating CBOR. |
 | `tx.evaluate.scripts` | Decode explicit context, run upstream phase-2 script evaluation when context is complete, and report per-redeemer execution units or failures without mutating CBOR. |
 
@@ -88,6 +89,13 @@ name and array indexes use `#<index>`, for example:
   }
 }
 ```
+
+`tx.witness.attach` accepts `args.vkey_witness_cbor_hex`. On success it returns
+the patched transaction bytes at `result.tx_cbor` and also reports
+`result.witness_attachment.signed_tx_cbor_hex` plus
+`witness_patch_action = "inserted" | "replaced"`. On rejection it returns
+`result.witness_attachment.status = "rejected"` with stable `errors[]`
+diagnostics instead of mutating the transaction.
 
 ## 0.1 Target Surface
 
@@ -115,6 +123,7 @@ The detailed contract and schemas are tracked in the repository:
 - [tx.identify result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-identify-result.schema.json)
 - [tx.intent result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-intent-result.schema.json)
 - [tx.witness.plan result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-witness-plan-result.schema.json)
+- [tx.witness.attach result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-witness-attach-result.schema.json)
 - [tx.validate result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-validate-result.schema.json)
 - [tx.evaluate.scripts result schema](https://github.com/lambdasistemi/cardano-ledger-inspector/blob/main/specs/001-ledger-functional-layer/schemas/tx-evaluate-scripts-result.schema.json)
 

--- a/gh-docs/architecture.md
+++ b/gh-docs/architecture.md
@@ -172,6 +172,7 @@ implicit network access during the final build.
 | `checks.<system>.ledger-functional-swagger-check` | Alias of the OpenAPI check for the Swagger compatibility name. |
 | `checks.<system>.tx-identify-smoke` | Runs `tx.identify` through `wasm-tx-inspector.wasm` and asserts stable identity, size, fee, and witness-count fields. |
 | `checks.<system>.tx-witness-plan-smoke` | Runs `tx.witness.plan` without context and asserts witness, script, datum, redeemer, and warning shapes. |
+| `checks.<system>.tx-witness-attach-smoke` | Runs `tx.witness.attach`, asserts inserted vs replaced behavior, preserves transaction identity, and checks rejected missing-witness diagnostics. |
 | `checks.<system>.tx-input-context-smoke` | Derives synthetic producer transaction context from inspection output and verifies resolved input reporting. |
 | `checks.<system>.tx-validate-smoke` | Covers missing context, unsupported provider-style UTxO JSON, complete valid context, deterministic validation output, and invalid supplied network context. |
 | `checks.<system>.tx-evaluate-scripts-smoke` | Covers missing context, rejected provider-style UTxO JSON, complete script evaluation, deterministic output, budgeted units, and evaluated units. |

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -102,6 +102,14 @@ producer transaction CBOR that could not be fetched.
   input address credentials and reference scripts cannot be inferred from
   transaction CBOR alone.
 
+`tx.witness.attach`
+: Decode one hex-encoded vkey witness and attach it upstream in Haskell rather
+  than browser-only JavaScript. The operation only inserts or replaces the
+  matching vkey witness, preserves all other witness-set content, returns the
+  patched bytes at `result.tx_cbor`, and reports stable `errors[]` diagnostics
+  when the witness payload is missing or malformed. It does not handle secret
+  keys.
+
 `tx.validate`
 : Return structured validation status for the selected transaction and explicit
   context. The operation reports `valid`, `invalid`, `incomplete`, or
@@ -124,6 +132,9 @@ transaction id is passed as explicit `args.context.producer_txs`, and provider
 tip/protocol-parameter data is passed as explicit validation context. Missing
 governance, certificate, or failed provider context remains visible as
 validation diagnostics rather than being guessed by the UI.
+
+`tx.witness.attach` is available through the same WASI/API boundary for signing
+flows, so browser and CLI hosts can share the same witness-set patching logic.
 
 `tx.evaluate.scripts` is available through the WASI/API boundary; a dedicated
 browser panel can be added separately once its UI flow is selected.

--- a/justfile
+++ b/justfile
@@ -22,6 +22,9 @@ check-identify:
 check-witness-plan:
     nix build .#checks.x86_64-linux.tx-witness-plan-smoke -o result-witness-plan-smoke
 
+check-witness-attach:
+    nix build .#checks.x86_64-linux.tx-witness-attach-smoke -o result-witness-attach-smoke
+
 check-intent:
     nix build .#checks.x86_64-linux.tx-intent-smoke -o result-intent-smoke
 
@@ -49,6 +52,7 @@ test-playwright: build-ui
 test:
     just check-identify
     just check-witness-plan
+    just check-witness-attach
     just check-intent
     just check-input-context
     just check-validate

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector.hs
@@ -36,10 +36,15 @@ import qualified Cardano.Ledger.TxIn as TxIn
 import Control.Monad ((>=>))
 import Conway.Inspector.Common
     ( InspectError (..)
+    , argsObject
+    , cborHexText
     , decodeTx
     , decodeTxWithBytes
+    , decodeVKeyWitness
     , keyHashHex
     , listAt
+    , lookupObjectValue
+    , lookupValue
     , multiAssetJson
     , safeHashHex
     , scriptHashHex
@@ -69,14 +74,16 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Lazy as BSL
 import Data.Foldable (toList)
+import Data.Function ((&))
 import Data.List (foldl', stripPrefix)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe, isNothing, mapMaybe)
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import Data.Typeable (Typeable)
 import Data.Word (Word64)
-import Lens.Micro ((^.))
+import Lens.Micro ((%~), (^.))
 import Text.Read (readMaybe)
 
 data LedgerOperationRequest = LedgerOperationRequest
@@ -124,6 +131,7 @@ instance Aeson.FromJSON LedgerOperationRequest where
         normalizeOperation "intent" = "tx.intent"
         normalizeOperation "identify" = "tx.identify"
         normalizeOperation "witness.plan" = "tx.witness.plan"
+        normalizeOperation "witness.attach" = "tx.witness.attach"
         normalizeOperation "validate" = "tx.validate"
         normalizeOperation "evaluate.scripts" = "tx.evaluate.scripts"
         normalizeOperation op = op
@@ -190,6 +198,11 @@ runLedgerOperation request = do
                     (lorOperation request)
                     [ "witness_plan" .= witnessPlanJson (lorArgs request) tx
                     ]
+        "tx.witness.attach" ->
+            pure $
+                ledgerOperationResponse
+                    (lorOperation request)
+                    (witnessAttachmentResultFields (lorArgs request) tx)
         "tx.validate" ->
             pure $
                 ledgerOperationResponse
@@ -213,6 +226,147 @@ ledgerOperationResponse operation resultFields =
         , "op" .= operation
         , "result" .= Aeson.object resultFields
         ]
+
+witnessAttachmentResultFields
+    :: Aeson.Value
+    -> L.Tx TopTx Conway.ConwayEra
+    -> [(AesonKey.Key, Aeson.Value)]
+witnessAttachmentResultFields args tx =
+    let attachment = witnessAttachmentJson args tx
+        txCborField =
+            case attachment of
+                Aeson.Object object ->
+                    case KeyMap.lookup "tx_cbor" object of
+                        Just txCbor -> ["tx_cbor" .= txCbor]
+                        Nothing -> []
+                _ -> []
+    in  txCborField <> ["witness_attachment" .= attachment]
+
+witnessAttachmentJson
+    :: Aeson.Value
+    -> L.Tx TopTx Conway.ConwayEra
+    -> Aeson.Value
+witnessAttachmentJson args tx =
+    let body = tx ^. L.bodyTxL
+    in  case decodeWitnessAttachmentArg args of
+            Left errors ->
+                Aeson.object
+                    [ "status" .= ("rejected" :: T.Text)
+                    , "tx_id" .= txIdHex (Core.txIdTx tx)
+                    , "body_hash" .= txIdHex (Core.txIdTxBody body)
+                    , "errors" .= errors
+                    , "warnings" .= ([] :: [T.Text])
+                    ]
+            Right witness ->
+                let existingWitnesses = tx ^. (Core.witsTxL . Core.addrTxWitsL)
+                    replacedExisting = any (sameWitnessKey witness) existingWitnesses
+                    nextWitnesses =
+                        Set.insert
+                            witness
+                            (Set.filter (not . sameWitnessKey witness) existingWitnesses)
+                    witnessPatchAction :: T.Text
+                    witnessPatchAction
+                        | replacedExisting =
+                            "replaced"
+                        | otherwise =
+                            "inserted"
+                    patchedTx =
+                        tx
+                            & Core.witsTxL
+                                . Core.addrTxWitsL
+                                %~ const nextWitnesses
+                    signedTxCborHex = cborHexText patchedTx
+                in  Aeson.object
+                        [ "status" .= ("applied" :: T.Text)
+                        , "tx_id" .= txIdHex (Core.txIdTx patchedTx)
+                        , "body_hash" .= txIdHex (Core.txIdTxBody body)
+                        , "tx_cbor" .= signedTxCborHex
+                        , "signed_tx_cbor_hex" .= signedTxCborHex
+                        , "witness_patch_action" .= witnessPatchAction
+                        , "errors" .= ([] :: [Aeson.Value])
+                        , "warnings" .= ([] :: [T.Text])
+                        ]
+
+decodeWitnessAttachmentArg
+    :: (Typeable kr)
+    => Aeson.Value
+    -> Either [Aeson.Value] (Keys.WitVKey kr)
+decodeWitnessAttachmentArg args =
+    case argsObject args >>= lookupObjectValue "vkey_witness_cbor_hex" of
+        Nothing ->
+            Left
+                [ witnessAttachmentErrorJson
+                    "missing_vkey_witness_cbor_hex"
+                    "Supply args.vkey_witness_cbor_hex as hex-encoded CBOR for a single vkey witness."
+                    ["args", "vkey_witness_cbor_hex"]
+                    Aeson.Null
+                ]
+        Just (Aeson.String witnessHex) ->
+            case decodeVKeyWitness (T.encodeUtf8 witnessHex) of
+                Left (MalformedHex err) ->
+                    Left
+                        [ witnessAttachmentErrorJson
+                            "malformed_vkey_witness_cbor_hex"
+                            "args.vkey_witness_cbor_hex must be valid hex."
+                            ["args", "vkey_witness_cbor_hex"]
+                            (Aeson.object ["detail" .= err])
+                        ]
+                Left (MalformedCbor err) ->
+                    Left
+                        [ witnessAttachmentErrorJson
+                            "malformed_vkey_witness_cbor"
+                            "args.vkey_witness_cbor_hex must decode as a single Shelley/Conway vkey witness."
+                            ["args", "vkey_witness_cbor_hex"]
+                            (Aeson.object ["detail" .= err])
+                        ]
+                Left other ->
+                    Left
+                        [ witnessAttachmentErrorJson
+                            "invalid_vkey_witness_cbor_hex"
+                            "args.vkey_witness_cbor_hex could not be used as a vkey witness."
+                            ["args", "vkey_witness_cbor_hex"]
+                            (Aeson.object ["detail" .= T.pack (show other)])
+                        ]
+                Right witness ->
+                    Right witness
+        Just value ->
+            Left
+                [ witnessAttachmentErrorJson
+                    "invalid_vkey_witness_cbor_hex_type"
+                    "args.vkey_witness_cbor_hex must be a hex string."
+                    ["args", "vkey_witness_cbor_hex"]
+                    (Aeson.object ["actual_type" .= jsonValueType value])
+                ]
+
+witnessAttachmentErrorJson
+    :: T.Text
+    -> T.Text
+    -> [T.Text]
+    -> Aeson.Value
+    -> Aeson.Value
+witnessAttachmentErrorJson code message path details =
+    Aeson.object
+        [ "code" .= code
+        , "message" .= message
+        , "path" .= path
+        , "details" .= details
+        ]
+
+sameWitnessKey
+    :: Keys.WitVKey leftRole
+    -> Keys.WitVKey rightRole
+    -> Bool
+sameWitnessKey left right =
+    Keys.witVKeyHash left == Keys.witVKeyHash right
+
+jsonValueType :: Aeson.Value -> T.Text
+jsonValueType = \case
+    Aeson.Object _ -> "object"
+    Aeson.Array _ -> "array"
+    Aeson.String _ -> "string"
+    Aeson.Number _ -> "number"
+    Aeson.Bool _ -> "boolean"
+    Aeson.Null -> "null"
 
 browserJson
     :: L.Tx TopTx Conway.ConwayEra

--- a/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
+++ b/libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs
@@ -11,9 +11,11 @@
 module Conway.Inspector.Common
     ( InspectError (..)
     , argsObject
+    , cborHexText
     , decodeConway
     , decodeTx
     , decodeTxWithBytes
+    , decodeVKeyWitness
     , hashHex
     , hexDecode
     , keyHashHex
@@ -44,6 +46,7 @@ import qualified Cardano.Ledger.Conway as Conway
 import Cardano.Ledger.Core (TxLevel (..))
 import qualified Cardano.Ledger.Credential as Credential
 import qualified Cardano.Ledger.Hashes as Hashes
+import qualified Cardano.Ledger.Keys as Keys
 import qualified Cardano.Ledger.Mary.Value as Mary
 import qualified Cardano.Ledger.Plutus.Data as PData
 import qualified Cardano.Ledger.TxIn as TxIn
@@ -58,6 +61,7 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
+import Data.Typeable (Typeable)
 import Lens.Micro ((^.))
 import qualified PlutusLedgerApi.V1 as PV1
 
@@ -100,6 +104,26 @@ decodeConway bs =
         bs of
         Left err -> Left (MalformedCbor (show err))
         Right tx -> Right tx
+
+decodeVKeyWitness
+    :: (Typeable kr)
+    => BS.ByteString
+    -> Either InspectError (Keys.WitVKey kr)
+decodeVKeyWitness hexBytes = do
+    witnessBytes <- hexDecode hexBytes
+    case Binary.decodeFullAnnotator
+        (Binary.natVersion @11)
+        "WitVKey"
+        Binary.decCBOR
+        (BSL.fromStrict witnessBytes) of
+        Left err -> Left (MalformedCbor (show err))
+        Right witness -> Right witness
+
+cborHexText :: (Binary.EncCBOR a) => a -> T.Text
+cborHexText =
+    T.decodeUtf8
+        . B16.encode
+        . Binary.serialize' (Binary.natVersion @11)
 
 listAt :: Int -> [a] -> Maybe a
 listAt index xs

--- a/nix/ledger-functional-openapi.nix
+++ b/nix/ledger-functional-openapi.nix
@@ -115,6 +115,17 @@
                     };
                   };
                 };
+                witnessAttach = {
+                  summary = "Attach or replace one vkey witness";
+                  value = {
+                    ledger_functional_layer = "cardano-ledger-functional/v1";
+                    tx_cbor = "84a4...";
+                    op = "tx.witness.attach";
+                    args = {
+                      vkey_witness_cbor_hex = "825820000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f5840202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f";
+                    };
+                  };
+                };
                 validate = {
                   summary = "Validate a transaction or report missing context";
                   value = {
@@ -496,6 +507,52 @@
                       };
                     };
                   };
+                  witnessAttach = {
+                    summary = "Witness attachment response envelope";
+                    value = {
+                      ledger_functional_layer = "cardano-ledger-functional/v1";
+                      op = "tx.witness.attach";
+                      result = {
+                        tx_cbor = "84a4...";
+                        witness_attachment = {
+                          status = "applied";
+                          tx_id = "0000000000000000000000000000000000000000000000000000000000000000";
+                          body_hash = "1111111111111111111111111111111111111111111111111111111111111111";
+                          tx_cbor = "84a4...";
+                          signed_tx_cbor_hex = "84a4...";
+                          witness_patch_action = "inserted";
+                          errors = [ ];
+                          warnings = [ ];
+                        };
+                      };
+                    };
+                  };
+                  witnessAttachRejected = {
+                    summary = "Rejected witness attachment with stable diagnostics";
+                    value = {
+                      ledger_functional_layer = "cardano-ledger-functional/v1";
+                      op = "tx.witness.attach";
+                      result = {
+                        witness_attachment = {
+                          status = "rejected";
+                          tx_id = "0000000000000000000000000000000000000000000000000000000000000000";
+                          body_hash = "1111111111111111111111111111111111111111111111111111111111111111";
+                          errors = [
+                            {
+                              code = "missing_vkey_witness_cbor_hex";
+                              message = "Supply args.vkey_witness_cbor_hex as hex-encoded CBOR for a single vkey witness.";
+                              path = [
+                                "args"
+                                "vkey_witness_cbor_hex"
+                              ];
+                              details = null;
+                            }
+                          ];
+                          warnings = [ ];
+                        };
+                      };
+                    };
+                  };
                   patch = {
                     summary = "Target shape for a transforming operation";
                     value = {
@@ -695,6 +752,9 @@
       };
       TxWitnessPlanResult = {
         "$ref" = "tx-witness-plan-result.schema.json";
+      };
+      TxWitnessAttachResult = {
+        "$ref" = "tx-witness-attach-result.schema.json";
       };
       TxValidateResult = {
         "$ref" = "tx-validate-result.schema.json";

--- a/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
+++ b/specs/001-ledger-functional-layer/contracts/ledger-functional-api.md
@@ -296,6 +296,7 @@ and null it is compact JSON.
 | `tx.identify` | implemented | Return stable identifiers and metadata such as transaction id, body hash, era, size, and witness counts. |
 | `tx.intent` | implemented | Return a signer-focused summary of visible transaction effects, signer value perspective, self-declared metadata intent, required signers, scripts, withdrawals, mint/burn, collateral, and context coverage. |
 | `tx.witness.plan` | implemented | Explain body-declared signer hashes, present witnesses, scripts, redeemers, datums, and reference inputs that are visible from the transaction alone. |
+| `tx.witness.attach` | implemented | Attach or replace one vkey witness in transaction CBOR, preserve all other witness-set content, and return patched transaction bytes plus stable diagnostics. |
 | `tx.validate` | implemented | Report whether explicit validation context is usable or incomplete; run Conway `applyTx` when modeled context is complete. |
 | `tx.evaluate.scripts` | implemented | Evaluate phase-2 scripts and report per-redeemer execution units or failures with explicit context. |
 | `tx.patch` | 0.1 target | Apply a controlled structural patch and return new transaction CBOR. |
@@ -634,6 +635,62 @@ matching producer transaction. The operation reports coverage in
 `witness_plan.context`, plus `resolved_inputs` and
 `resolved_reference_inputs`.
 
+### `tx.witness.attach`
+
+Decode the supplied Conway transaction, decode one hex-encoded vkey witness,
+and attach it to the witness set. The operation only inserts or replaces a
+vkey witness with the same verification key hash; it preserves all non-target
+witness-set content. It does not sign, hold secret keys, or prove that the
+witness matches the transaction body.
+
+Arguments:
+
+```json
+{
+  "vkey_witness_cbor_hex": "<hex-encoded CBOR for one Shelley/Conway vkey witness>"
+}
+```
+
+Successful result payload:
+
+```json
+{
+  "status": "applied",
+  "tx_id": "<transaction id hex>",
+  "body_hash": "<transaction body hash hex>",
+  "tx_cbor": "<patched transaction CBOR hex>",
+  "signed_tx_cbor_hex": "<patched transaction CBOR hex>",
+  "witness_patch_action": "inserted",
+  "errors": [],
+  "warnings": []
+}
+```
+
+Rejected result payload:
+
+```json
+{
+  "status": "rejected",
+  "tx_id": "<transaction id hex>",
+  "body_hash": "<transaction body hash hex>",
+  "errors": [
+    {
+      "code": "missing_vkey_witness_cbor_hex",
+      "message": "Supply args.vkey_witness_cbor_hex as hex-encoded CBOR for a single vkey witness.",
+      "path": ["args", "vkey_witness_cbor_hex"],
+      "details": null
+    }
+  ],
+  "warnings": []
+}
+```
+
+When the attachment succeeds, the response also includes the same patched bytes
+at `result.tx_cbor` to satisfy the shared mutation contract. Within
+`witness_attachment`, `witness_patch_action` is `inserted` when the
+verification key was absent and `replaced` when an existing vkey witness for
+the same key hash was updated.
+
 ### `tx.validate`
 
 Decode the supplied Conway transaction and report whether explicit validation
@@ -853,6 +910,7 @@ Machine-readable draft schemas are tracked next to this contract:
 - `../schemas/tx-identify-result.schema.json`
 - `../schemas/tx-intent-result.schema.json`
 - `../schemas/tx-witness-plan-result.schema.json`
+- `../schemas/tx-witness-attach-result.schema.json`
 - `../schemas/tx-validate-result.schema.json`
 - `../schemas/tx-evaluate-scripts-result.schema.json`
 
@@ -876,3 +934,4 @@ Legacy operation names are normalized:
 | `identify` | `tx.identify` |
 | `intent` | `tx.intent` |
 | `witness.plan` | `tx.witness.plan` |
+| `witness.attach` | `tx.witness.attach` |

--- a/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
+++ b/specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json
@@ -58,6 +58,9 @@
       "TxValidateResult": {
         "$ref": "tx-validate-result.schema.json"
       },
+      "TxWitnessAttachResult": {
+        "$ref": "tx-witness-attach-result.schema.json"
+      },
       "TxWitnessPlanResult": {
         "$ref": "tx-witness-plan-result.schema.json"
       }
@@ -201,6 +204,17 @@
                     },
                     "ledger_functional_layer": "cardano-ledger-functional/v1",
                     "op": "tx.validate",
+                    "tx_cbor": "84a4..."
+                  }
+                },
+                "witnessAttach": {
+                  "summary": "Attach or replace one vkey witness",
+                  "value": {
+                    "args": {
+                      "vkey_witness_cbor_hex": "825820000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f5840202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
+                    },
+                    "ledger_functional_layer": "cardano-ledger-functional/v1",
+                    "op": "tx.witness.attach",
                     "tx_cbor": "84a4..."
                   }
                 },
@@ -614,6 +628,52 @@
                           "status": "incomplete",
                           "tx_id": "0000000000000000000000000000000000000000000000000000000000000000",
                           "valid_for_supplied_context": null,
+                          "warnings": []
+                        }
+                      }
+                    }
+                  },
+                  "witnessAttach": {
+                    "summary": "Witness attachment response envelope",
+                    "value": {
+                      "ledger_functional_layer": "cardano-ledger-functional/v1",
+                      "op": "tx.witness.attach",
+                      "result": {
+                        "tx_cbor": "84a4...",
+                        "witness_attachment": {
+                          "body_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+                          "errors": [],
+                          "signed_tx_cbor_hex": "84a4...",
+                          "status": "applied",
+                          "tx_cbor": "84a4...",
+                          "tx_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                          "warnings": [],
+                          "witness_patch_action": "inserted"
+                        }
+                      }
+                    }
+                  },
+                  "witnessAttachRejected": {
+                    "summary": "Rejected witness attachment with stable diagnostics",
+                    "value": {
+                      "ledger_functional_layer": "cardano-ledger-functional/v1",
+                      "op": "tx.witness.attach",
+                      "result": {
+                        "witness_attachment": {
+                          "body_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+                          "errors": [
+                            {
+                              "code": "missing_vkey_witness_cbor_hex",
+                              "details": null,
+                              "message": "Supply args.vkey_witness_cbor_hex as hex-encoded CBOR for a single vkey witness.",
+                              "path": [
+                                "args",
+                                "vkey_witness_cbor_hex"
+                              ]
+                            }
+                          ],
+                          "status": "rejected",
+                          "tx_id": "0000000000000000000000000000000000000000000000000000000000000000",
                           "warnings": []
                         }
                       }

--- a/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/ledger-operation-request.schema.json
@@ -37,6 +37,11 @@
         "context": {
           "$ref": "producer-tx-context.schema.json",
           "description": "Explicit external context owned by the host workspace."
+        },
+        "vkey_witness_cbor_hex": {
+          "type": "string",
+          "pattern": "^[0-9A-Fa-f\\s]+$",
+          "description": "Hex-encoded CBOR for one Shelley/Conway vkey witness used by tx.witness.attach."
         }
       },
       "additionalProperties": true

--- a/specs/001-ledger-functional-layer/schemas/tx-witness-attach-result.schema.json
+++ b/specs/001-ledger-functional-layer/schemas/tx-witness-attach-result.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lambdasistemi.github.io/cardano-ledger-inspector/schemas/tx-witness-attach-result.schema.json",
+  "title": "Cardano Ledger WASI tx.witness.attach Result",
+  "type": "object",
+  "required": [
+    "status",
+    "tx_id",
+    "body_hash",
+    "errors",
+    "warnings"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": ["applied", "rejected"]
+    },
+    "tx_id": {
+      "$ref": "#/$defs/hash32"
+    },
+    "body_hash": {
+      "$ref": "#/$defs/hash32"
+    },
+    "tx_cbor": {
+      "type": "string",
+      "pattern": "^[0-9a-f]+$",
+      "description": "Patched transaction CBOR hex when the witness attachment is applied."
+    },
+    "signed_tx_cbor_hex": {
+      "type": "string",
+      "pattern": "^[0-9a-f]+$",
+      "description": "Patched transaction CBOR hex returned for signing-oriented hosts."
+    },
+    "witness_patch_action": {
+      "type": "string",
+      "enum": ["inserted", "replaced"]
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/error"
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "applied"
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "required": [
+          "tx_cbor",
+          "signed_tx_cbor_hex",
+          "witness_patch_action"
+        ]
+      }
+    }
+  ],
+  "additionalProperties": true,
+  "$defs": {
+    "hash32": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "path": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "error": {
+      "type": "object",
+      "required": ["code", "message", "path", "details"],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "path": {
+          "$ref": "#/$defs/path"
+        },
+        "details": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": true
+    }
+  }
+}

--- a/specs/011-tx-witness-attach/plan.md
+++ b/specs/011-tx-witness-attach/plan.md
@@ -1,0 +1,109 @@
+# Implementation Plan: Attach a VKey Witness to Transaction CBOR
+
+**Branch**: `011-tx-witness-attach` | **Date**: 2026-05-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/011-tx-witness-attach/spec.md`
+
+## Summary
+
+Add `tx.witness.attach` to the Cardano Ledger WASI functional layer. The
+operation accepts transaction CBOR plus `vkey_witness_cbor_hex`, patches the
+transaction witness set through Haskell ledger types, returns the patched
+transaction CBOR artifact, reports whether the operation inserted or replaced a
+vkey witness, and returns structured rejection diagnostics for witness-input
+problems that happen after the request envelope is decoded.
+
+## Technical Context
+
+**Language/Version**: Haskell2010 compiled with GHC 9.12 to `wasm32-wasi`; Nix
+flakes for packages and checks
+
+**Primary Dependencies**: `cardano-ledger-api`, `cardano-ledger-conway`,
+`cardano-ledger-core`, `cardano-ledger-binary`, `aeson`, `bytestring`,
+`containers`, `microlens`
+
+**Storage**: None. The host owns the transaction document and detached witness
+material and sends both on every call.
+
+**Testing**: Nix smoke checks, OpenAPI regeneration checks, Fourmolu format
+check, and existing repo test gates
+
+**Target Platform**: WASI command artifact, native library consumers, generated
+OpenAPI/docs artifacts
+
+**Project Type**: Ledger-operation library with generated schema/docs surface
+
+**Constraints**: Ledger code is authoritative, CBOR remains the data plane,
+secret keys stay out of scope, non-target witness content must survive, and the
+operation must not mutate inputs, outputs, or transaction body content.
+
+## Constitution Check
+
+- **Ledger Code Is Authoritative**: PASS. The patch happens in Haskell ledger
+  code instead of browser JavaScript.
+- **Transaction Documents Own State**: PASS. The operation consumes the current
+  `tx_cbor` and returns a new `tx_cbor` artifact without hidden state.
+- **JSON Control Plane, CBOR Data Plane**: PASS. JSON carries operation name
+  and witness argument; transaction and witness data remain CBOR hex.
+- **Explicit Context Only**: PASS. No hidden provider lookup or signing state is
+  introduced.
+- **The Library Is the Canonical Artifact**: PASS. Browser and CLI hosts will
+  share the same typed entry point.
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/011-tx-witness-attach/
+├── spec.md
+├── plan.md
+└── tasks.md
+```
+
+### Source Code
+
+```text
+libs/cardano-ledger-inspector/src/Conway/
+├── Inspector.hs
+└── Common.hs
+
+specs/001-ledger-functional-layer/
+├── contracts/ledger-functional-api.md
+├── openapi/cardano-ledger-functional.openapi.json
+└── schemas/
+
+flake.nix
+justfile
+.github/workflows/ci.yml
+scripts/setup-branch-protection.sh
+```
+
+## Phase Plan
+
+1. **Contract first**: Add the feature spec artifacts, public contract text,
+   result schema, OpenAPI source wiring, and generated OpenAPI JSON updates.
+2. **Red test**: Add a new smoke check for `tx.witness.attach` plus `just`/CI
+   wiring and watch it fail before the operation exists.
+3. **Implementation**: Add witness-payload decoding, vkey witness set
+   insert/replace logic, transaction re-encoding, and structured result/error
+   helpers.
+4. **Verification**: Re-run the new smoke, then the relevant contract and repo
+   checks.
+
+## Design Notes
+
+- Operation name: `tx.witness.attach`, with compatibility normalization for
+  legacy `witness.attach`.
+- Successful result shape: nested under `result.witness_attachment` to match
+  the existing operation envelope style.
+- Success status: `applied` with `witness_patch_action` equal to `inserted` or
+  `replaced`.
+- Rejection status: `rejected` with `errors` describing missing or malformed
+  `vkey_witness_cbor_hex`.
+- Command-level error boundary remains unchanged for malformed transaction hex,
+  malformed transaction CBOR, malformed top-level operation envelopes, and
+  unknown operations.
+
+## Complexity Tracking
+
+No constitution violations or complexity exceptions are required.

--- a/specs/011-tx-witness-attach/spec.md
+++ b/specs/011-tx-witness-attach/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Attach a VKey Witness to Transaction CBOR
+
+**Feature Branch**: `011-tx-witness-attach`
+
+**Created**: 2026-05-04
+
+**Status**: Draft
+
+**Input**: User description: "Add a ledger operation that accepts transaction CBOR plus a generated vkey witness CBOR payload, patches that witness into the transaction witness set, returns the signed transaction CBOR, reports whether the witness was inserted or replaced, and exposes stable diagnostics for malformed or unsupported request inputs."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Attach or Replace a VKey Witness (Priority: P1)
+
+A caller with a decoded transaction body hash and a generated vkey witness can
+ask the ledger layer to patch that witness into the transaction CBOR and get
+back a new signed transaction artifact.
+
+**Why this priority**: This is the whole point of the issue. The browser and
+CLI hosts both need one authoritative ledger-shaped operation for the witness
+patch step.
+
+**Independent Test**: Run the new operation with a well-formed witness against
+an existing transaction, then re-run it with the same witness against the
+patched transaction and confirm the first call inserts while the second call
+replaces without changing the transaction body identity.
+
+**Acceptance Scenarios**:
+
+1. **Given** a well-formed transaction and a well-formed vkey witness whose
+   verification key is not already present, **When** the caller requests
+   witness attachment, **Then** the result returns a patched transaction CBOR
+   artifact and reports `inserted`.
+2. **Given** a well-formed transaction whose witness set already contains a
+   vkey witness for the same verification key, **When** the caller requests
+   witness attachment, **Then** the result replaces the prior vkey witness
+   instead of duplicating it and reports `replaced`.
+3. **Given** a transaction whose witness set contains bootstrap witnesses,
+   scripts, redeemers, datums, or other non-vkey content, **When** the caller
+   patches a vkey witness, **Then** the non-target witness-set content remains
+   present in the returned transaction artifact.
+
+---
+
+### User Story 2 - Reject Malformed Witness Attachment Inputs (Priority: P2)
+
+A caller can distinguish request-level transaction decoding failures from
+operation-level witness-input failures and get stable structured diagnostics for
+the latter.
+
+**Why this priority**: The operation is only useful if hosts can surface clear
+rejection reasons instead of guessing whether the failure came from the
+transaction, the witness payload, or unsupported request structure.
+
+**Independent Test**: Invoke the operation with malformed or unsupported
+`vkey_witness_cbor_hex` values after the outer request still decodes, and
+verify the result reports `rejected` with actionable `errors`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a decoded ledger-operation request that omits the witness payload,
+   **When** the caller requests attachment, **Then** the result reports
+   `rejected` and identifies the missing argument.
+2. **Given** a decoded ledger-operation request whose witness payload is not
+   valid hex or not a valid Conway/Shelley vkey witness CBOR item, **When** the
+   caller requests attachment, **Then** the result reports `rejected` with a
+   stable witness-input diagnostic.
+3. **Given** a decoded ledger-operation request whose witness payload decodes
+   but is not usable for vkey attachment, **When** the caller requests
+   attachment, **Then** the result reports `rejected` and does not emit a fake
+   signed transaction artifact.
+
+### Edge Cases
+
+- Transaction hex, transaction CBOR, malformed operation envelopes, and unknown
+  operations stay on the existing command-level error boundary.
+- The operation may re-encode collections with canonical CBOR lengths as long
+  as the resulting transaction remains a valid ledger transaction encoding.
+- The supplied witness may be well-formed but unrelated to the transaction
+  body; this operation patches witness-set structure and does not validate
+  signature correctness.
+- Transactions with no prior vkey witness collection still need a new witness
+  set entry inserted under the vkey class.
+- Transactions that already contain the same verification key witness must not
+  accumulate duplicate entries for that key.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose a dedicated ledger operation for attaching
+  a vkey witness to transaction CBOR.
+- **FR-002**: The operation MUST accept the current transaction as canonical
+  `tx_cbor` on every call.
+- **FR-003**: The operation MUST accept a generated vkey witness payload via
+  `args.vkey_witness_cbor_hex`.
+- **FR-004**: The operation MUST return a patched transaction artifact as hex
+  and MUST identify whether the witness was inserted or replaced.
+- **FR-005**: The operation MUST preserve the transaction body and all
+  non-target witness-set content while mutating only the vkey witness set.
+- **FR-006**: The operation MUST replace an existing vkey witness for the same
+  verification key instead of duplicating it.
+- **FR-007**: The operation MUST be deterministic for identical `tx_cbor` and
+  identical witness payload input.
+- **FR-008**: Once the outer request is decoded, malformed or unsupported
+  witness-input failures MUST be represented as a structured successful result
+  payload, not as command-level process failures.
+- **FR-009**: The operation MUST keep secret-key handling out of this
+  repository; it accepts detached witness material only.
+- **FR-010**: The operation MUST remain scoped to vkey witness attachment and
+  replacement only. Bootstrap witness mutation, script witness synthesis, and
+  submission remain out of scope.
+
+### Key Entities *(include if feature involves data)*
+
+- **Candidate Transaction**: The authoritative transaction document represented
+  as `tx_cbor`.
+- **VKey Witness Payload**: A generated verification-key witness represented as
+  CBOR hex for a single witness pair.
+- **Witness Attachment Result**: The structured outcome describing whether the
+  patch was applied, whether it inserted or replaced, the returned transaction
+  CBOR artifact, and any warnings or errors.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A smoke check can attach a witness to a known fixture
+  transaction, re-run the operation with the same witness, and observe
+  `inserted` then `replaced`.
+- **SC-002**: Re-inspecting the patched transaction shows the same transaction
+  identity and an updated vkey witness count.
+- **SC-003**: Structured rejected results identify missing or malformed witness
+  arguments without producing a patched transaction artifact.
+- **SC-004**: The public contract, schemas, OpenAPI, and CI all expose the new
+  operation before downstream UI or CLI hosts depend on it.
+
+## Assumptions
+
+- The transaction itself already decodes as a Conway transaction before this
+  operation runs.
+- The supplied witness payload is detached witness material generated
+  elsewhere.
+- Canonical ledger re-encoding is acceptable even when the original bytes used
+  different definite/indefinite CBOR collection forms.

--- a/specs/011-tx-witness-attach/tasks.md
+++ b/specs/011-tx-witness-attach/tasks.md
@@ -1,0 +1,47 @@
+# Tasks: Attach a VKey Witness to Transaction CBOR
+
+**Input**: Design documents from `/specs/011-tx-witness-attach/`
+**Prerequisites**: plan.md, spec.md
+**Tests**: Included because this feature adds a public ledger operation, a new
+smoke check, and contract/OpenAPI changes.
+
+## Phase 1: Contract and Check Scaffolding
+
+- [x] T001 Add `tx.witness.attach` to the public operation registry and
+  contract text in `specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`
+- [x] T002 Add a public result schema for the operation under
+  `specs/001-ledger-functional-layer/schemas/`
+- [x] T003 Add request/response examples and schema registration in
+  `nix/ledger-functional-openapi.nix`
+- [x] T004 Regenerate
+  `specs/001-ledger-functional-layer/openapi/cardano-ledger-functional.openapi.json`
+
+## Phase 2: Red Test
+
+- [x] T005 Add a new fixture or inline witness payload used by
+  `tx.witness.attach` smoke coverage
+- [x] T006 Add `tx-witness-attach-smoke` to `flake.nix`
+- [x] T007 Add `just check-witness-attach` to `justfile`
+- [x] T008 Add the smoke check to `.github/workflows/ci.yml` and
+  `scripts/setup-branch-protection.sh`
+- [x] T009 Run the new smoke check and confirm it fails before the Haskell
+  operation exists
+
+## Phase 3: Implementation
+
+- [x] T010 Add operation normalization and dispatch for `tx.witness.attach` in
+  `libs/cardano-ledger-inspector/src/Conway/Inspector.hs`
+- [x] T011 Add witness-payload decoding and transaction re-encoding helpers in
+  `libs/cardano-ledger-inspector/src/Conway/Inspector/Common.hs` or
+  `Conway/Inspector.hs`
+- [x] T012 Implement insert-or-replace logic for the vkey witness set while
+  preserving non-target witness content
+- [x] T013 Return structured `applied` and `rejected` result payloads with
+  stable diagnostics
+
+## Phase 4: Verification
+
+- [x] T014 Run `just check-witness-attach`
+- [x] T015 Run `just check-openapi` and `just check-swagger`
+- [x] T016 Run `just format-check`
+- [x] T017 Run relevant repo verification, ending with `just test`


### PR DESCRIPTION
Closes #68

## Summary
- add upstream `tx.witness.attach` / legacy `witness.attach` support in the Conway inspector
- attach or replace a single vkey witness while preserving the rest of the witness set and returning patched CBOR plus stable diagnostics
- publish the contract, schema, OpenAPI, docs, and smoke coverage for the new operation

## Verification
- `just check-witness-attach`
- `just test`

## Notes
- local-only changes remain in `.github/workflows/ci.yml` and `scripts/setup-branch-protection.sh`
- the GitHub credential available in this environment lacks `workflow` scope, so workflow-file updates could not be pushed in this PR
