### PR TITLE
Use localhost PR preview checks

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -31,48 +29,31 @@ jobs:
         run: nix --quiet build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
 
       - name: Build repository docs
-        run: nix develop --quiet -c mkdocs build --strict --site-dir surge-site
+        run: nix develop --quiet -c mkdocs build --strict --site-dir preview-site
 
-      - name: Prepare Surge site
+      - name: Prepare preview site
         run: |
-          mkdir -p surge-site/inspector
-          cp -L result-inspector/* surge-site/inspector/
-          mkdir -p surge-site/openapi
-          cp -L result-openapi/* surge-site/openapi/
-          chmod -R u+w surge-site
+          mkdir -p preview-site/inspector
+          cp -L result-inspector/* preview-site/inspector/
+          mkdir -p preview-site/openapi
+          cp -L result-openapi/* preview-site/openapi/
+          chmod -R u+w preview-site
 
-      - name: Deploy to Surge
+      - name: Smoke test preview site on localhost
         run: |
-          nix --quiet shell nixpkgs#nodePackages.surge -c surge \
-            surge-site \
-            ${{ github.repository_owner }}-${{ github.event.repository.name }}-pr-${{ github.event.number }}.surge.sh \
-            --token ${{ secrets.SURGE_TOKEN }}
+          nix --quiet shell nixpkgs#python3 nixpkgs#curl -c bash -euo pipefail <<'SCRIPT'
+          python3 -m http.server 4173 --bind 127.0.0.1 --directory preview-site &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
 
-      - name: Comment preview URL on PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const url = `https://${context.repo.owner}-${context.repo.repo}-pr-${context.issue.number}.surge.sh`;
-            const marker = '<!-- surge-preview-url -->';
-            const body = `${marker}\nPreview: ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:4173/ >/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          curl -fsS http://127.0.0.1:4173/ >/dev/null
+          curl -fsS http://127.0.0.1:4173/inspector/ >/dev/null
+          curl -fsS http://127.0.0.1:4173/openapi/ >/dev/null
+          SCRIPT

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-inspector/swagger/>
 
 Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>
 
-Pull-request previews are published to Surge by the `PR preview` workflow.
+Pull requests build the preview bundle and smoke-test it on localhost in CI.
 
 ## Releases
 


### PR DESCRIPTION
## Summary
- replace the PR preview deployment with a localhost smoke check on the `nixos` runner
- remove PR comment permissions and external preview-service secret usage
- update README preview wording

## Verification
- `nix run nixpkgs#actionlint -- -ignore 'label "nixos" is unknown' .github/workflows/pr-preview.yml`\n- `rg -n "surge\\.sh|SURGE_TOKEN|SURGE_LOGIN|nodePackages\\.surge|npx .*surge|\\bSurge\\b|\\bsurge\\b" .github/workflows README.md` returned no matches