### PR TITLE
Move backend config to settings

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -291,7 +291,7 @@ fieldset {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(280px, 0.78fr) minmax(0, 1.22fr);
+  grid-template-columns: 1fr;
   gap: 18px;
   align-items: start;
 }
@@ -311,14 +311,38 @@ fieldset {
 }
 
 .panel[data-md3-surface],
+.settings-summary[data-md3-surface],
 [data-md3-surface="decoded"] {
   border-color: var(--md-sys-color-outline-variant);
   background: var(--md-sys-color-surface-container-low);
 }
 
-.provider-panel {
-  position: sticky;
-  top: 16px;
+.settings-layout {
+  display: grid;
+  max-width: 760px;
+}
+
+.settings-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 12px 14px;
+}
+
+.settings-summary-copy {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.settings-summary-copy strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .panel-heading {
@@ -1066,9 +1090,6 @@ pre {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .provider-panel {
-    position: static;
-  }
 }
 
 @media (max-width: 640px) {
@@ -1165,5 +1186,10 @@ pre {
     align-items: start;
     flex-direction: column;
     gap: 0.2rem;
+  }
+
+  .settings-summary {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -12,7 +12,7 @@ import Effect.Aff (attempt)
 import Effect.Aff.Class (class MonadAff)
 import Effect.Class (liftEffect)
 import Effect.Exception (message)
-import FFI.Blockfrost (Network(..))
+import FFI.Blockfrost (Network(..), networkName)
 import FFI.Clipboard (copy) as Clipboard
 import FFI.Inspector (InspectorResult, runLedgerOperation)
 import FFI.Json (Browser, Identification, IntentSummary, RdfGraph, Validation, WitnessPlan, inspect, operationArgsMerged, operationArgsWithPath, operationBrowser, operationIdentification, operationInspection, operationIntentSummary, operationRdfGraph, operationValidation, operationWitnessPlan, pretty, providerResolutionErrorArgs) as Json
@@ -46,6 +46,9 @@ koiosKey = "koios_bearer_token"
 providerKey :: String
 providerKey = "provider"
 
+networkKey :: String
+networkKey = "network"
+
 persistKeysStorageKey :: String
 persistKeysStorageKey = "persist_api_keys"
 
@@ -76,12 +79,17 @@ main = HA.runHalogenAff do
   kOS  <- liftEffect
     (if persistInitial then Storage.getItem koiosKey else pure "")
   prov <- liftEffect (Storage.getItem providerKey)
+  net  <- liftEffect (Storage.getItem networkKey)
   route <- liftEffect Routing.currentRoute
   routeBase <- liftEffect Routing.currentBasePath
   theme <- liftEffect Shell.initialTheme
   let initialProv = case prov of
         "Koios"      -> Koios
         _            -> Blockfrost
+      initialNetwork = case net of
+        "preprod" -> Preprod
+        "preview" -> Preview
+        _         -> Mainnet
       mountTarget = case app of
         Just el -> el
         Nothing -> body
@@ -90,6 +98,7 @@ main = HA.runHalogenAff do
         { bf
         , koios: kOS
         , prov: initialProv
+        , network: initialNetwork
         , persistKeys: persistInitial
         , route
         , routeBase
@@ -169,6 +178,7 @@ type InitialKeys =
   { bf :: String
   , koios :: String
   , prov :: Provider
+  , network :: Network
   , persistKeys :: Boolean
   , route :: Route
   , routeBase :: String
@@ -211,7 +221,7 @@ inspectorComponent initial =
         , koiosBearer: initial.koios
         , persistKeys: initial.persistKeys
         , mode: ByHash
-        , network: Mainnet
+        , network: initial.network
         , txHash: ""
         , txHex: ""
         , result: Nothing
@@ -261,7 +271,7 @@ inspectorComponent initial =
           [ classNames [ "page-frame", "shell-main" ] ]
           [ case state.route of
               RouteInspect -> renderInspector state
-              RouteSettings -> Shell.placeholderPage "Settings"
+              RouteSettings -> renderSettings state
               RouteLibrary -> Shell.placeholderPage "Library"
           ]
       , Shell.siteFooter
@@ -276,25 +286,64 @@ inspectorComponent initial =
               [ HH.h1_ [ HH.text "Conway tx inspector" ]
               , HH.p_
                   [ HH.text
-                      "Decode Conway transaction CBOR in the browser with the upstream Haskell ledger compiled to "
-                  , HH.code_ [ HH.text "wasm32-wasi" ]
-                  , HH.text "."
+                      "Decode, inspect, and validate Conway transaction CBOR with explicit chain-data context."
                   ]
               ]
           , HH.div
               [ classNames [ "tech-pills" ] ]
-              [ HH.span_ [ HH.text "cardano-ledger-conway" ]
-              , HH.span_ [ HH.text "cardano-ledger-binary" ]
-              , HH.span_ [ HH.text "WASI" ]
+              [ HH.span_ [ HH.text "CBOR" ]
+              , HH.span_ [ HH.text "context-aware" ]
+              , HH.span_ [ HH.text "RDF views" ]
               ]
           ]
+      , renderSettingsSummary state
       , HH.div
           [ classNames [ "workspace" ] ]
-          [ renderProvider state
-          , HH.div
+          [ HH.div
               [ classNames [ "workspace-main" ] ]
               (renderWorkspaceMain state)
           ]
+      ]
+
+  renderSettings state =
+    HH.div
+      [ classNames [ "app-shell", "settings-page" ] ]
+      [ HH.section
+          [ classNames [ "intro-strip" ] ]
+          [ HH.div_
+              [ HH.h1_ [ HH.text "Settings" ]
+              , HH.p_
+                  [ HH.text
+                      "Configure the chain-data provider, network, and credential persistence used by transaction decoding."
+                  ]
+              ]
+          ]
+      , HH.div
+          [ classNames [ "settings-layout" ] ]
+          [ renderProvider state ]
+      ]
+
+  renderSettingsSummary state =
+    HH.section
+      [ classNames [ "settings-summary" ]
+      , mdSurface "provider"
+      ]
+      [ HH.div
+          [ classNames [ "settings-summary-copy" ] ]
+          [ HH.span
+              [ classNames [ "identity-section-title" ] ]
+              [ HH.text "Active chain data" ]
+          , HH.strong_
+              [ HH.text
+                  (Provider.providerName state.provider <> " / " <> networkName state.network)
+              ]
+          ]
+      , HH.a
+          [ classNames [ "header-link" ]
+          , HP.href (state.routeBase <> Routing.routePath RouteSettings)
+          , HE.onClick (Navigate RouteSettings)
+          ]
+          [ HH.text "Settings" ]
       ]
 
   renderWorkspaceMain state =
@@ -1676,7 +1725,9 @@ inspectorComponent initial =
             Storage.setItem blockfrostKey ""
             Storage.setItem koiosKey ""
     SelectMode m -> H.modify_ _ { mode = m, fetchError = Nothing, copiedPath = Nothing }
-    SelectNetwork n -> H.modify_ _ { network = n, fetchError = Nothing, copiedPath = Nothing }
+    SelectNetwork n -> do
+      H.modify_ _ { network = n, fetchError = Nothing, copiedPath = Nothing }
+      liftEffect (Storage.setItem networkKey (networkName n))
     SetTxHash s -> H.modify_ _ { txHash = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
     SetTxHex s -> H.modify_ _ { txHex = s, copied = false, copiedPath = Nothing, fetchError = Nothing }
     SetOverlayInput s -> H.modify_ _ { overlayInput = s, overlayError = Nothing }

--- a/docs/inspector/src/Shell.purs
+++ b/docs/inspector/src/Shell.purs
@@ -38,7 +38,7 @@ topbar active opts =
         [ HH.div
             [ classNames [ "brand" ] ]
             [ HH.strong_ [ HH.text "Cardano transaction inspector" ]
-            , HH.span_ [ HH.text "Haskell ledger in the browser" ]
+            , HH.span_ [ HH.text "Decode, inspect, and validate transactions" ]
             ]
         , HH.nav
             [ classNames [ "topbar-nav" ]
@@ -108,10 +108,7 @@ siteFooter =
         , extLink "https://github.com/lambdasistemi/cardano-ledger-inspector" "Source"
         ]
     , HH.div_
-        [ HH.text "Built with the upstream Haskell ledger, cross-compiled to "
-        , HH.code_ [ HH.text "wasm32-wasi" ]
-        , HH.text "."
-        ]
+        [ HH.text "Browser-based Cardano transaction inspection with explicit chain-data context." ]
     ]
   where
   extLink href label =

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -202,6 +202,35 @@ async function decodeFixture(page, txFixturePath = fixturePath) {
   await decodeFixtureAt(page, "/", txFixturePath);
 }
 
+async function configureChainData(page, options = {}) {
+  const {
+    provider = "Blockfrost",
+    network = "mainnet",
+    blockfrostKey = "mainnet-test-project",
+    koiosBearer = "koios-test-token",
+    persist = false,
+  } = options;
+
+  await page.goto("/settings");
+  await page.getByRole("radio", { name: provider }).check();
+  await page.getByRole("radio", { name: network }).check();
+  if (provider === "Blockfrost") {
+    await page
+      .getByPlaceholder("mainnet... / preprod... / preview...")
+      .fill(blockfrostKey);
+  } else {
+    await page.getByPlaceholder("eyJhbGciOi...").fill(koiosBearer);
+  }
+  if (persist) {
+    await page.getByRole("switch", { name: "Persist API credentials" }).check();
+  }
+}
+
+async function openInspectViaShell(page) {
+  await page.getByRole("banner").getByRole("link", { name: "Inspect" }).click();
+  await expect(page).toHaveURL(/\/inspect$/);
+}
+
 async function expectInFirstViewport(locator) {
   await expect(locator).toBeVisible();
   const box = await locator.evaluate((element) => {
@@ -277,7 +306,11 @@ test("MD3 shell routes topbar nav and theme toggle", async ({ page }) => {
   await navigation.getByRole("link", { name: "Settings" }).click();
   await expect(page).toHaveURL(/\/settings$/);
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
-  await expect(page.getByText("Settings placeholder", { exact: true })).toBeVisible();
+  await expect(page.locator(".provider-panel")).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Blockfrost" })).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Koios" })).toBeVisible();
+  await expect(page.getByRole("switch", { name: "Persist API credentials" })).toBeVisible();
+  await expect(page.getByText("cleartext", { exact: false })).toBeVisible();
 
   await navigation.getByRole("link", { name: "Library" }).click();
   await expect(page).toHaveURL(/\/library$/);
@@ -289,20 +322,31 @@ test("MD3 shell keeps route navigation inside deployed subpaths", async ({
   page,
 }) => {
   await withPrefixedInspectorSite(async (baseUrl) => {
-    await page.goto(`${baseUrl}settings/`);
-    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
-    expect(page.url().startsWith(`${baseUrl}settings/`)).toBe(true);
+    const routes = [
+      { path: "inspect", assert: async () => {
+        await expect(page.getByRole("radio", { name: "CBOR hex" })).toBeVisible();
+      } },
+      { path: "settings", assert: async () => {
+        await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+        await expect(page.locator(".provider-panel")).toBeVisible();
+      } },
+      { path: "library", assert: async () => {
+        await expect(page.getByRole("heading", { name: "Library" })).toBeVisible();
+        await expect(page.getByText("Library placeholder", { exact: true })).toBeVisible();
+      } },
+    ];
+
+    for (const route of routes) {
+      await page.goto(`${baseUrl}${route.path}/`);
+      await route.assert();
+      expect(page.url().startsWith(`${baseUrl}${route.path}`)).toBe(true);
+      expect(new URL(page.url()).pathname).not.toBe(`/${route.path}`);
+      await page.reload();
+      await route.assert();
+      expect(page.url().startsWith(`${baseUrl}${route.path}`)).toBe(true);
+    }
 
     const navigation = page.getByRole("banner").getByRole("navigation");
-    await navigation.getByRole("link", { name: "Library" }).click();
-    await expect(page.getByRole("heading", { name: "Library" })).toBeVisible();
-    expect(page.url().startsWith(`${baseUrl}library`)).toBe(true);
-    expect(new URL(page.url()).pathname).not.toBe("/library");
-
-    await page.reload();
-    await expect(page.getByRole("heading", { name: "Library" })).toBeVisible();
-    expect(page.url().startsWith(`${baseUrl}library`)).toBe(true);
-
     await navigation.getByRole("link", { name: "Inspect" }).click();
     await expect(page.getByRole("radio", { name: "CBOR hex" })).toBeVisible();
     expect(page.url().startsWith(`${baseUrl}inspect`)).toBe(true);
@@ -316,36 +360,14 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   await page.addInitScript(() => {
     localStorage.setItem("cardano-ledger-inspector-theme", "light");
   });
-  await decodeFixtureAt(page, "/inspect");
+  await page.goto("/settings");
 
   const providerPanel = page.locator(".provider-panel");
-  const inputPanel = page.locator(".input-panel");
-  const resultPanel = page.locator(".result-panel");
-  const identityPanel = page.locator(".identity-panel").first();
-  const validationPanel = page.locator(".validation-panel");
-  const rdfPanel = page.locator(".rdf-panel");
-  const lensPanel = page.locator(".sparql-lens-panel").first();
 
   await expect(providerPanel).toHaveAttribute("data-md3-surface", "provider");
-  await expect(inputPanel).toHaveAttribute("data-md3-surface", "input");
-  await expect(resultPanel).toHaveAttribute("data-md3-surface", "result");
-  await expect(identityPanel).toHaveAttribute("data-md3-surface", "decoded");
-  await expect(validationPanel).toHaveAttribute("data-md3-surface", "decoded");
-  await expect(rdfPanel).toHaveAttribute("data-md3-surface", "decoded");
-  await expect(lensPanel).toHaveAttribute("data-md3-surface", "decoded");
-
-  await expect(page.getByRole("button", { name: "Decode" })).toHaveAttribute(
-    "data-md3-control",
-    "primary",
-  );
-  await expect(page.getByRole("button", { name: "Copy JSON" })).toHaveAttribute(
-    "data-md3-control",
-    "secondary",
-  );
-  await expect(page.getByRole("button", { name: "Copy current" })).toHaveAttribute(
-    "data-md3-control",
-    "inline",
-  );
+  await expect(page.getByRole("radio", { name: "Blockfrost" })).toBeVisible();
+  await expect(page.getByRole("radio", { name: "mainnet" })).toBeVisible();
+  await expect(page.getByRole("switch", { name: "Persist API credentials" })).toBeVisible();
 
   await expectColorToken(
     page,
@@ -374,6 +396,127 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
     "--md-sys-color-surface-container-low",
   );
   await expect(providerPanel).not.toHaveCSS("background-color", lightBackground);
+
+  await page.goto("/inspect");
+  await decodeFixtureAt(page, "/inspect");
+
+  const inputPanel = page.locator(".input-panel");
+  const resultPanel = page.locator(".result-panel");
+  const identityPanel = page.locator(".identity-panel").first();
+  const validationPanel = page.locator(".validation-panel");
+  const rdfPanel = page.locator(".rdf-panel");
+  const lensPanel = page.locator(".sparql-lens-panel").first();
+
+  await expect(page.locator(".provider-panel")).toHaveCount(0);
+  await expect(inputPanel).toHaveAttribute("data-md3-surface", "input");
+  await expect(resultPanel).toHaveAttribute("data-md3-surface", "result");
+  await expect(identityPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await expect(validationPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await expect(rdfPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await expect(lensPanel).toHaveAttribute("data-md3-surface", "decoded");
+
+  await expect(page.getByRole("button", { name: "Decode" })).toHaveAttribute(
+    "data-md3-control",
+    "primary",
+  );
+  await expect(page.getByRole("button", { name: "Copy JSON" })).toHaveAttribute(
+    "data-md3-control",
+    "secondary",
+  );
+  await expect(page.getByRole("button", { name: "Copy current" })).toHaveAttribute(
+    "data-md3-control",
+    "inline",
+  );
+});
+
+test("inspect keeps chain-data settings compact and gives input/results the workspace", async ({
+  page,
+}) => {
+  await page.goto("/inspect");
+
+  await expect(page.locator(".provider-panel")).toHaveCount(0);
+  const settingsSummary = page.locator(".settings-summary");
+  await expect(settingsSummary).toBeVisible();
+  await expect(settingsSummary).toContainText("Blockfrost");
+  await expect(settingsSummary).toContainText("mainnet");
+  await expect(settingsSummary.getByRole("link", { name: "Settings" })).toBeVisible();
+
+  const workspaceBox = await page.locator(".workspace").boundingBox();
+  const inputBox = await page.locator(".input-panel").boundingBox();
+  const resultBox = await page.locator(".result-panel").boundingBox();
+  expect(inputBox.width).toBeGreaterThan(workspaceBox.width * 0.9);
+  expect(resultBox.width).toBeGreaterThan(workspaceBox.width * 0.9);
+});
+
+test("settings changes provider state used by inspect hash decode", async ({ page }) => {
+  const txCbor = (await readFile(fixturePath, "utf8")).trim();
+  const validationContext = await loadValidationContext();
+  const requestedHashes = [];
+  let tipRequests = 0;
+  let protocolParameterRequests = 0;
+
+  await installClipboardMock(page);
+  await page.route("https://preview.koios.rest/api/v1/tx_cbor", async (route) => {
+    const requestBody = route.request().postDataJSON();
+    requestedHashes.push(...requestBody._tx_hashes);
+    expect(route.request().headers().authorization).toBe("Bearer koios-settings-token");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        requestBody._tx_hashes.map((txHash) => ({
+          cbor: producerCbor(validationContext, txHash, txCbor),
+        })),
+      ),
+    });
+  });
+  await page.route("https://preview.koios.rest/api/v1/tip", async (route) => {
+    tipRequests += 1;
+    expect(route.request().headers().authorization).toBe("Bearer koios-settings-token");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          abs_slot: Number(validationContext.slot),
+          epoch_no: Number(validationContext.epoch),
+        },
+      ]),
+    });
+  });
+  await page.route(
+    "https://preview.koios.rest/api/v1/cli_protocol_params",
+    async (route) => {
+      protocolParameterRequests += 1;
+      expect(route.request().headers().authorization).toBe("Bearer koios-settings-token");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(validationContext.protocol_parameters),
+      });
+    },
+  );
+
+  await configureChainData(page, {
+    provider: "Koios",
+    network: "preview",
+    koiosBearer: "koios-settings-token",
+  });
+
+  await openInspectViaShell(page);
+  await expect(page.locator(".settings-summary")).toContainText("Koios");
+  await expect(page.locator(".settings-summary")).toContainText("preview");
+  await page
+    .getByPlaceholder("64-char tx hash")
+    .fill("0".repeat(64));
+  await page.getByRole("button", { name: "Fetch and decode" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "Conway transaction identity" }),
+  ).toBeVisible();
+  expect(requestedHashes).toContain("0".repeat(64));
+  expect(tipRequests).toBe(1);
+  expect(protocolParameterRequests).toBe(1);
 });
 
 test("decodes a Conway transaction and exposes compact identity values", async ({
@@ -818,10 +961,12 @@ test("passes producer transaction CBOR into witness planning", async ({
     await route.abort();
   });
 
-  await page.goto("/");
-  await page
-    .getByPlaceholder("mainnet... / preprod... / preview...")
-    .fill("mainnet-test-project");
+  await configureChainData(page, {
+    provider: "Blockfrost",
+    network: "mainnet",
+    blockfrostKey: "mainnet-test-project",
+  });
+  await openInspectViaShell(page);
   await page.getByRole("radio", { name: "CBOR hex" }).check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
@@ -909,10 +1054,12 @@ test("passes producer transaction CBOR into RDF resolved value flow", async ({
     await route.abort();
   });
 
-  await page.goto("/");
-  await page
-    .getByPlaceholder("mainnet... / preprod... / preview...")
-    .fill("mainnet-test-project");
+  await configureChainData(page, {
+    provider: "Blockfrost",
+    network: "mainnet",
+    blockfrostKey: "mainnet-test-project",
+  });
+  await openInspectViaShell(page);
   await page.getByRole("radio", { name: "CBOR hex" }).check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
@@ -952,10 +1099,12 @@ test("surfaces hard provider context resolution failures", async ({
     });
   });
 
-  await page.goto("/");
-  await page
-    .getByPlaceholder("mainnet... / preprod... / preview...")
-    .fill("mainnet-test-project");
+  await configureChainData(page, {
+    provider: "Blockfrost",
+    network: "mainnet",
+    blockfrostKey: "mainnet-test-project",
+  });
+  await openInspectViaShell(page);
   await page.getByRole("radio", { name: "CBOR hex" }).check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
@@ -1008,9 +1157,12 @@ test("uses the same tx CBOR provider boundary for Koios", async ({ page }) => {
     });
   });
 
-  await page.goto("/");
-  await page.getByRole("radio", { name: "Koios" }).check();
-  await page.getByPlaceholder("eyJhbGciOi...").fill("koios-test-token");
+  await configureChainData(page, {
+    provider: "Koios",
+    network: "mainnet",
+    koiosBearer: "koios-test-token",
+  });
+  await openInspectViaShell(page);
   await page.getByRole("radio", { name: "CBOR hex" }).check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
@@ -1030,7 +1182,7 @@ test("uses the same tx CBOR provider boundary for Koios", async ({ page }) => {
 });
 
 test("routes Blockfrost-shaped keys away from Koios auth", async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/settings");
   await page.getByRole("radio", { name: "Koios" }).check();
   await page.getByPlaceholder("eyJhbGciOi...").fill("mainnet-test-project");
 

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build .#packages.x86_64-linux.tx-inspector-ui
+nix develop --quiet -c just ui-check
+nix develop --quiet -c just test-playwright

--- a/specs/100-settings-full-width/plan.md
+++ b/specs/100-settings-full-width/plan.md
@@ -1,0 +1,53 @@
+# Plan
+
+## Context
+
+#98 introduced the MD3 shell, topbar routes, theme handling, and subpath-safe
+routing. `/settings` and `/library` are placeholders. The provider controls
+are still rendered inside `docs/inspector/src/Main.purs` as
+`renderProvider`, and Playwright still expects `.provider-panel` on
+`/inspect`.
+
+## Implementation
+
+Use one vertical slice because this ticket is a single UI behavior move:
+
+- Keep settings state in the existing Halogen root component so route changes
+  do not remount or lose memory-only credentials.
+- Load `provider`, `network`, `persist_api_keys`, and persisted credentials at
+  startup. Read credentials from localStorage only when persistence is enabled.
+- Render the provider/key/network/persist form only on `/settings`.
+- Render `/inspect` as a full-width input/results workspace with a compact
+  settings summary and Settings link.
+- Keep `/library` as a placeholder.
+- Update shell/intro/footer copy so the product is framed as a general Cardano
+  transaction inspector instead of a Haskell/WASI showcase.
+- Adjust CSS grid rules for the full-width inspect layout and the settings
+  form.
+- Update Playwright assertions for the moved settings form and extend the
+  existing subpath test to deep-link and refresh all three routes.
+
+## Owned Files
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/src/Shell.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+## Verification
+
+- `./gate.sh`
+- Manual smoke after build: serve `result/` under a non-root subpath and check
+  `/inspect`, `/settings`, `/library` direct loads, navigation, refresh, and
+  decode.
+- Final preview smoke on `preview.dev.plutimus.com` before `COMPLETE`.
+
+## Risks
+
+- Provider credentials may be accidentally persisted when the toggle is off.
+  The handler must continue clearing stored API keys when persistence is
+  disabled.
+- Network persistence is newly required by #100; use the `network` key without
+  renaming existing provider keys.
+- The settings form must not become a second source of truth; `/inspect` must
+  decode from the same state edited on `/settings`.

--- a/specs/100-settings-full-width/spec.md
+++ b/specs/100-settings-full-width/spec.md
@@ -1,0 +1,44 @@
+# Issue 100 — Settings Config And Full-Width Inspect
+
+## User Story
+
+As a transaction inspector user, I want chain-data provider settings to live
+on a dedicated Settings page so the Inspect page can focus on transaction
+input and decoded results.
+
+## Scope
+
+- Move provider, API key, network, and credential persistence controls from
+  `/inspect` to `/settings`.
+- Keep the existing localStorage keys:
+  `blockfrost_project_id`, `koios_bearer_token`, `provider`, `network`, and
+  `persist_api_keys`.
+- Let `/inspect` read the shared settings state while `/settings` edits it.
+- Show a compact `/inspect` affordance with the active network and provider
+  plus a link to Settings.
+- Reframe visible product copy as a general Cardano transaction inspector,
+  with implementation technology de-emphasized.
+
+## Non-Goals
+
+- Do not add a local book store or export/import flow.
+- Do not restructure decoded results into tabs.
+- Do not add SPARQL lens explainers.
+- Do not add a catalog backend.
+- Do not change ledger operation semantics or provider API adapters.
+
+## Acceptance Criteria
+
+- `/inspect` has no chain-data configuration panel and uses the freed width for
+  Input and Decoded JSON/results.
+- `/settings` contains the provider, API key, network, persist toggle, and
+  cleartext-storage warning.
+- Changing provider, network, or keys on `/settings` affects hash decode on
+  `/inspect`.
+- Persisted settings survive reload through the existing localStorage keys,
+  including `network`.
+- Decode by pasted CBOR still works end-to-end.
+- Playwright covers moved settings, full-width inspect, and subpath navigation
+  plus refresh for `/inspect`, `/settings`, and `/library`.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just ui-check`, and
+  `just test-playwright` pass before completion.

--- a/specs/100-settings-full-width/tasks.md
+++ b/specs/100-settings-full-width/tasks.md
@@ -2,9 +2,9 @@
 
 ## Slice 1 — Move Chain-Data Settings
 
-- [ ] T100-S1 Move the chain-data form from `/inspect` to `/settings`.
-- [ ] T101-S1 Keep provider/key/network/persist state shared across routes and backed by the existing localStorage keys.
-- [ ] T102-S1 Make `/inspect` full-width with Input plus Decoded result and a compact settings affordance linking to `/settings`.
-- [ ] T103-S1 De-emphasize Haskell/WASI implementation copy in the shell, intro, and footer.
-- [ ] T104-S1 Update Playwright coverage for moved settings, full-width inspect, decode, and subpath deep-link/refresh behavior.
-- [ ] T105-S1 Run `./gate.sh`, record smoke evidence, and commit the slice.
+- [X] T100-S1 Move the chain-data form from `/inspect` to `/settings`.
+- [X] T101-S1 Keep provider/key/network/persist state shared across routes and backed by the existing localStorage keys.
+- [X] T102-S1 Make `/inspect` full-width with Input plus Decoded result and a compact settings affordance linking to `/settings`.
+- [X] T103-S1 De-emphasize Haskell/WASI implementation copy in the shell, intro, and footer.
+- [X] T104-S1 Update Playwright coverage for moved settings, full-width inspect, decode, and subpath deep-link/refresh behavior.
+- [X] T105-S1 Run `./gate.sh`, record smoke evidence, and commit the slice.

--- a/specs/100-settings-full-width/tasks.md
+++ b/specs/100-settings-full-width/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## Slice 1 — Move Chain-Data Settings
+
+- [ ] T100-S1 Move the chain-data form from `/inspect` to `/settings`.
+- [ ] T101-S1 Keep provider/key/network/persist state shared across routes and backed by the existing localStorage keys.
+- [ ] T102-S1 Make `/inspect` full-width with Input plus Decoded result and a compact settings affordance linking to `/settings`.
+- [ ] T103-S1 De-emphasize Haskell/WASI implementation copy in the shell, intro, and footer.
+- [ ] T104-S1 Update Playwright coverage for moved settings, full-width inspect, decode, and subpath deep-link/refresh behavior.
+- [ ] T105-S1 Run `./gate.sh`, record smoke evidence, and commit the slice.


### PR DESCRIPTION
## Scope
- move chain-data provider settings from Inspect to Settings
- make Inspect focus on input and decoded results with a compact active-provider affordance
- keep provider, network, key, and persist state shared through the existing localStorage keys
- update subpath, settings, shared-state, and decode coverage

## Verification
- `./gate.sh`
- CI green on PR #101
- PR preview green
- live preview smoke: `https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-101/inspector/`

Closes #100
