### PR TITLE
docs: align documentation with code and org docs standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,73 @@
-# cardano-ledger-inspector Development Guidelines
+# cardano-ledger-inspector — Agent Guide
 
-Auto-generated from feature plans, then curated for this repository.
-Last updated: 2026-04-26
+## What this repo is
 
-## Active Technologies
+One Haskell library (`libs/cardano-ledger-inspector/`) implements eight
+Conway ledger operations (`tx.inspect`, `tx.browse`, `tx.identify`,
+`tx.intent`, `tx.witness.plan`, `tx.witness.attach`, `tx.validate`,
+`tx.evaluate.scripts`) behind the JSON dispatcher
+`Conway.Inspector.runLedgerOperationInput`. The library is compiled three
+ways: to a `wasm32-wasi` reactor (`wasm-tx-inspector.wasm`, GHC 9.12) used
+by the browser workbench, to a wasm Extism plugin for cross-implementation
+conformance testing, and natively (GHC 9.8.4) into the `tx-deep-diagnosis`
+CLI. Builds are Nix flakes (haskell.nix + CHaP pins); the UI is
+PureScript/Halogen built with spago.
 
-- Haskell2010 compiled with GHC 9.12 to `wasm32-wasi`
-- PureScript/Halogen browser workbench
-- Nix flakes and haskell.nix builds
-- Cardano ledger packages: `cardano-ledger-api`, `cardano-ledger-conway`,
-  `cardano-ledger-core`, `cardano-ledger-binary`
-- JSON/control dependencies: `aeson`, `bytestring`, `containers`, `microlens`
-
-## Project Structure
+## Project structure
 
 ```text
-libs/cardano-ledger-inspector/   # Conway tx inspector library (lib + wasm Main.hs)
+libs/cardano-ledger-inspector/   # Conway tx inspector library (lib + WASI Main.hs)
 apps/tx-deep-diagnosis/          # Native Haskell CLI for layered tx diagnosis
 apps/extism-spike-host/          # Native Extism host loading the wasm spike
-apps/wasm-extism-spike/          # Wasm Extism plugin spike
-docs/inspector/                  # Browser workbench and Playwright tests
-specs/                           # Spec Kit artifacts and public API contracts
+apps/wasm-extism-spike/          # Wasm Extism plugin (tx_identify/tx_validate/tx_evaluate_scripts)
+docs/inspector/                  # Browser workbench, Playwright tests, protocol registry
+specs/                           # Spec Kit artifacts, public API contracts, fixtures
 gh-docs/                         # MkDocs pages published to GitHub Pages
-nix/                             # Nix builders, generated OpenAPI source, checks
+nix/                             # Nix builders (wasm + native), generated OpenAPI source
+scripts/                         # fetch-tx-cbor.sh, setup-branch-protection.sh
 ```
 
-## Commands
+## How to work here
+
+All workflows go through `just` (run `just --list` for everything):
 
 ```bash
-just build-wasm
-just build-ui
-just check-openapi
-just check-swagger
-just check-identify
+just build-wasm                # nix build the WASI reactor
+just build-ui                  # nix build the browser bundle
+just check-openapi             # OpenAPI regen matches committed spec
+just check-identify            # tx.identify smoke against committed fixture
 just check-witness-plan
+just check-witness-attach
+just check-intent
 just check-input-context
-just test-playwright
-just test
+just check-validate
+just check-evaluate-scripts
+just check-extism-spike        # Extism vs WASI byte-identical conformance
+just hlint                     # lint
+just format                    # fourmolu in place
+just ui-check                  # spago build of the workbench
+just test-playwright           # browser E2E against the packaged UI
+just test                      # smokes + lint + browser suite
 ```
 
-## Code Style
+The first full WASI build populates a Cabal dependency cache and is slow;
+later Haskell-only edits rebuild fast through the split `prebuiltDeps`
+path. The docs site builds with `mkdocs build --strict` (mkdocs + material
+are in the dev shell).
 
-- Haskell sources are Fourmolu-formatted.
+## Code style and boundaries
+
+- Haskell sources are Fourmolu-formatted (`just format-check` gates CI).
 - Ledger semantics belong in Haskell/WASI, not browser or provider adapters.
 - Transaction CBOR and producer transaction CBOR are canonical data-plane
   inputs. JSON is for control arguments, summaries, diagnostics, and views.
-- Ledger operations must receive explicit context and must not depend on hidden
-  prior calls.
+- Ledger operations must receive explicit context and must not depend on
+  hidden prior calls.
 
-## Recent Changes
+## Skills
 
-- `002-tx-validate`: added the planned `tx.validate` functional operation
-  contract, data model, and implementation plan.
+Activatable procedures live under `skills/`:
 
-<!-- MANUAL ADDITIONS START -->
-<!-- MANUAL ADDITIONS END -->
+- `skills/cardano-ledger-inspector-guide/` — repository map, build/test
+  commands, code navigation, and how to run the ledger operations; load it
+  when working on or answering questions about this repo.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,55 @@
 # cardano-ledger-inspector
 
 Cardano ledger operations compiled to WASI, with a browser transaction
-workbench that exercises the same Haskell ledger code.
+workbench and a native diagnosis CLI that exercise the same Haskell ledger
+code.
+
+## What Is This
+
+One Haskell library, `libs/cardano-ledger-inspector/`, implements eight
+Conway ledger operations — `tx.inspect`, `tx.browse`, `tx.identify`,
+`tx.intent`, `tx.witness.plan`, `tx.witness.attach`, `tx.validate`, and
+`tx.evaluate.scripts` — behind a single JSON dispatcher
+(`Conway.Inspector.runLedgerOperationInput`). Operations receive a JSON
+control envelope carrying the transaction as CBOR hex, run real
+`cardano-ledger-conway` code (including `applyTx` and phase-2 script
+evaluation), and return JSON results.
+
+The library is compiled three ways from the same source: to a `wasm32-wasi`
+reactor (`wasm-tx-inspector.wasm`) loaded by the browser workbench and
+runnable under `wasmtime`; to a wasm Extism plugin
+(`wasm-extism-spike.wasm`) used as a conformance reference for alternative
+node implementations; and natively, linked into the `tx-deep-diagnosis`
+CLI, which adds Blockfrost producer-transaction resolution and protocol
+registry labelling on top.
 
 This repository was split out of
 [`lambdasistemi/cardano-node-clients`](https://github.com/lambdasistemi/cardano-node-clients)
-so the WASI ledger operation layer can evolve independently from the node-client
-library.
+so the WASI ledger operation layer can evolve independently from the
+node-client library.
 
-## What Is Here
+## Architecture
+
+```mermaid
+flowchart TB
+  UI["docs/inspector<br/>PureScript browser workbench"]
+  CLI["apps/tx-deep-diagnosis<br/>native diagnosis CLI"]
+  ExtHost["apps/extism-spike-host<br/>native Extism host"]
+  WASI["wasm-tx-inspector.wasm<br/>WASI reactor"]
+  Plugin["wasm-extism-spike.wasm<br/>Extism plugin"]
+  Lib["libs/cardano-ledger-inspector<br/>Conway inspector library"]
+  Ledger["cardano-ledger-conway, cardano-ledger-api, plutus-ledger-api<br/>pinned via CHaP"]
+
+  UI -- "JSON envelope via browser_wasi_shim" --> WASI
+  ExtHost -- "JSON envelope via libextism" --> Plugin
+  CLI -- "links the library natively" --> Lib
+  Lib -- "wasm32-wasi build" --> WASI
+  Lib -- "wasm32-wasi + extism-pdk build" --> Plugin
+  Lib --> Ledger
+```
 
 - `libs/cardano-ledger-inspector/` — Haskell library implementing the Conway
-  ledger operations (`tx.intent`, `tx.validate`, `tx.evaluate.scripts`, …).
-  The library plus a 25-line WASI `Main.hs` compile to
+  ledger operations. The library plus a 34-line WASI `Main.hs` compile to
   `wasm-tx-inspector.wasm`; the same library is also linked natively by the
   CLI below.
 - `apps/tx-deep-diagnosis/` — native CLI that links the inspector library
@@ -33,28 +70,104 @@ library.
 - `specs/001-ledger-functional-layer/contracts/ledger-functional-api.md` —
   current JSON-control / CBOR-data operation contract.
 
-## Build
+## Install
 
-```bash
-nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
-nix build .#packages.x86_64-linux.tx-inspector-ui -o result-site
-nix build .#packages.x86_64-linux.ledger-functional-openapi -o result-openapi
-nix build .#packages.x86_64-linux.tx-deep-diagnosis -o result-cli
-```
+Tagged releases are produced by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit history. Each release attaches:
 
-The WASI executable is `./result-wasm/wasm-tx-inspector.wasm`. The built
-browser bundle is `./result-site/{index.html,index.js}` after the UI build.
-The OpenAPI/Swagger artifact is `./result-openapi/cardano-ledger-functional.openapi.json`
-with the JSON schemas it references. The native CLI is
-`./result-cli/bin/tx-deep-diagnosis` — see `gh-docs/build.md` for a
-walkthrough on the SundaeSwap fixture.
+- `cardano-ledger-reference-<tag>.wasm` — Extism plugin exposing
+  `tx_identify`, `tx_validate`, and `tx_evaluate_scripts`. The conformance
+  reference for alternative node implementations: load this in your test
+  runner via any [Extism host SDK](https://extism.org/docs/concepts/host-sdk),
+  call the same exports against the same input, diff your output. The
+  Wasmtime-backed SDKs (Rust, Haskell, Python via libextism, etc.)
+  work; the Go SDK currently does not because its bundled wazero
+  predates wasm tail-call support.
+- `wasm-tx-inspector-<tag>.wasm` — same Conway ledger, packaged as a
+  WASI reactor (stdin/stdout JSON). Suitable for shell-driven debug
+  and the inspector UI.
+- `ledger-functional-openapi-<tag>.tar.gz` — OpenAPI contract for the
+  JSON envelope.
+- `SHA256SUMS-<tag>.txt` — checksums.
 
-You can also build directly from GitHub:
+Releases: <https://github.com/lambdasistemi/cardano-ledger-inspector/releases>
+
+You can also build any artifact directly from GitHub:
 
 ```bash
 nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.wasm-tx-inspector
 nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.tx-inspector-ui
 ```
+
+Every `CI` workflow run additionally uploads per-run artifacts
+(`wasm-tx-inspector`, `tx-inspector-ui`, `ledger-functional-openapi`, each
+with `SHA256SUMS`) retained for 30 days. Use these for inspecting a specific
+PR; use a tagged release for anything you depend on. Download them from the
+**Artifacts** section of a run under
+<https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml>.
+
+## Quickstart
+
+Run a ledger operation against a committed mainnet fixture, no provider
+keys needed:
+
+```bash
+nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+nix develop --quiet -c sh -c \
+  'wasmtime result-wasm/wasm-tx-inspector.wasm \
+     < specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex'
+```
+
+Raw transaction hex on stdin runs the legacy inspection path. Named
+operations use the JSON envelope:
+
+```bash
+nix develop --quiet -c sh -c '
+  jq -n --rawfile tx specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex \
+    "{ledger_functional_layer: \"cardano-ledger-functional/v1\",
+      tx_cbor: (\$tx | gsub(\"\\\\s\"; \"\")), op: \"tx.identify\", args: {}}" \
+  | wasmtime result-wasm/wasm-tx-inspector.wasm'
+```
+
+## Usage
+
+| Operation | Description |
+| --- | --- |
+| `tx.inspect` | Decode transaction CBOR and return a compact summary plus the root browser view. |
+| `tx.browse` | Return a navigable representation of the transaction at `args.path`. |
+| `tx.identify` | Return transaction id, body hash, era, byte size, fee, structural counts, and witness counts. |
+| `tx.intent` | Return a signer-focused summary: visible effects, self-declared metadata claims, required signers, scripts, withdrawals, mint/burn, collateral, and context coverage. |
+| `tx.witness.plan` | Return signer, witness, script, redeemer, datum, reference-input, and producer-transaction context coverage data. |
+| `tx.witness.attach` | Attach or replace one vkey witness and return patched transaction CBOR plus stable diagnostics. |
+| `tx.validate` | Build a Conway ledger environment from explicit context, run `applyTx` when context is complete, and report ledger failures. |
+| `tx.evaluate.scripts` | Run phase-2 script evaluation when context is complete and report per-redeemer execution units or failures. |
+
+Hosts and entry points:
+
+- **Browser workbench** —
+  <https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>,
+  with Blockfrost and Koios provider adapters for fetching transaction and
+  validation context.
+- **Native CLI** — `nix run .#tx-deep-diagnosis -- --cbor tx.hex --format explain`
+  produces a layered markdown diagnosis;
+  see the [CLI walkthrough](https://lambdasistemi.github.io/cardano-ledger-inspector/build/)
+  for registries, Blockfrost resolution, and `--emit-explain` artifacts.
+- **Extism host** —
+  `extism-spike-host PATH-TO-WASM [FUNCTION] < envelope.json > response.json`
+  calls the plugin's `tx_identify`, `tx_validate`, or `tx_evaluate_scripts`
+  exports.
+
+## Documentation
+
+- Repository docs: <https://lambdasistemi.github.io/cardano-ledger-inspector/>
+- Functional API definition: <https://lambdasistemi.github.io/cardano-ledger-inspector/api/>
+- Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-inspector/swagger/>
+- Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>
+
+Pull requests build the preview bundle and smoke-test it on localhost in CI.
+
+For AI agents, start at [AGENTS.md](AGENTS.md).
 
 ## Development
 
@@ -66,6 +179,8 @@ just check-openapi
 just check-swagger
 just check-identify
 just check-witness-plan
+just check-witness-attach
+just check-intent
 just check-input-context
 just check-validate
 just check-evaluate-scripts
@@ -86,6 +201,8 @@ regression. `just check-intent` verifies signer-perspective value accounting
 against a complete producer-context fixture.
 `just check-witness-plan` verifies the implemented `tx.witness.plan` response
 shape against the same fixture.
+`just check-witness-attach` verifies inserted vs replaced witness behavior and
+rejected missing-witness diagnostics.
 `just check-input-context` verifies that explicit `args.context.producer_txs`
 entries are decoded by Haskell and reported as complete witness-plan input
 context.
@@ -97,58 +214,8 @@ The positive validation fixture is
 response shape, including incomplete-context diagnostics, per-redeemer budget
 data, and complete-context execution-unit reporting.
 `just test-playwright` runs the Playwright E2E suite against the packaged inspector UI.
-`just test` runs the feature smoke check plus the browser suite.
-
-## Published Site
-
-Repository docs: <https://lambdasistemi.github.io/cardano-ledger-inspector/>
-
-Functional API definition: <https://lambdasistemi.github.io/cardano-ledger-inspector/api/>
-
-Swagger UI: <https://lambdasistemi.github.io/cardano-ledger-inspector/swagger/>
-
-Transaction inspector: <https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>
-
-Pull requests build the preview bundle and smoke-test it on localhost in CI.
-
-## Releases
-
-Tagged releases are produced by
-[release-please](https://github.com/googleapis/release-please) from
-conventional-commit history. Each release attaches:
-
-- `cardano-ledger-reference-<tag>.wasm` — Extism plugin exposing
-  `tx_identify` and `tx_validate`. The conformance reference for
-  alternative node implementations: load this in your test runner via
-  any [Extism host SDK](https://extism.org/docs/concepts/host-sdk),
-  call the same exports against the same input, diff your output. The
-  Wasmtime-backed SDKs (Rust, Haskell, Python via libextism, etc.)
-  work; the Go SDK currently does not because its bundled wazero
-  predates wasm tail-call support.
-- `wasm-tx-inspector-<tag>.wasm` — same Conway ledger, packaged as a
-  WASI reactor (stdin/stdout JSON). Suitable for shell-driven debug
-  and the inspector UI.
-- `ledger-functional-openapi-<tag>.tar.gz` — OpenAPI contract for the
-  JSON envelope.
-- `SHA256SUMS-<tag>.txt` — checksums.
-
-Releases: <https://github.com/lambdasistemi/cardano-ledger-inspector/releases>
-
-## CI Artifacts (per-run, ephemeral)
-
-Every `CI` workflow run also uploads per-run artifacts retained for 30
-days. Use these for inspecting a specific PR; use a tagged release for
-anything you depend on.
-
-- `wasm-tx-inspector` — `wasm-tx-inspector.wasm` plus `SHA256SUMS`.
-- `tx-inspector-ui` — static `index.html`, `index.js`, plus `SHA256SUMS`.
-- `ledger-functional-openapi` — OpenAPI JSON, referenced schemas, plus
-  `SHA256SUMS`.
-
-Open a workflow run under
-<https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml>
-and download them from the run's **Artifacts** section.
+`just test` runs the feature smoke checks plus lint and the browser suite.
 
 ## License
 
-See `LICENSE`.
+MIT — see [LICENSE](LICENSE).

--- a/gh-docs/architecture.md
+++ b/gh-docs/architecture.md
@@ -61,8 +61,8 @@ different targets, all from the same source.
 
 ### WASI Layer
 
-The library's `app/Main.hs` is a 25-line WASI reactor that reads one JSON
-envelope from stdin and writes one JSON response. Its wasm build, configured
+The library's `app/Main.hs` is a 34-line WASI reactor that reads one JSON
+envelope (or raw transaction hex) from stdin and writes one JSON response. Its wasm build, configured
 by `libs/cardano-ledger-inspector/cabal-wasm.project`, produces
 `wasm-tx-inspector.wasm`. The browser loads it with `@bjorn3/browser_wasi_shim`.
 
@@ -152,6 +152,7 @@ per-system `pkgs`, `ghc-wasm-meta`, CHaP source, and target source tree into
 | `packages.<system>.wasm-extism-spike` | `wasm-extism-spike.wasm` | Extism PDK plugin exposing the same ledger operation contract through named exports. |
 | `packages.<system>.extism-spike-host` | Native executable `extism-spike-host` | Wasmtime-backed host used to call the Extism plugin in checks. |
 | `packages.<system>.tx-deep-diagnosis` | Native executable `tx-deep-diagnosis` | Native CLI that links the inspector library, resolves inputs via Blockfrost, and labels script hashes against vendored blueprints + the Amaru journal. Produces a layered diagnosis report. |
+| `packages.<system>.tx-deep-diagnosis-render-snapshot` | Native executable `tx-deep-diagnosis-render-snapshot` | Golden-file snapshot harness for the explain-artifact renderers; `--write` regenerates the expected files under `apps/tx-deep-diagnosis/test/golden/`. |
 | `packages.<system>.libextism` | Native `libextism` library and headers | Prebuilt Extism runtime used by the native host package. |
 | `packages.<system>.tx-inspector-ui` | `index.html`, `index.js` | Browser workbench bundle. The WASI inspector bytes are embedded during the PureScript/esbuild build. |
 | `packages.<system>.ledger-functional-openapi-generated` | Generated `cardano-ledger-functional.openapi.json` | Deterministic OpenAPI JSON generated from the Nix source definition. |
@@ -173,10 +174,13 @@ implicit network access during the final build.
 | `checks.<system>.tx-identify-smoke` | Runs `tx.identify` through `wasm-tx-inspector.wasm` and asserts stable identity, size, fee, and witness-count fields. |
 | `checks.<system>.tx-witness-plan-smoke` | Runs `tx.witness.plan` without context and asserts witness, script, datum, redeemer, and warning shapes. |
 | `checks.<system>.tx-witness-attach-smoke` | Runs `tx.witness.attach`, asserts inserted vs replaced behavior, preserves transaction identity, and checks rejected missing-witness diagnostics. |
+| `checks.<system>.tx-intent-smoke` | Runs `tx.intent` against a complete producer-context fixture and verifies signer-perspective value accounting. |
 | `checks.<system>.tx-input-context-smoke` | Derives synthetic producer transaction context from inspection output and verifies resolved input reporting. |
 | `checks.<system>.tx-validate-smoke` | Covers missing context, unsupported provider-style UTxO JSON, complete valid context, deterministic validation output, and invalid supplied network context. |
 | `checks.<system>.tx-evaluate-scripts-smoke` | Covers missing context, rejected provider-style UTxO JSON, complete script evaluation, deterministic output, budgeted units, and evaluated units. |
 | `checks.<system>.tx-extism-spike-smoke` | Calls the Extism plugin through `extism-spike-host` and checks that Extism responses for shared envelopes match the WASI reactor byte-for-byte. |
+| `checks.<system>.tx-explain-render-smoke` | Runs the render-snapshot harness in compare mode against the committed golden explain artifacts. |
+| `checks.<system>.tx-deep-diagnosis-emit-explain-smoke` | Runs the native CLI with `--emit-explain` end-to-end and verifies the emitted artifact set. |
 
 The smoke checks are intentionally fixture-driven. They do not fetch provider
 state or hide network lookups inside the ledger layer; all transaction CBOR and

--- a/gh-docs/functional-layer.md
+++ b/gh-docs/functional-layer.md
@@ -125,8 +125,9 @@ producer transaction CBOR that could not be fetched.
   and evaluated execution units, and preserves missing-context diagnostics. It
   never mutates or returns transaction CBOR.
 
-The browser inspector now calls `tx.inspect`, `tx.identify`, `tx.intent`,
-`tx.witness.plan`, and `tx.validate` from the same selected transaction CBOR.
+The browser inspector now calls `tx.inspect`, `tx.browse`, `tx.identify`,
+`tx.intent`, `tx.witness.plan`, and `tx.validate` from the same selected
+transaction CBOR.
 When provider credentials are available, producer transaction CBOR fetched by
 transaction id is passed as explicit `args.context.producer_txs`, and provider
 tip/protocol-parameter data is passed as explicit validation context. Missing

--- a/gh-docs/index.md
+++ b/gh-docs/index.md
@@ -9,8 +9,8 @@ ledger semantics in JavaScript or PureScript.
 
 The transaction inspector is the first published workbench built on this
 layer. It accepts transaction CBOR, runs the Haskell ledger WASI module in
-the browser, and renders identity, witness planning, validation diagnostics,
-and a browsable transaction result.
+the browser, and renders identity, signer intent, witness planning,
+validation diagnostics, and a browsable transaction result.
 
 [Open the inspector](inspector/){ .md-button .md-button--primary }
 

--- a/gh-docs/installation.md
+++ b/gh-docs/installation.md
@@ -1,0 +1,51 @@
+# Installation
+
+## Release artifacts
+
+Tagged releases are produced by
+[release-please](https://github.com/googleapis/release-please) from
+conventional-commit history. Each release attaches:
+
+| Asset | Contents |
+| --- | --- |
+| `cardano-ledger-reference-<tag>.wasm` | Extism plugin exposing `tx_identify`, `tx_validate`, and `tx_evaluate_scripts`. The conformance reference for alternative node implementations: load it with any Wasmtime-backed [Extism host SDK](https://extism.org/docs/concepts/host-sdk). The Go SDK does not work yet because its bundled wazero predates wasm tail-call support. |
+| `wasm-tx-inspector-<tag>.wasm` | The same Conway ledger packaged as a WASI reactor (stdin/stdout JSON), for shell-driven debugging and the inspector UI. |
+| `ledger-functional-openapi-<tag>.tar.gz` | OpenAPI contract for the JSON envelope. |
+| `SHA256SUMS-<tag>.txt` | Checksums for the assets above. |
+
+Download from
+[the releases page](https://github.com/lambdasistemi/cardano-ledger-inspector/releases).
+
+## Build with Nix
+
+All artifacts are flake outputs and can be built without a checkout:
+
+```bash
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.wasm-tx-inspector
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.tx-inspector-ui
+nix build github:lambdasistemi/cardano-ledger-inspector#packages.x86_64-linux.tx-deep-diagnosis
+```
+
+The native CLI also runs directly; its protocol registry is bundled into
+the binary, so no checkout is needed:
+
+```bash
+nix run github:lambdasistemi/cardano-ledger-inspector#tx-deep-diagnosis -- \
+  --cbor my-tx.hex --format explain
+```
+
+Flake outputs are exposed for `x86_64-linux` and `aarch64-darwin`; CI
+exercises the Linux outputs.
+
+## CI artifacts (per-run, ephemeral)
+
+Every `CI` workflow run uploads `wasm-tx-inspector`, `tx-inspector-ui`, and
+`ledger-functional-openapi` artifacts (each with `SHA256SUMS`) retained for
+30 days. Use these for inspecting a specific PR; use a tagged release for
+anything you depend on. See
+[CI workflow runs](https://github.com/lambdasistemi/cardano-ledger-inspector/actions/workflows/ci.yml).
+
+## Browser workbench
+
+The transaction inspector needs no installation; it runs in the browser at
+<https://lambdasistemi.github.io/cardano-ledger-inspector/inspector/>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,11 +28,14 @@ theme:
 
 nav:
   - Overview: index.md
+  - Installation: installation.md
+  - User Manual:
+      - Functional Layer: functional-layer.md
+      - API Definition: api.md
+      - Swagger UI: swagger.md
   - Architecture: architecture.md
-  - Functional Layer: functional-layer.md
-  - API Definition: api.md
-  - Swagger UI: swagger.md
-  - Build and Artifacts: build.md
+  - Development:
+      - Build and Artifacts: build.md
   - Repository: https://github.com/lambdasistemi/cardano-ledger-inspector
 
 plugins:

--- a/skills/cardano-ledger-inspector-guide/SKILL.md
+++ b/skills/cardano-ledger-inspector-guide/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: cardano-ledger-inspector-guide
+description: Working guide for the lambdasistemi/cardano-ledger-inspector repository — Conway ledger operations compiled to wasm32-wasi plus a native diagnosis CLI. Load when a task mentions wasm-tx-inspector, tx-deep-diagnosis, the ledger functional layer or its operations (tx.inspect, tx.browse, tx.identify, tx.intent, tx.witness.plan, tx.witness.attach, tx.validate, tx.evaluate.scripts), the Extism conformance plugin (tx_identify, tx_validate, tx_evaluate_scripts exports, extism-spike-host), the PureScript inspector workbench under docs/inspector, the protocol registry (registry.json, --registry, --no-bundled-registry, the Amaru journal), Conway.Inspector modules, the ledger-functional OpenAPI contract, error strings like malformed_cbor or unknown_ledger_operation, or just recipes such as build-wasm, check-identify, check-validate, test-playwright in this repo.
+---
+
+# cardano-ledger-inspector guide
+
+## Repository map
+
+| Path | Purpose |
+| --- | --- |
+| `libs/cardano-ledger-inspector/` | The canonical Haskell library. `src/Conway/Inspector.hs` holds the dispatcher and envelope codec; `Validation.hs`, `Evaluation.hs`, `Context.hs`, `Common.hs` implement the operations. `app/Main.hs` is the 34-line WASI reactor. |
+| `apps/tx-deep-diagnosis/` | Native CLI linking the library. `app/Main.hs` parses flags and orchestrates the intent → Blockfrost resolution → validate pipeline; `src/TxDeepDiagnosisHost/` holds Blockfrost, Registry, and the markdown/diagram renderers; `snapshot/Main.hs` is the golden-file harness. |
+| `apps/wasm-extism-spike/` | Extism PDK plugin; `src/Extism/Spike.hs` exports `tx_identify`, `tx_validate`, `tx_evaluate_scripts`. |
+| `apps/extism-spike-host/` | Native host calling the plugin via libextism/Wasmtime. |
+| `docs/inspector/` | PureScript/Halogen browser workbench (`src/Main.purs`, `src/Provider.purs`, `src/FFI/`), Playwright tests (`tests/`), and the protocol registry (`protocols/`). |
+| `specs/001-ledger-functional-layer/` | API contract, JSON schemas, OpenAPI document, and committed transaction fixtures. |
+| `gh-docs/` | MkDocs pages published to GitHub Pages. |
+| `nix/` | `wasm/` (mkCardanoLedgerWasm, forks, wasm C libs), `host/` (native builds, libextism), `ledger-functional-openapi.nix`, `wasm-targets.nix`, `wasm-ui.nix`. |
+
+## Build, test, run
+
+Use `just` recipes (they wrap `nix build`):
+
+- `just build-wasm` / `just build-ui` / `just build-openapi` — main artifacts.
+- `just check-identify`, `check-witness-plan`, `check-witness-attach`,
+  `check-intent`, `check-input-context`, `check-validate`,
+  `check-evaluate-scripts` — fixture-driven smoke checks, one per operation.
+- `just check-extism-spike` — asserts Extism responses match the WASI
+  reactor byte-for-byte.
+- `just hlint`, `just format` / `format-check`, `just ui-check`.
+- `just test-playwright` — browser E2E; `just test` — full local gate.
+
+The first WASI build is slow (fresh Cabal dependency cache); subsequent
+Haskell-only edits rebuild fast. Flake outputs exist for `x86_64-linux` and
+`aarch64-darwin`; CI exercises Linux.
+
+## Navigating the code
+
+- Operation dispatch: `libs/cardano-ledger-inspector/src/Conway/Inspector.hs`,
+  `runLedgerOperation` — the case table maps the eight `op` strings to
+  handlers; `normalizeOperation` accepts legacy unprefixed names.
+- Request/response envelope and error categories (`malformed_hex`,
+  `malformed_cbor`, `malformed_ledger_operation`,
+  `unknown_ledger_operation`): same file plus `app/Main.hs`.
+- Validation (`applyTx`, context assembly, missing-context diagnostics):
+  `src/Conway/Inspector/Validation.hs`. Phase-2 script evaluation:
+  `src/Conway/Inspector/Evaluation.hs`.
+- CLI flags (`--cbor`, `--registry`, `--no-bundled-registry`, `--format`,
+  `--emit-explain`, `--network`, `--blockfrost-id`, env
+  `BLOCKFROST_PROJECT_ID`): `apps/tx-deep-diagnosis/app/Main.hs`.
+- Registry layering (bundled via cabal data-files, extra roots concat,
+  Amaru journal last-wins): `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Registry.hs`.
+- Report section order and renderers:
+  `apps/tx-deep-diagnosis/src/TxDeepDiagnosisHost/Render/Summary.hs` and
+  golden files under `apps/tx-deep-diagnosis/test/golden/`.
+- UI operation calls and provider adapters: `docs/inspector/src/Main.purs`,
+  `src/Provider.purs`, `src/FFI/Blockfrost.purs`, `src/FFI/Koios.purs`.
+
+## Using the ledger operations
+
+The WASI reactor reads one JSON envelope (or raw tx hex) on stdin and
+writes one JSON response on stdout:
+
+```bash
+nix build .#packages.x86_64-linux.wasm-tx-inspector -o result-wasm
+nix develop --quiet -c sh -c \
+  'wasmtime result-wasm/wasm-tx-inspector.wasm \
+     < specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex'
+```
+
+Envelope shape: `{"ledger_functional_layer": "cardano-ledger-functional/v1",
+"tx_cbor": "<hex>", "op": "tx.identify", "args": {}}`. Producer context goes
+in `args.context.producer_txs`. The native CLI:
+
+```bash
+nix run .#tx-deep-diagnosis -- --cbor tx.hex --format explain
+```
+
+Extism conformance host:
+`extism-spike-host PATH-TO-WASM [FUNCTION] < envelope.json` (FUNCTION
+defaults to `tx_identify`).
+
+## Answering questions
+
+- "What operations exist / what do they return?" — README Usage table;
+  full contract in `gh-docs/api.md` and
+  `specs/001-ledger-functional-layer/contracts/ledger-functional-api.md`;
+  result schemas under `specs/001-ledger-functional-layer/schemas/`.
+- "How do I install / download artifacts?" — `gh-docs/installation.md`
+  (release assets, nix build/run, CI artifacts).
+- "How does the architecture fit together?" — `gh-docs/architecture.md`
+  (layer-by-layer, flake output tables) and the README mermaid diagram.
+- "How do I diagnose a transaction?" — `gh-docs/build.md` CLI walkthrough
+  (registries, Blockfrost, `--emit-explain` artifacts).
+- "How do I identify my protocol's scripts?" —
+  `docs/inspector/protocols/README.md` and `WORKED-EXAMPLE.md`.
+- "Why doesn't the Go Extism SDK work?" — `apps/wasm-extism-spike/README.md`
+  (wazero predates wasm tail-call support; use Wasmtime-backed SDKs).
+- The hosted workbench, API page, and Swagger UI live under
+  <https://lambdasistemi.github.io/cardano-ledger-inspector/>.


### PR DESCRIPTION
Documentation review against the current state of the code, conforming to the org-wide docs standard.

## What was inaccurate

- README and `gh-docs/architecture.md` described the WASI `Main.hs` as 25 lines; it is 34 lines (`libs/cardano-ledger-inspector/app/Main.hs`) and also accepts raw tx hex on stdin.
- README's release-asset description listed only `tx_identify` and `tx_validate` as Extism exports; the plugin also exports `tx_evaluate_scripts` (`apps/wasm-extism-spike/src/Extism/Spike.hs`, cabal linker flags).
- `gh-docs/architecture.md` flake output tables were missing the `tx-deep-diagnosis-render-snapshot` package and the `tx-intent-smoke`, `tx-explain-render-smoke`, and `tx-deep-diagnosis-emit-explain-smoke` checks (all present in `flake.nix`).
- `gh-docs/functional-layer.md` omitted `tx.browse` from the list of operations the browser inspector calls (it is wired in `docs/inspector/src`).
- `AGENTS.md` was a stale speckit artifact: dated 2026-04-26, still describing `tx.validate` as planned, missing the newer check recipes, and stating only the wasm GHC (9.12) while the native CLI builds with GHC 9.8.4.

## What changed

- README restructured to the standard section order: What Is This, Architecture (new mermaid diagram), Install, Quickstart, Usage (the eight operations), Documentation, Development, License (now stated as MIT, matching `LICENSE`).
- New `gh-docs/installation.md`; mkdocs nav grouped into Installation / User Manual / Architecture / Development. Page filenames and URLs unchanged.
- `AGENTS.md` rewritten to the standard agent-guide shape, keeping the curated code-style boundaries; new `skills/cardano-ledger-inspector-guide/SKILL.md` (agentskills.io format) with repository map, build/test/run, code navigation, and question-answering pointers.

## Verification

- Operation list, envelope shape, and error categories checked against `Conway.Inspector` dispatch (`runLedgerOperation`, `normalizeOperation`).
- CLI flags, env var, registry layering, and emitted artifacts checked against `apps/tx-deep-diagnosis/app/Main.hs`, `Registry.hs`, `Render/Emit.hs`, and the golden files; the app README's section-order and `<details>` claims verified against `test/golden/value-not-conserved/expected/`.
- Flake package/check names, CI jobs, Pages deployment, and release asset names checked against `flake.nix` and `.github/workflows/*`.
- Quickstart commands: the jq envelope snippet executed locally against the committed fixture; the wasmtime invocation mirrors the `tx-identify-smoke` check; raw-hex stdin fallback confirmed in `Conway/Inspector.hs` (whitespace-filtering hex decode).
- `mkdocs build --strict` run with material + pymdown-extensions: passes with the new nav and page.
- New README mermaid diagram drawn from the verified compile/link relationships; existing architecture diagrams re-checked node-by-node against the tree.
