### PR TITLE
RDF-3: overlay books

### DIFF
--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -444,6 +444,7 @@
       .intent-panel,
       .rdf-panel,
       .overlay-book-panel,
+      .resolved-labels-panel,
       .sparql-lens-panel {
         display: grid;
         gap: 12px;
@@ -581,6 +582,10 @@
         min-width: 0;
       }
 
+      .resolved-labels-panel {
+        min-width: 0;
+      }
+
       .overlay-import-grid,
       .overlay-selection-grid {
         display: grid;
@@ -639,6 +644,10 @@
         border-radius: 8px;
         background: var(--surface-soft);
         padding: 0.64rem 0.7rem;
+      }
+
+      .resolved-labels-row {
+        grid-template-columns: minmax(0, 1.1fr) minmax(7rem, 0.42fr) minmax(0, 1.1fr) minmax(0, 1.1fr);
       }
 
       .sparql-lens-cell {

--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -443,6 +443,7 @@
       .identity-panel,
       .intent-panel,
       .rdf-panel,
+      .overlay-book-panel,
       .sparql-lens-panel {
         display: grid;
         gap: 12px;
@@ -574,6 +575,43 @@
 
       .rdf-panel {
         min-width: 0;
+      }
+
+      .overlay-book-panel {
+        min-width: 0;
+      }
+
+      .overlay-import-grid,
+      .overlay-selection-grid {
+        display: grid;
+        gap: 12px;
+        min-width: 0;
+      }
+
+      .overlay-selection-grid {
+        grid-template-columns: minmax(12rem, 0.8fr) minmax(0, 1.2fr);
+        align-items: start;
+      }
+
+      .overlay-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .overlay-part-list {
+        display: grid;
+        gap: 8px;
+        min-width: 0;
+      }
+
+      .overlay-part-list .choice-option {
+        min-height: 38px;
+        background: #ffffff;
+      }
+
+      .overlay-selection-grid textarea {
+        min-height: 240px;
       }
 
       .rdf-meta {
@@ -972,6 +1010,7 @@
 
         .browser-heading,
         .browser-row,
+        .overlay-selection-grid,
         .sparql-lens-row {
           grid-template-columns: 1fr;
         }
@@ -997,6 +1036,10 @@
         .primary-action,
         .secondary-action {
           width: 100%;
+        }
+
+        .overlay-actions {
+          display: grid;
         }
 
         .field-label {

--- a/docs/inspector/protocols/amaru-treasury/overlay.ttl
+++ b/docs/inspector/protocols/amaru-treasury/overlay.ttl
@@ -1,0 +1,248 @@
+@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix overlay: <https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#> .
+
+overlay:OverlayPart
+  a rdfs:Class ;
+  rdfs:label "Overlay part" .
+
+overlay:Treasury
+  a rdfs:Class ;
+  rdfs:label "Budget treasury" .
+
+overlay:Address
+  a rdfs:Class ;
+  rdfs:label "Cardano address" .
+
+overlay:CardanoScript
+  a rdfs:Class ;
+  rdfs:label "Cardano script" .
+
+overlay:Owner
+  a rdfs:Class ;
+  rdfs:label "Owner key" .
+
+overlay:ScopeOwners
+  a rdfs:Class ;
+  rdfs:label "Scope owners reference" .
+
+overlay:slug a rdf:Property ; rdfs:label "Slug" .
+overlay:budgetAda a rdf:Property ; rdfs:label "Budget in ADA" .
+overlay:address a rdf:Property ; rdfs:label "Treasury address" .
+overlay:owner a rdf:Property ; rdfs:label "Treasury owner" .
+overlay:scopeOwners a rdf:Property ; rdfs:label "Scope owners" .
+overlay:treasuryScript a rdf:Property ; rdfs:label "Treasury script" .
+overlay:permissionsScript a rdf:Property ; rdfs:label "Permissions script" .
+overlay:registryScript a rdf:Property ; rdfs:label "Registry script" .
+overlay:scriptRole a rdf:Property ; rdfs:label "Script role" .
+
+overlay:amaruScopeOwners
+  a overlay:ScopeOwners ;
+  rdfs:label "Amaru treasury scope owners" ;
+  cardano:fromTxOutRef "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#00" .
+
+overlay:amaruAddress-contingency
+  a overlay:Address ;
+  rdfs:label "Amaru Contingency treasury address" ;
+  cardano:bech32 "addr1x8ndhlcfy30t38z0tql64fpg8ply93r37xrgvdagfpsz5nhxm0lsjfz7hzwy7kpl42jzswr7gtz8ruvxscm6sjrq9f8qruq0ae" .
+
+overlay:amaruTreasury-contingency
+  a overlay:Treasury ;
+  rdfs:label "Amaru Contingency treasury" ;
+  overlay:slug "contingency" ;
+  overlay:budgetAda 4057000 ;
+  overlay:address overlay:amaruAddress-contingency ;
+  overlay:scopeOwners overlay:amaruScopeOwners ;
+  overlay:treasuryScript <urn:cardano:id:script:e6dbff09245eb89c4f583faaa428387e42c471f1868637a848602a4e> ;
+  overlay:permissionsScript <urn:cardano:id:script:2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a> ;
+  overlay:registryScript <urn:cardano:id:script:7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988> .
+
+<urn:cardano:id:script:e6dbff09245eb89c4f583faaa428387e42c471f1868637a848602a4e>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Contingency treasury script" ;
+  overlay:scriptRole "treasury_script" ;
+  cardano:fromTxOutRef "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#00" ;
+  overlay:slug "contingency-treasury_script" .
+
+<urn:cardano:id:script:2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Contingency permissions script" ;
+  overlay:scriptRole "permissions_script" ;
+  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04" ;
+  overlay:slug "contingency-permissions_script" .
+
+<urn:cardano:id:script:7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Contingency registry script" ;
+  overlay:scriptRole "registry_script" ;
+  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04" ;
+  overlay:slug "contingency-registry_script" .
+
+overlay:amaruAddress-core_development
+  a overlay:Address ;
+  rdfs:label "Amaru Core Development treasury address" ;
+  cardano:bech32 "addr1x90mk0jjjhppr36ethwj8kewpgyrxyc7q6qucl4gqru96dzlhvl999wzz8r4jhway0djuzsgxvf3up5pe3l2sq8ct56qtjz6ah" .
+
+<urn:cardano:id:key:7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb>
+  a overlay:Owner ;
+  rdfs:label "Amaru Core Development owner key" .
+
+overlay:amaruTreasury-core_development
+  a overlay:Treasury ;
+  rdfs:label "Amaru Core Development treasury" ;
+  overlay:slug "core_development" ;
+  overlay:budgetAda 2575000 ;
+  overlay:address overlay:amaruAddress-core_development ;
+  overlay:owner <urn:cardano:id:key:7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb> ;
+  overlay:scopeOwners overlay:amaruScopeOwners ;
+  overlay:treasuryScript <urn:cardano:id:script:5fbb3e5295c211c7595ddd23db2e0a0833131e0681cc7ea800f85d34> ;
+  overlay:permissionsScript <urn:cardano:id:script:03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39> ;
+  overlay:registryScript <urn:cardano:id:script:1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b> .
+
+<urn:cardano:id:script:5fbb3e5295c211c7595ddd23db2e0a0833131e0681cc7ea800f85d34>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Core Development treasury script" ;
+  overlay:scriptRole "treasury_script" ;
+  cardano:fromTxOutRef "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#00" ;
+  overlay:slug "core_development-treasury_script" .
+
+<urn:cardano:id:script:03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Core Development permissions script" ;
+  overlay:scriptRole "permissions_script" ;
+  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#00" ;
+  overlay:slug "core_development-permissions_script" .
+
+<urn:cardano:id:script:1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Core Development registry script" ;
+  overlay:scriptRole "registry_script" ;
+  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#00" ;
+  overlay:slug "core_development-registry_script" .
+
+overlay:amaruAddress-middleware
+  a overlay:Address ;
+  rdfs:label "Amaru Middleware treasury address" ;
+  cardano:bech32 "addr1x8a5gxtm0ynzw80f80rsps3a5dwem43swsekpnctd0wuwxhmgsvhk7fxyuw7jw78qrprmg6anhtrqapnvr8sk67acudqhnwrjp" .
+
+<urn:cardano:id:key:97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2>
+  a overlay:Owner ;
+  rdfs:label "Amaru Middleware owner key" .
+
+overlay:amaruTreasury-middleware
+  a overlay:Treasury ;
+  rdfs:label "Amaru Middleware treasury" ;
+  overlay:slug "middleware" ;
+  overlay:budgetAda 900000 ;
+  overlay:address overlay:amaruAddress-middleware ;
+  overlay:owner <urn:cardano:id:key:97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2> ;
+  overlay:scopeOwners overlay:amaruScopeOwners ;
+  overlay:treasuryScript <urn:cardano:id:script:fb44197b7926271de93bc700c23da35d9dd630743360cf0b6bddc71a> ;
+  overlay:permissionsScript <urn:cardano:id:script:212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c> ;
+  overlay:registryScript <urn:cardano:id:script:def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638> .
+
+<urn:cardano:id:script:fb44197b7926271de93bc700c23da35d9dd630743360cf0b6bddc71a>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Middleware treasury script" ;
+  overlay:scriptRole "treasury_script" ;
+  cardano:fromTxOutRef "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#00" ;
+  overlay:slug "middleware-treasury_script" .
+
+<urn:cardano:id:script:212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Middleware permissions script" ;
+  overlay:scriptRole "permissions_script" ;
+  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#03" ;
+  overlay:slug "middleware-permissions_script" .
+
+<urn:cardano:id:script:def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Middleware registry script" ;
+  overlay:scriptRole "registry_script" ;
+  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#03" ;
+  overlay:slug "middleware-registry_script" .
+
+overlay:amaruAddress-network_compliance
+  a overlay:Address ;
+  rdfs:label "Amaru Network Compliance treasury address" ;
+  cardano:bech32 "addr1xyezq8wpaqnssdjvd3p220uf7e6nzjae44w6yu625y965rfjyqwur6p8pqmycmzz55lcnan4x99mnt2a5fe54ggt4gxs8thzgk" .
+
+<urn:cardano:id:key:8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1>
+  a overlay:Owner ;
+  rdfs:label "Amaru Network Compliance owner key" .
+
+overlay:amaruTreasury-network_compliance
+  a overlay:Treasury ;
+  rdfs:label "Amaru Network Compliance treasury" ;
+  overlay:slug "network_compliance" ;
+  overlay:budgetAda 1450000 ;
+  overlay:address overlay:amaruAddress-network_compliance ;
+  overlay:owner <urn:cardano:id:key:8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1> ;
+  overlay:scopeOwners overlay:amaruScopeOwners ;
+  overlay:treasuryScript <urn:cardano:id:script:32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d> ;
+  overlay:permissionsScript <urn:cardano:id:script:a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094> ;
+  overlay:registryScript <urn:cardano:id:script:38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d> .
+
+<urn:cardano:id:script:32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Network Compliance treasury script" ;
+  overlay:scriptRole "treasury_script" ;
+  cardano:fromTxOutRef "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#00" ;
+  overlay:slug "network_compliance-treasury_script" .
+
+<urn:cardano:id:script:a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Network Compliance permissions script" ;
+  overlay:scriptRole "permissions_script" ;
+  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#02" ;
+  overlay:slug "network_compliance-permissions_script" .
+
+<urn:cardano:id:script:38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Network Compliance registry script" ;
+  overlay:scriptRole "registry_script" ;
+  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#02" ;
+  overlay:slug "network_compliance-registry_script" .
+
+overlay:amaruAddress-ops_and_use_cases
+  a overlay:Address ;
+  rdfs:label "Amaru Ops And Use Cases treasury address" ;
+  cardano:bech32 "addr1x9r8gmryz5wrwvlxm6g4s4u9ssdz656z95hwjnk9rgamedzxw3kxg9guxue7dh53tptctpq694f5ytfwa98v2x3mhj6qe3kxep" .
+
+<urn:cardano:id:key:f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e>
+  a overlay:Owner ;
+  rdfs:label "Amaru Ops And Use Cases owner key" .
+
+overlay:amaruTreasury-ops_and_use_cases
+  a overlay:Treasury ;
+  rdfs:label "Amaru Ops And Use Cases treasury" ;
+  overlay:slug "ops_and_use_cases" ;
+  overlay:budgetAda 1160000 ;
+  overlay:address overlay:amaruAddress-ops_and_use_cases ;
+  overlay:owner <urn:cardano:id:key:f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e> ;
+  overlay:scopeOwners overlay:amaruScopeOwners ;
+  overlay:treasuryScript <urn:cardano:id:script:46746c64151c3733e6de91585785841a2d53422d2ee94ec51a3bbcb4> ;
+  overlay:permissionsScript <urn:cardano:id:script:cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb> ;
+  overlay:registryScript <urn:cardano:id:script:bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c> .
+
+<urn:cardano:id:script:46746c64151c3733e6de91585785841a2d53422d2ee94ec51a3bbcb4>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Ops And Use Cases treasury script" ;
+  overlay:scriptRole "treasury_script" ;
+  cardano:fromTxOutRef "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#00" ;
+  overlay:slug "ops_and_use_cases-treasury_script" .
+
+<urn:cardano:id:script:cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Ops And Use Cases permissions script" ;
+  overlay:scriptRole "permissions_script" ;
+  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#01" ;
+  overlay:slug "ops_and_use_cases-permissions_script" .
+
+<urn:cardano:id:script:bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c>
+  a overlay:CardanoScript ;
+  rdfs:label "Amaru Ops And Use Cases registry script" ;
+  overlay:scriptRole "registry_script" ;
+  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#01" ;
+  overlay:slug "ops_and_use_cases-registry_script" .

--- a/docs/inspector/src/FFI/OverlayBook.js
+++ b/docs/inspector/src/FFI/OverlayBook.js
@@ -1,0 +1,306 @@
+const PREFIXES = `@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix overlay: <https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#> .
+`;
+
+const VOCAB = `overlay:OverlayPart
+  a rdfs:Class ;
+  rdfs:label "Overlay part" .
+
+overlay:Treasury
+  a rdfs:Class ;
+  rdfs:label "Budget treasury" .
+
+overlay:Address
+  a rdfs:Class ;
+  rdfs:label "Cardano address" .
+
+overlay:CardanoScript
+  a rdfs:Class ;
+  rdfs:label "Cardano script" .
+
+overlay:Owner
+  a rdfs:Class ;
+  rdfs:label "Owner key" .
+
+overlay:ScopeOwners
+  a rdfs:Class ;
+  rdfs:label "Scope owners reference" .
+
+overlay:slug a rdf:Property ; rdfs:label "Slug" .
+overlay:budgetAda a rdf:Property ; rdfs:label "Budget in ADA" .
+overlay:address a rdf:Property ; rdfs:label "Treasury address" .
+overlay:owner a rdf:Property ; rdfs:label "Treasury owner" .
+overlay:scopeOwners a rdf:Property ; rdfs:label "Scope owners" .
+overlay:treasuryScript a rdf:Property ; rdfs:label "Treasury script" .
+overlay:permissionsScript a rdf:Property ; rdfs:label "Permissions script" .
+overlay:registryScript a rdf:Property ; rdfs:label "Registry script" .
+overlay:scriptRole a rdf:Property ; rdfs:label "Script role" .
+`;
+
+const AMARU_JOURNAL = {
+  scope_owners: "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#00",
+  treasuries: {
+    core_development: {
+      owner: "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
+      budget: 2575000,
+      address: "addr1x90mk0jjjhppr36ethwj8kewpgyrxyc7q6qucl4gqru96dzlhvl999wzz8r4jhway0djuzsgxvf3up5pe3l2sq8ct56qtjz6ah",
+      treasury_script: {
+        hash: "5fbb3e5295c211c7595ddd23db2e0a0833131e0681cc7ea800f85d34",
+        deployed_at: "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#00",
+      },
+      permissions_script: {
+        hash: "03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#00",
+      },
+      registry_script: {
+        hash: "1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#00",
+      },
+    },
+    ops_and_use_cases: {
+      owner: "f3ab64b0f97dcf0f91232754603283df5d75a1201337432c04d23e2e",
+      budget: 1160000,
+      address: "addr1x9r8gmryz5wrwvlxm6g4s4u9ssdz656z95hwjnk9rgamedzxw3kxg9guxue7dh53tptctpq694f5ytfwa98v2x3mhj6qe3kxep",
+      treasury_script: {
+        hash: "46746c64151c3733e6de91585785841a2d53422d2ee94ec51a3bbcb4",
+        deployed_at: "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#00",
+      },
+      permissions_script: {
+        hash: "cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#01",
+      },
+      registry_script: {
+        hash: "bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#01",
+      },
+    },
+    network_compliance: {
+      owner: "8bd03209d227956aaf9670751e0aa2057b51c1537a43f155b24fb1c1",
+      budget: 1450000,
+      address: "addr1xyezq8wpaqnssdjvd3p220uf7e6nzjae44w6yu625y965rfjyqwur6p8pqmycmzz55lcnan4x99mnt2a5fe54ggt4gxs8thzgk",
+      treasury_script: {
+        hash: "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
+        deployed_at: "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#00",
+      },
+      permissions_script: {
+        hash: "a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#02",
+      },
+      registry_script: {
+        hash: "38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#02",
+      },
+    },
+    middleware: {
+      owner: "97e0f6d6c86dbebf15cc8fdf0981f939b2f2b70928a46511edd49df2",
+      budget: 900000,
+      address: "addr1x8a5gxtm0ynzw80f80rsps3a5dwem43swsekpnctd0wuwxhmgsvhk7fxyuw7jw78qrprmg6anhtrqapnvr8sk67acudqhnwrjp",
+      treasury_script: {
+        hash: "fb44197b7926271de93bc700c23da35d9dd630743360cf0b6bddc71a",
+        deployed_at: "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#00",
+      },
+      permissions_script: {
+        hash: "212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#03",
+      },
+      registry_script: {
+        hash: "def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#03",
+      },
+    },
+    contingency: {
+      owner: null,
+      budget: 4057000,
+      address: "addr1x8ndhlcfy30t38z0tql64fpg8ply93r37xrgvdagfpsz5nhxm0lsjfz7hzwy7kpl42jzswr7gtz8ruvxscm6sjrq9f8qruq0ae",
+      treasury_script: {
+        hash: "e6dbff09245eb89c4f583faaa428387e42c471f1868637a848602a4e",
+        deployed_at: "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#00",
+      },
+      permissions_script: {
+        hash: "2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04",
+      },
+      registry_script: {
+        hash: "7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04",
+      },
+    },
+  },
+};
+
+export const bundledAmaruJournal = JSON.stringify(AMARU_JOURNAL, null, 2);
+
+const text = (value) =>
+  value === null || value === undefined ? "" : String(value);
+
+const literal = (value) => JSON.stringify(text(value));
+
+const localName = (value) => text(value).replace(/[^A-Za-z0-9_-]/g, "-");
+
+const words = (slug) => text(slug).split(/[_\s-]+/).filter(Boolean);
+
+const capitalize = (word) =>
+  word.length === 0 ? "" : word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase();
+
+const sentenceLabel = (slug) => {
+  const parts = words(slug).map((word) => word.toLowerCase());
+  if (parts.length === 0) return "Overlay part";
+  parts[0] = capitalize(parts[0]);
+  return parts.join(" ");
+};
+
+const titleLabel = (slug) => words(slug).map(capitalize).join(" ");
+
+const iri = (kind, value) => `<urn:cardano:id:${kind}:${text(value)}>`;
+
+const turtleNumber = (value) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? String(value) : literal(value);
+};
+
+const block = (subject, predicates) => {
+  const rows = predicates.map(([predicate, object], index) => {
+    const terminator = index === predicates.length - 1 ? "." : ";";
+    return `  ${predicate} ${object} ${terminator}`;
+  });
+  return `${subject}\n${rows.join("\n")}\n`;
+};
+
+const scriptBlock = (treasurySlug, role, script) => {
+  const slug = localName(treasurySlug);
+  const title = titleLabel(treasurySlug);
+  const roleLabel = role.replace(/_/g, " ");
+  return block(iri("script", script.hash), [
+    ["a", "overlay:CardanoScript"],
+    ["rdfs:label", literal(`Amaru ${title} ${roleLabel}`)],
+    ["overlay:scriptRole", literal(role)],
+    ["cardano:fromTxOutRef", literal(script.deployed_at)],
+    ["overlay:slug", literal(`${slug}-${role}`)],
+  ]);
+};
+
+const buildAmaruPart = (slug, treasury, scopeOwners) => {
+  const safeSlug = localName(slug);
+  const label = sentenceLabel(slug);
+  const title = titleLabel(slug);
+  const subject = `overlay:amaruTreasury-${safeSlug}`;
+  const address = `overlay:amaruAddress-${safeSlug}`;
+  const scopeOwnersSubject = "overlay:amaruScopeOwners";
+  const predicates = [
+    ["a", "overlay:Treasury"],
+    ["rdfs:label", literal(`Amaru ${title} treasury`)],
+    ["overlay:slug", literal(slug)],
+    ["overlay:budgetAda", turtleNumber(treasury.budget)],
+    ["overlay:address", address],
+    ["overlay:scopeOwners", scopeOwnersSubject],
+    ["overlay:treasuryScript", iri("script", treasury.treasury_script.hash)],
+    ["overlay:permissionsScript", iri("script", treasury.permissions_script.hash)],
+    ["overlay:registryScript", iri("script", treasury.registry_script.hash)],
+  ];
+
+  if (treasury.owner) {
+    predicates.splice(5, 0, ["overlay:owner", iri("key", treasury.owner)]);
+  }
+
+  const owner = treasury.owner
+    ? `${block(iri("key", treasury.owner), [
+        ["a", "overlay:Owner"],
+        ["rdfs:label", literal(`Amaru ${title} owner key`)],
+      ])}\n`
+    : "";
+
+  const turtle = `${PREFIXES}
+${VOCAB}
+${block(scopeOwnersSubject, [
+    ["a", "overlay:ScopeOwners"],
+    ["rdfs:label", literal("Amaru treasury scope owners")],
+    ["cardano:fromTxOutRef", literal(scopeOwners)],
+  ])}
+${block(address, [
+    ["a", "overlay:Address"],
+    ["rdfs:label", literal(`Amaru ${title} treasury address`)],
+    ["cardano:bech32", literal(treasury.address)],
+  ])}
+${owner}${block(subject, predicates)}
+${scriptBlock(slug, "treasury_script", treasury.treasury_script)}
+${scriptBlock(slug, "permissions_script", treasury.permissions_script)}
+${scriptBlock(slug, "registry_script", treasury.registry_script)}`;
+
+  return {
+    id: `amaru-treasury-${safeSlug}`,
+    label,
+    turtle: `${turtle.trim()}\n`,
+  };
+};
+
+const buildAmaruBook = (journal) => {
+  if (!journal || typeof journal !== "object") {
+    throw new Error("journal is not an object");
+  }
+  if (!journal.treasuries || typeof journal.treasuries !== "object") {
+    throw new Error("journal missing treasuries");
+  }
+
+  const scopeOwners = text(journal.scope_owners);
+  const parts = Object.keys(journal.treasuries)
+    .sort()
+    .map((slug) => buildAmaruPart(slug, journal.treasuries[slug], scopeOwners));
+
+  return {
+    title: "Amaru treasury 2026 overlay",
+    source: "docs/inspector/protocols/amaru-treasury/journal-2026.json",
+    parts,
+    turtle: parts.map((part) => part.turtle).join("\n"),
+  };
+};
+
+const hashText = (raw) => {
+  let hash = 2166136261;
+  for (let i = 0; i < raw.length; i += 1) {
+    hash ^= raw.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const pastedTurtleBook = (raw) => {
+  const turtle = `${raw.trim()}\n`;
+  const part = {
+    id: `pasted-turtle-${hashText(turtle)}`,
+    label: "Pasted Turtle",
+    turtle,
+  };
+  return {
+    title: "Pasted overlay Turtle",
+    source: "paste",
+    parts: [part],
+    turtle,
+  };
+};
+
+const parseBook = (input) => {
+  const raw = text(input).trim();
+  if (raw === "") {
+    throw new Error("overlay input is empty");
+  }
+
+  if (raw.startsWith("{")) {
+    const parsed = JSON.parse(raw);
+    return buildAmaruBook(parsed);
+  }
+
+  return pastedTurtleBook(raw);
+};
+
+const errText = (err) =>
+  err && err.message ? String(err.message) : String(err);
+
+export const parseImpl = (left) => (right) => (input) => () => {
+  try {
+    return right(parseBook(input));
+  } catch (err) {
+    return left(errText(err));
+  }
+};

--- a/docs/inspector/src/FFI/OverlayBook.purs
+++ b/docs/inspector/src/FFI/OverlayBook.purs
@@ -1,0 +1,33 @@
+module FFI.OverlayBook
+  ( OverlayBook
+  , OverlayPart
+  , bundledAmaruJournal
+  , parse
+  ) where
+
+import Data.Either (Either(..))
+import Effect (Effect)
+
+type OverlayPart =
+  { id :: String
+  , label :: String
+  , turtle :: String
+  }
+
+type OverlayBook =
+  { title :: String
+  , source :: String
+  , parts :: Array OverlayPart
+  , turtle :: String
+  }
+
+foreign import bundledAmaruJournal :: String
+
+foreign import parseImpl
+  :: (String -> Either String OverlayBook)
+  -> (OverlayBook -> Either String OverlayBook)
+  -> String
+  -> Effect (Either String OverlayBook)
+
+parse :: String -> Effect (Either String OverlayBook)
+parse = parseImpl Left Right

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -17,10 +17,62 @@ GROUP BY ?transaction ?txId
 ORDER BY ?transaction
 `;
 
+const resolvedLabelsQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX overlay: <https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#>
+SELECT ?label ?entity ?type ?scriptRole ?fromTxOutRef ?bech32 ?slug
+WHERE {
+  ?entity rdfs:label ?label .
+  FILTER(
+    STRSTARTS(STR(?entity), "https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#")
+    || STRSTARTS(STR(?entity), "urn:cardano:id:")
+  )
+  OPTIONAL { ?entity a ?type . }
+  OPTIONAL { ?entity overlay:scriptRole ?scriptRole . }
+  OPTIONAL { ?entity cardano:fromTxOutRef ?fromTxOutRef . }
+  OPTIONAL { ?entity cardano:bech32 ?bech32 . }
+  OPTIONAL { ?entity overlay:slug ?slug . }
+}
+ORDER BY ?label ?entity
+`;
+
 const bindingValue = (binding) =>
   binding && binding.value !== undefined && binding.value !== null
     ? String(binding.value)
     : "";
+
+const firstBindingValue = (...bindings) => {
+  for (const binding of bindings) {
+    const value = bindingValue(binding);
+    if (value !== "") return value;
+  }
+  return "";
+};
+
+const localName = (value) => {
+  const raw = String(value || "");
+  const hashIndex = raw.lastIndexOf("#");
+  if (hashIndex >= 0) return raw.slice(hashIndex + 1);
+  const slashIndex = raw.lastIndexOf("/");
+  if (slashIndex >= 0) return raw.slice(slashIndex + 1);
+  const colonIndex = raw.lastIndexOf(":");
+  if (colonIndex >= 0) return raw.slice(colonIndex + 1);
+  return raw;
+};
+
+const humanToken = (value) => {
+  const token = localName(value)
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  if (token === "") return "Label";
+  return token
+    .split(/\s+/)
+    .map((word) => word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
+};
 
 const normalizeTransactionOutputRows = (result) => {
   if (!result || result.kind !== "solutions") {
@@ -39,9 +91,41 @@ const normalizeTransactionOutputRows = (result) => {
   }));
 };
 
+const normalizeResolvedLabelRows = (result) => {
+  if (!result || result.kind !== "solutions") {
+    throw new Error("query did not return solution rows");
+  }
+
+  const bindings = result.json?.results?.bindings;
+  if (!Array.isArray(bindings)) {
+    throw new Error("query result missing bindings");
+  }
+
+  return bindings.map((binding) => ({
+    label: bindingValue(binding.label),
+    role: humanToken(firstBindingValue(binding.scriptRole, binding.type)),
+    entity: bindingValue(binding.entity),
+    matched: firstBindingValue(
+      binding.fromTxOutRef,
+      binding.bech32,
+      binding.slug,
+      binding.entity,
+    ),
+  }));
+};
+
 export const queryImpl = (left) => (right) => (graphTtl) => (sparql) => () => {
   try {
     return right(globalThis.rdfShapes.query(graphTtl, sparql));
+  } catch (err) {
+    return left(errText(err));
+  }
+};
+
+export const queryResolvedLabelsImpl = (left) => (right) => (graphTtl) => () => {
+  try {
+    const result = globalThis.rdfShapes.query(graphTtl, resolvedLabelsQuery);
+    return right(normalizeResolvedLabelRows(result));
   } catch (err) {
     return left(errText(err));
   }

--- a/docs/inspector/src/FFI/RdfShapes.purs
+++ b/docs/inspector/src/FFI/RdfShapes.purs
@@ -1,7 +1,9 @@
 module FFI.RdfShapes
   ( Json
+  , ResolvedLabelRow
   , TransactionOutputRow
   , query
+  , queryResolvedLabels
   , queryTransactionOutputs
   ) where
 
@@ -17,6 +19,13 @@ type TransactionOutputRow =
   , outputs :: String
   }
 
+type ResolvedLabelRow =
+  { label :: String
+  , role :: String
+  , entity :: String
+  , matched :: String
+  }
+
 foreign import queryImpl
   :: (String -> Either String Json)
   -> (Json -> Either String Json)
@@ -30,8 +39,17 @@ foreign import queryTransactionOutputsImpl
   -> String
   -> Effect (Either String (Array TransactionOutputRow))
 
+foreign import queryResolvedLabelsImpl
+  :: (String -> Either String (Array ResolvedLabelRow))
+  -> (Array ResolvedLabelRow -> Either String (Array ResolvedLabelRow))
+  -> String
+  -> Effect (Either String (Array ResolvedLabelRow))
+
 query :: String -> String -> Effect (Either String Json)
 query = queryImpl Left Right
 
 queryTransactionOutputs :: String -> Effect (Either String (Array TransactionOutputRow))
 queryTransactionOutputs = queryTransactionOutputsImpl Left Right
+
+queryResolvedLabels :: String -> Effect (Either String (Array ResolvedLabelRow))
+queryResolvedLabels = queryResolvedLabelsImpl Left Right

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -91,6 +91,7 @@ type State =
   , validation :: Maybe Json.Validation
   , rdf :: Maybe Json.RdfGraph
   , sparqlLens :: Maybe SparqlLens
+  , resolvedLabelsLens :: Maybe ResolvedLabelsLens
   , overlayInput :: String
   , overlayParts :: Array OverlayPart
   , selectedOverlayPartIds :: Array String
@@ -111,6 +112,11 @@ type BrowserNode =
 
 type SparqlLens =
   { rows :: Array RdfShapes.TransactionOutputRow
+  , error :: Maybe String
+  }
+
+type ResolvedLabelsLens =
+  { rows :: Array RdfShapes.ResolvedLabelRow
   , error :: Maybe String
   }
 
@@ -165,6 +171,7 @@ inspectorComponent initial =
         , validation: Nothing
         , rdf: Nothing
         , sparqlLens: Nothing
+        , resolvedLabelsLens: Nothing
         , overlayInput: ""
         , overlayParts: []
         , selectedOverlayPartIds: []
@@ -502,6 +509,7 @@ inspectorComponent initial =
       Just rdf ->
         if exitOk && rdf.valid then
           [ renderRdfGraph rdf, renderOverlayBooks state ]
+            <> renderResolvedLabelsLensMaybe state.resolvedLabelsLens
             <> renderSparqlLensMaybe state.sparqlLens
         else []
       Nothing -> []
@@ -749,10 +757,77 @@ inspectorComponent initial =
   selectedOverlayTurtle state =
     String.joinWith "\n" (map _.turtle (selectedOverlayParts state))
 
+  mergedRdfTurtle transactionGraphTurtle overlayTurtle =
+    transactionGraphTurtle <> overlayTurtle
+
   selectedOverlayParts state =
     Array.filter
       (\part -> Array.elem part.id state.selectedOverlayPartIds)
       state.overlayParts
+
+  renderResolvedLabelsLensMaybe lens =
+    case lens of
+      Just value -> [ renderResolvedLabelsLens value ]
+      Nothing -> []
+
+  renderResolvedLabelsLens lens =
+    HH.div
+      [ classNames [ "resolved-labels-panel" ] ]
+      [ HH.div
+          [ classNames [ "identity-heading" ] ]
+          [ HH.div_
+              [ HH.h3_ [ HH.text "SPARQL lens: resolved labels" ]
+              , HH.p_ [ HH.text "Fixed query over the transaction RDF graph plus selected overlays." ]
+              ]
+          ]
+      , case lens.error of
+          Just err ->
+            HH.div
+              [ classNames [ "sparql-lens-error" ] ]
+              [ HH.text ("Resolved-labels query failed: " <> err) ]
+          Nothing ->
+            if Array.null lens.rows then
+              HH.div
+                [ classNames [ "witness-empty" ] ]
+                [ HH.text "No resolved labels." ]
+            else
+              HH.div
+                [ classNames [ "sparql-lens-row-list" ] ]
+                (map renderResolvedLabelsRow lens.rows)
+      ]
+
+  renderResolvedLabelsRow row =
+    HH.div
+      [ classNames [ "sparql-lens-row", "resolved-labels-row" ] ]
+      [ HH.div
+          [ classNames [ "sparql-lens-cell" ] ]
+          [ HH.span
+              [ classNames [ "identity-section-title" ] ]
+              [ HH.text "Label" ]
+          , HH.strong_ [ HH.text row.label ]
+          ]
+      , HH.div
+          [ classNames [ "sparql-lens-cell" ] ]
+          [ HH.span
+              [ classNames [ "identity-section-title" ] ]
+              [ HH.text "Role" ]
+          , HH.code_ [ HH.text row.role ]
+          ]
+      , HH.div
+          [ classNames [ "sparql-lens-cell" ] ]
+          [ HH.span
+              [ classNames [ "identity-section-title" ] ]
+              [ HH.text "Entity" ]
+          , HH.code_ [ HH.text row.entity ]
+          ]
+      , HH.div
+          [ classNames [ "sparql-lens-cell" ] ]
+          [ HH.span
+              [ classNames [ "identity-section-title" ] ]
+              [ HH.text "Matched" ]
+          , HH.code_ [ HH.text row.matched ]
+          ]
+      ]
 
   renderSparqlLensMaybe lens =
     case lens of
@@ -1134,6 +1209,32 @@ inspectorComponent initial =
         || StringCodeUnits.take 7 trimmed == "preprod"
         || StringCodeUnits.take 7 trimmed == "preview"
 
+  resolvedLabelsLensFromGraph graphTurtle = do
+    lensResult <- liftEffect (RdfShapes.queryResolvedLabels graphTurtle)
+    pure
+      ( Just
+          ( case lensResult of
+              Left err ->
+                { rows: []
+                , error: Just err
+                }
+              Right rows ->
+                { rows
+                , error: Nothing
+                }
+          )
+      )
+
+  resolvedLabelsLensForState st =
+    case st.rdf of
+      Just rdf ->
+        if rdf.valid then
+          resolvedLabelsLensFromGraph
+            (mergedRdfTurtle rdf.turtle (selectedOverlayTurtle st))
+        else
+          pure Nothing
+      Nothing -> pure Nothing
+
   handleAction = case _ of
     SetBlockfrostKey s -> do
       H.modify_ _ { blockfrostKey = s }
@@ -1175,12 +1276,16 @@ inspectorComponent initial =
       case parsed of
         Left err ->
           H.modify_ _ { overlayError = Just err }
-        Right book ->
+        Right book -> do
+          st <- H.get
+          let nextState = st { overlayParts = book.parts, selectedOverlayPartIds = [] }
+          resolvedLabelsLens <- resolvedLabelsLensForState nextState
           H.modify_
             _
               { overlayParts = book.parts
               , selectedOverlayPartIds = []
               , overlayError = Nothing
+              , resolvedLabelsLens = resolvedLabelsLens
               }
     LoadAmaruOverlayBook -> do
       let input = OverlayBook.bundledAmaruJournal
@@ -1188,19 +1293,29 @@ inspectorComponent initial =
       case parsed of
         Left err ->
           H.modify_ _ { overlayInput = input, overlayError = Just err }
-        Right book ->
+        Right book -> do
+          st <- H.get
+          let nextState = st { overlayParts = book.parts, selectedOverlayPartIds = [] }
+          resolvedLabelsLens <- resolvedLabelsLensForState nextState
           H.modify_
             _
               { overlayInput = input
               , overlayParts = book.parts
               , selectedOverlayPartIds = []
               , overlayError = Nothing
+              , resolvedLabelsLens = resolvedLabelsLens
               }
-    ToggleOverlayPart partId selected ->
-      H.modify_ \st ->
-        st
-          { selectedOverlayPartIds =
-              toggleOverlayPartId partId selected st.selectedOverlayPartIds
+    ToggleOverlayPart partId selected -> do
+      st <- H.get
+      let
+        selectedOverlayPartIds =
+          toggleOverlayPartId partId selected st.selectedOverlayPartIds
+        nextState = st { selectedOverlayPartIds = selectedOverlayPartIds }
+      resolvedLabelsLens <- resolvedLabelsLensForState nextState
+      H.modify_
+        _
+          { selectedOverlayPartIds = selectedOverlayPartIds
+          , resolvedLabelsLens = resolvedLabelsLens
           }
     Decode -> do
       st <- H.get
@@ -1217,6 +1332,7 @@ inspectorComponent initial =
           , validation = Nothing
           , rdf = Nothing
           , sparqlLens = Nothing
+          , resolvedLabelsLens = Nothing
           , browserNodes = []
           , expandedPaths = []
           , copied = false
@@ -1299,6 +1415,12 @@ inspectorComponent initial =
                 )
             else
               pure Nothing
+          resolvedLabelsLens <-
+            if operationResult.exitOk && rdfResult.exitOk && rdf.valid then
+              resolvedLabelsLensFromGraph
+                (mergedRdfTurtle rdf.turtle (selectedOverlayTurtle st))
+            else
+              pure Nothing
           H.modify_
             _
               { running = false
@@ -1322,6 +1444,7 @@ inspectorComponent initial =
                   if operationResult.exitOk && rdfResult.exitOk && rdf.valid then Just rdf
                   else Nothing
               , sparqlLens = sparqlLens
+              , resolvedLabelsLens = resolvedLabelsLens
               , browserNodes =
                   if operationResult.exitOk && browser.valid then rootBrowserNodes browser
                   else []

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Array as Array
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
-import Data.String (Pattern(..), Replacement(..), replaceAll, trim) as String
+import Data.String (Pattern(..), Replacement(..), joinWith, replaceAll, trim) as String
 import Data.String.CodeUnits as StringCodeUnits
 import Effect (Effect)
 import Effect.Aff (attempt)
@@ -16,6 +16,8 @@ import FFI.Blockfrost (Network(..))
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runLedgerOperation)
 import FFI.Json (Browser, Identification, IntentSummary, RdfGraph, Validation, WitnessPlan, inspect, operationArgsWithPath, operationBrowser, operationIdentification, operationInspection, operationIntentSummary, operationRdfGraph, operationValidation, operationWitnessPlan, pretty) as Json
+import FFI.OverlayBook (OverlayPart)
+import FFI.OverlayBook as OverlayBook
 import FFI.RdfShapes as RdfShapes
 import FFI.Storage as Storage
 import Provider (Provider(..))
@@ -89,6 +91,10 @@ type State =
   , validation :: Maybe Json.Validation
   , rdf :: Maybe Json.RdfGraph
   , sparqlLens :: Maybe SparqlLens
+  , overlayInput :: String
+  , overlayParts :: Array OverlayPart
+  , selectedOverlayPartIds :: Array String
+  , overlayError :: Maybe String
   , browserNodes :: Array BrowserNode
   , expandedPaths :: Array String
   , running :: Boolean
@@ -124,6 +130,10 @@ data Action
   | SelectNetwork Network
   | SetTxHash String
   | SetTxHex String
+  | SetOverlayInput String
+  | ImportOverlayBook
+  | LoadAmaruOverlayBook
+  | ToggleOverlayPart String Boolean
   | Decode
   | Copy
   | CopyValue String String
@@ -155,6 +165,10 @@ inspectorComponent initial =
         , validation: Nothing
         , rdf: Nothing
         , sparqlLens: Nothing
+        , overlayInput: ""
+        , overlayParts: []
+        , selectedOverlayPartIds: []
+        , overlayError: Nothing
         , browserNodes: []
         , expandedPaths: []
         , running: false
@@ -486,7 +500,9 @@ inspectorComponent initial =
   renderRdfMaybe state exitOk =
     case state.rdf of
       Just rdf ->
-        if exitOk && rdf.valid then [ renderRdfGraph rdf ] <> renderSparqlLensMaybe state.sparqlLens
+        if exitOk && rdf.valid then
+          [ renderRdfGraph rdf, renderOverlayBooks state ]
+            <> renderSparqlLensMaybe state.sparqlLens
         else []
       Nothing -> []
 
@@ -640,6 +656,103 @@ inspectorComponent initial =
           [ classNames [ "rdf-turtle" ] ]
           [ HH.text rdf.turtle ]
       ]
+
+  renderOverlayBooks state =
+    HH.div
+      [ classNames [ "overlay-book-panel" ] ]
+      [ HH.div
+          [ classNames [ "identity-heading" ] ]
+          [ HH.div_
+              [ HH.h3_ [ HH.text "Overlay books" ]
+              , HH.p_ [ HH.text "Import optional RDF overlay parts for later graph union." ]
+              ]
+          ]
+      , HH.div
+          [ classNames [ "overlay-import-grid" ] ]
+          [ HH.label
+              [ classNames [ "field-stack" ] ]
+              [ HH.span
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "Overlay Turtle or Amaru journal JSON" ]
+              , HH.textarea
+                  [ HP.value state.overlayInput
+                  , HP.rows 8
+                  , HH.attr (HH.AttrName "aria-label") "Overlay Turtle or Amaru journal JSON"
+                  , HE.onValueInput SetOverlayInput
+                  ]
+              ]
+          , HH.div
+              [ classNames [ "overlay-actions" ] ]
+              [ HH.button
+                  [ classNames [ "secondary-action" ]
+                  , HE.onClick (\_ -> LoadAmaruOverlayBook)
+                  ]
+                  [ HH.text "Load Amaru overlay book" ]
+              , HH.button
+                  [ classNames [ "primary-action" ]
+                  , HE.onClick (\_ -> ImportOverlayBook)
+                  ]
+                  [ HH.text "Import overlay book" ]
+              ]
+          ]
+      , case state.overlayError of
+          Just err ->
+            HH.div
+              [ classNames [ "sparql-lens-error" ] ]
+              [ HH.text ("Overlay import failed: " <> err) ]
+          Nothing -> HH.text ""
+      , HH.div
+          [ classNames [ "overlay-selection-grid" ] ]
+          [ HH.div
+              [ classNames [ "overlay-part-list" ] ]
+              (renderOverlayPartList state)
+          , HH.label
+              [ classNames [ "field-stack" ] ]
+              [ HH.span
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "Selected overlay Turtle" ]
+              , HH.textarea
+                  [ HP.value (selectedOverlayTurtle state)
+                  , HP.rows 10
+                  , HH.attr (HH.AttrName "aria-label") "Selected overlay Turtle"
+                  , HH.attr (HH.AttrName "readonly") "readonly"
+                  ]
+              ]
+          ]
+      ]
+
+  renderOverlayPartList state =
+    if Array.null state.overlayParts then
+      [ HH.div
+          [ classNames [ "witness-empty" ] ]
+          [ HH.text "No overlay parts imported." ]
+      ]
+    else
+      map (renderOverlayPart state) state.overlayParts
+
+  renderOverlayPart state part =
+    let
+      selected = Array.elem part.id state.selectedOverlayPartIds
+    in
+      HH.label
+        [ choiceClass selected ]
+        [ HH.input
+            [ HP.type_ HP.InputCheckbox
+            , HP.checked selected
+            , HE.onChecked (ToggleOverlayPart part.id)
+            ]
+        , HH.span
+            [ classNames [ "choice-title" ] ]
+            [ HH.text part.label ]
+        ]
+
+  selectedOverlayTurtle state =
+    String.joinWith "\n" (map _.turtle (selectedOverlayParts state))
+
+  selectedOverlayParts state =
+    Array.filter
+      (\part -> Array.elem part.id state.selectedOverlayPartIds)
+      state.overlayParts
 
   renderSparqlLensMaybe lens =
     case lens of
@@ -1055,6 +1168,40 @@ inspectorComponent initial =
     SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing, copiedPath = Nothing }
     SetTxHash s -> H.modify_ _ { txHash = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
     SetTxHex s -> H.modify_ _ { txHex = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
+    SetOverlayInput s -> H.modify_ _ { overlayInput = s, overlayError = Nothing }
+    ImportOverlayBook -> do
+      input <- H.gets _.overlayInput
+      parsed <- liftEffect (OverlayBook.parse input)
+      case parsed of
+        Left err ->
+          H.modify_ _ { overlayError = Just err }
+        Right book ->
+          H.modify_
+            _
+              { overlayParts = book.parts
+              , selectedOverlayPartIds = []
+              , overlayError = Nothing
+              }
+    LoadAmaruOverlayBook -> do
+      let input = OverlayBook.bundledAmaruJournal
+      parsed <- liftEffect (OverlayBook.parse input)
+      case parsed of
+        Left err ->
+          H.modify_ _ { overlayInput = input, overlayError = Just err }
+        Right book ->
+          H.modify_
+            _
+              { overlayInput = input
+              , overlayParts = book.parts
+              , selectedOverlayPartIds = []
+              , overlayError = Nothing
+              }
+    ToggleOverlayPart partId selected ->
+      H.modify_ \st ->
+        st
+          { selectedOverlayPartIds =
+              toggleOverlayPartId partId selected st.selectedOverlayPartIds
+          }
     Decode -> do
       st <- H.get
       H.modify_
@@ -1221,3 +1368,10 @@ inspectorComponent initial =
                     if operationResult.exitOk && browser.valid then Nothing
                     else Just (if operationResult.stderr == "" then "Haskell ledger operation browse failed." else operationResult.stderr)
                 }
+
+  toggleOverlayPartId partId selected ids =
+    if selected then
+      if Array.elem partId ids then ids
+      else Array.snoc ids partId
+    else
+      Array.filter (_ /= partId) ids

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -236,12 +236,32 @@ test("selects Amaru overlay book parts into deterministic Turtle", async ({
 
   const selectedTurtle = overlayPanel.getByLabel("Selected overlay Turtle");
   const coreDevelopment = overlayPanel.getByLabel("Core development");
+  const resolvedLabelsPanel = page.locator(".resolved-labels-panel");
   await coreDevelopment.check();
   await expect(selectedTurtle).toHaveValue(/Amaru Core Development treasury/);
   await expect(selectedTurtle).toHaveValue(/@prefix cardano:/);
+  await expect(
+    resolvedLabelsPanel.getByRole("heading", {
+      name: "SPARQL lens: resolved labels",
+    }),
+  ).toBeVisible();
+  await expect(
+    resolvedLabelsPanel.getByText("Amaru Core Development treasury", {
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(resolvedLabelsPanel.getByText("Treasury", { exact: true })).toBeVisible();
 
   await coreDevelopment.uncheck();
   await expect(selectedTurtle).not.toHaveValue(/Amaru Core Development treasury/);
+  await expect(
+    resolvedLabelsPanel.getByText("Amaru Core Development treasury", {
+      exact: true,
+    }),
+  ).toHaveCount(0);
+  await expect(
+    resolvedLabelsPanel.getByText("No resolved labels.", { exact: true }),
+  ).toBeVisible();
 });
 
 test("exposes the vendored RDF query engine", async ({ page }) => {

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -19,6 +19,10 @@ const validationFixturePath = path.join(
   repoRoot,
   "specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json",
 );
+const amaruJournalFixturePath = path.join(
+  repoRoot,
+  "docs/inspector/protocols/amaru-treasury/journal-2026.json",
+);
 
 async function loadValidationContext() {
   const request = JSON.parse(await readFile(validationFixturePath, "utf8"));
@@ -212,6 +216,32 @@ test("renders the transaction RDF graph after decode", async ({ page }) => {
   await expect(lensPanel.locator(".sparql-lens-row").first()).toBeVisible();
   await expect(lensPanel.getByText("5", { exact: true })).toBeVisible();
   await expect(lensPanel.getByText(/urn:cardano:tx:/)).toBeVisible();
+});
+
+test("selects Amaru overlay book parts into deterministic Turtle", async ({
+  page,
+}) => {
+  const journalJson = await readFile(amaruJournalFixturePath, "utf8");
+  await decodeFixture(page);
+
+  const overlayPanel = page.locator(".overlay-book-panel");
+  await expect(
+    overlayPanel.getByRole("heading", { name: "Overlay books" }),
+  ).toBeVisible();
+
+  await overlayPanel
+    .getByLabel("Overlay Turtle or Amaru journal JSON")
+    .fill(journalJson);
+  await overlayPanel.getByRole("button", { name: "Import overlay book" }).click();
+
+  const selectedTurtle = overlayPanel.getByLabel("Selected overlay Turtle");
+  const coreDevelopment = overlayPanel.getByLabel("Core development");
+  await coreDevelopment.check();
+  await expect(selectedTurtle).toHaveValue(/Amaru Core Development treasury/);
+  await expect(selectedTurtle).toHaveValue(/@prefix cardano:/);
+
+  await coreDevelopment.uncheck();
+  await expect(selectedTurtle).not.toHaveValue(/Amaru Core Development treasury/);
 });
 
 test("exposes the vendored RDF query engine", async ({ page }) => {

--- a/gate.sh
+++ b/gate.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd "$(git rev-parse --show-toplevel)"
-
-nix develop --quiet -c just check-rdf
-nix develop --quiet -c just ui-check
-nix develop --quiet -c just test-playwright

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+nix develop --quiet -c just check-rdf
+nix develop --quiet -c just ui-check
+nix develop --quiet -c just test-playwright

--- a/specs/080-rdf-overlay-books/plan.md
+++ b/specs/080-rdf-overlay-books/plan.md
@@ -1,0 +1,53 @@
+# Implementation Plan: RDF-3 overlay books
+
+## Context
+
+RDF-1 emits deterministic `cardano:` Turtle through `tx.rdf`. RDF-2 vendors
+`rdf-shapes-wasm` and renders a fixed SPARQL lens over that graph. RDF-3 adds
+overlay data authored outside the transaction, selected by the user, merged by
+IRI union, then queried with another fixed named lens.
+
+## Technical Shape
+
+- **Overlay asset**: add a repository-local Amaru overlay Turtle asset next to
+  `docs/inspector/protocols/amaru-treasury/journal-2026.json`.
+- **Book parsing**: add a small browser-side parser/import layer for pasted
+  Turtle and the Amaru journal JSON shape. Journal JSON becomes overlay parts:
+  scopes, treasury addresses, owner identifiers, and deployed script refs.
+- **Selection state**: keep selected part ids in Halogen state. The merged graph
+  is `tx.rdf.turtle <> selectedOverlayTurtle`.
+- **Resolved-labels lens**: extend the `FFI.RdfShapes` wrapper with a named
+  query returning normalized rows. The query joins overlay `cardano:Entity`
+  labels/roles to transaction graph IRIs/literals via shared IRI and canonical
+  Cardano predicates.
+- **UI**: render import controls, a selected-parts checklist, merged graph
+  status, and resolved-label rows inside the existing result area.
+- **Tests**: extend the Playwright fixture decode test to import the bundled
+  overlay, prove a label appears, deselect it, and prove the label disappears.
+
+## Slices
+
+### Slice 1 - Overlay Book Asset And Parser
+
+Create the Amaru overlay Turtle asset and browser-side import/selection model.
+This slice should prove selectivity without depending on the final resolved
+labels lens rendering.
+
+### Slice 2 - Merge And Resolved Labels UX
+
+Union selected overlay Turtle with the transaction graph, run the named SPARQL
+resolved-labels lens, render results, and add Playwright coverage.
+
+## Verification
+
+Per slice:
+
+- `nix develop --quiet -c just check-rdf`
+- `nix develop --quiet -c just ui-check`
+- `nix develop --quiet -c just test-playwright`
+- `./gate.sh`
+
+Final:
+
+- `just build-ui`
+- `./gate.sh`

--- a/specs/080-rdf-overlay-books/spec.md
+++ b/specs/080-rdf-overlay-books/spec.md
@@ -1,0 +1,52 @@
+# Feature Specification: RDF-3 overlay books
+
+**Issue**: cardano-ledger-inspector#80
+**Branch**: feat/rdf-overlay-books
+**Status**: Draft
+
+## User Story
+
+As a browser workbench user inspecting a Conway transaction, I can import a
+local overlay book, select which overlay parts to merge, and see resolved human
+labels for transaction entities without uploading anything or relying on a
+server-side join.
+
+## Functional Requirements
+
+- **FR-001**: The workbench exposes a Books panel after a valid transaction RDF
+  graph is available.
+- **FR-002**: A book import accepts pasted Turtle and a paste/file shape derived
+  from `docs/inspector/protocols/amaru-treasury/journal-2026.json`.
+- **FR-003**: The Amaru treasury journal is reframed as a bundled overlay book
+  in the repository, emitted as Turtle keyed by canonical Cardano IRIs.
+- **FR-004**: The user can select individual overlay parts before merge. An
+  unselected part contributes no triples to the resolved graph and no rows to
+  the resolved-labels lens.
+- **FR-005**: Merging is plain RDF union by IRI. The implementation must not
+  special-case the transaction JSON or manually join labels outside SPARQL.
+- **FR-006**: A named resolved-labels lens runs through
+  `rdf-shapes-wasm query()` over the merged Turtle and renders label, role,
+  identifier, and matched entity rows.
+- **FR-007**: The feature stays fully client-side. Imported data is held in page
+  state/local browser controls only; there is no upload path.
+- **FR-008**: Existing transaction RDF graph rendering and the RDF-2 transaction
+  outputs lens continue to work.
+
+## Acceptance Criteria
+
+- Importing the bundled Amaru overlay and selecting one scope/role part merges
+  that part into the in-page `cardano:` graph and renders its resolved label.
+- Deselecting that part removes its labels from the merged graph and from the
+  resolved-labels lens.
+- The resolved-labels lens is a SPARQL query over Turtle, joining by canonical
+  IRIs and `cardano:bech32` / `cardano:fromTxOutRef` / identifier predicates
+  where present.
+- `nix develop --quiet -c just check-rdf`,
+  `nix develop --quiet -c just ui-check`, `just build-ui`, and
+  `nix develop --quiet -c just test-playwright` pass.
+
+## Out Of Scope
+
+- Blueprint books, CIP-57 datum/redeemer decoding, and SHACL validation.
+- Book signing, distribution trust roots, remote catalogs, and upload/sync.
+- Raw arbitrary SPARQL editing in the UI.

--- a/specs/080-rdf-overlay-books/tasks.md
+++ b/specs/080-rdf-overlay-books/tasks.md
@@ -2,15 +2,15 @@
 
 ## Slice 1 - Overlay Book Asset And Parser
 
-- [ ] T080-S1 Add an Amaru overlay Turtle asset derived from
+- [X] T080-S1 Add an Amaru overlay Turtle asset derived from
   `docs/inspector/protocols/amaru-treasury/journal-2026.json`.
-- [ ] T080-S1 Add browser import/parse state for pasted Turtle and bundled
+- [X] T080-S1 Add browser import/parse state for pasted Turtle and bundled
   Amaru journal JSON.
-- [ ] T080-S1 Add selectable overlay parts with deterministic selected Turtle
+- [X] T080-S1 Add selectable overlay parts with deterministic selected Turtle
   output and zero contribution from unselected parts.
-- [ ] T080-S1 Run `nix develop --quiet -c just check-rdf`,
+- [X] T080-S1 Run `nix develop --quiet -c just check-rdf`,
   `nix develop --quiet -c just ui-check`, and `./gate.sh`.
-- [ ] T080-S1 Commit as `feat: add rdf overlay book import model`.
+- [X] T080-S1 Commit as `feat: add rdf overlay book import model`.
 
 ## Slice 2 - Merge And Resolved Labels UX
 

--- a/specs/080-rdf-overlay-books/tasks.md
+++ b/specs/080-rdf-overlay-books/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: RDF-3 overlay books
+
+## Slice 1 - Overlay Book Asset And Parser
+
+- [ ] T080-S1 Add an Amaru overlay Turtle asset derived from
+  `docs/inspector/protocols/amaru-treasury/journal-2026.json`.
+- [ ] T080-S1 Add browser import/parse state for pasted Turtle and bundled
+  Amaru journal JSON.
+- [ ] T080-S1 Add selectable overlay parts with deterministic selected Turtle
+  output and zero contribution from unselected parts.
+- [ ] T080-S1 Run `nix develop --quiet -c just check-rdf`,
+  `nix develop --quiet -c just ui-check`, and `./gate.sh`.
+- [ ] T080-S1 Commit as `feat: add rdf overlay book import model`.
+
+## Slice 2 - Merge And Resolved Labels UX
+
+- [ ] T080-S2 Merge selected overlay Turtle with `tx.rdf` by RDF union only.
+- [ ] T080-S2 Add a named resolved-labels SPARQL lens through
+  `rdf-shapes-wasm query()` and render label/role/entity rows.
+- [ ] T080-S2 Extend Playwright coverage for import, select, merge,
+  resolved-label rendering, and deselect selectivity.
+- [ ] T080-S2 Run `nix develop --quiet -c just check-rdf`,
+  `nix develop --quiet -c just ui-check`,
+  `nix develop --quiet -c just test-playwright`, and `./gate.sh`.
+- [ ] T080-S2 Commit as `feat: render resolved labels from rdf overlay books`.

--- a/specs/080-rdf-overlay-books/tasks.md
+++ b/specs/080-rdf-overlay-books/tasks.md
@@ -14,12 +14,12 @@
 
 ## Slice 2 - Merge And Resolved Labels UX
 
-- [ ] T080-S2 Merge selected overlay Turtle with `tx.rdf` by RDF union only.
-- [ ] T080-S2 Add a named resolved-labels SPARQL lens through
+- [X] T080-S2 Merge selected overlay Turtle with `tx.rdf` by RDF union only.
+- [X] T080-S2 Add a named resolved-labels SPARQL lens through
   `rdf-shapes-wasm query()` and render label/role/entity rows.
-- [ ] T080-S2 Extend Playwright coverage for import, select, merge,
+- [X] T080-S2 Extend Playwright coverage for import, select, merge,
   resolved-label rendering, and deselect selectivity.
-- [ ] T080-S2 Run `nix develop --quiet -c just check-rdf`,
+- [X] T080-S2 Run `nix develop --quiet -c just check-rdf`,
   `nix develop --quiet -c just ui-check`,
   `nix develop --quiet -c just test-playwright`, and `./gate.sh`.
-- [ ] T080-S2 Commit as `feat: render resolved labels from rdf overlay books`.
+- [X] T080-S2 Commit as `feat: render resolved labels from rdf overlay books`.


### PR DESCRIPTION
Closes #80.

Implements RDF overlay books: import/paste an overlay Turtle book, select overlay parts, merge selected Turtle by IRI union into the transaction RDF graph, and render resolved labels through a named browser SPARQL lens.

Verification:
- `nix develop --quiet -c just check-rdf`
- `nix develop --quiet -c just ui-check`
- `nix develop --quiet -c just test-playwright`
- `nix develop --quiet -c just build-ui`
- `./gate.sh` before dropping the temporary gate script

Navigator note: the current resolved-label lens intentionally stays fixed/named for RDF-3; future refinement can reduce noisy schema-label rows if desired.