### PR TITLE
Two-pane decoded-structure tree from RDF/SPARQL

### DIFF
--- a/docs/inspector/dist/index.html
+++ b/docs/inspector/dist/index.html
@@ -6,6 +6,20 @@
     <meta name="color-scheme" content="light dark" />
     <title>Cardano transaction inspector</title>
     <link rel="icon" href="data:," />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,400,0,0&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,wght@8..144,400..700&display=swap"
+    />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;500;700&display=swap"
+    />
     <link rel="stylesheet" href="./styles.css" />
     <script type="module" src="./material.js"></script>
   </head>

--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -942,6 +942,76 @@ md-icon-button:focus-visible,
   padding: 12px;
 }
 
+.decoded-tree-row-list {
+  display: grid;
+  gap: 8px;
+}
+
+.decoded-tree-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.35rem;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--md-sys-color-surface-container-low);
+  padding: 0.62rem 0.7rem;
+}
+
+.decoded-tree-row.is-expanded {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--md-sys-color-primary-container) 44%, var(--surface));
+}
+
+.decoded-tree-depth-1 {
+  margin-left: 12px;
+}
+
+.decoded-tree-depth-2 {
+  margin-left: 24px;
+}
+
+.decoded-tree-depth-3 {
+  margin-left: 36px;
+}
+
+.decoded-tree-main {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.decoded-tree-keyline {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.decoded-tree-toggle {
+  min-width: 104px;
+}
+
+.decoded-tree-summary,
+.decoded-tree-meta {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.decoded-tree-meta {
+  font-size: 0.78rem;
+}
+
+.decoded-tree-children {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  border-left: 2px solid var(--border);
+  padding-left: 10px;
+}
+
 .browser-heading {
   display: flex;
   align-items: start;

--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -40,7 +40,7 @@
   --shadow: 0 14px 34px rgba(23, 33, 47, 0.08);
   --app-radius: 8px;
   font-family:
-    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Roboto Flex", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
   font-size: 15px;
   line-height: 1.5;
@@ -123,8 +123,28 @@ textarea,
 input[type="text"],
 input[type="password"] {
   font-family:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     monospace;
+}
+
+md-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  font-family: "Material Symbols Outlined";
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: 0;
+  text-transform: none;
+  white-space: nowrap;
+  direction: ltr;
+  font-feature-settings: "liga";
+  -webkit-font-feature-settings: "liga";
+  -webkit-font-smoothing: antialiased;
 }
 
 code {
@@ -205,6 +225,9 @@ code {
 .topbar-theme {
   width: 40px;
   padding: 0;
+  --md-icon-button-icon-color: var(--text);
+  --md-icon-button-hover-icon-color: var(--accent-strong);
+  --md-icon-button-pressed-icon-color: var(--accent-strong);
 }
 
 .topbar-theme md-icon {
@@ -291,11 +314,13 @@ fieldset {
 
 .workspace {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(280px, 0.42fr) minmax(0, 0.58fr);
   gap: 18px;
   align-items: start;
 }
 
+.workspace-left,
+.workspace-right,
 .workspace-main {
   display: grid;
   gap: 18px;
@@ -303,6 +328,7 @@ fieldset {
 }
 
 .panel {
+  display: block;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface);
@@ -332,6 +358,35 @@ fieldset {
   border-radius: 8px;
   background: var(--surface);
   padding: 12px 14px;
+}
+
+.books-panel,
+.decoded-structure-panel {
+  display: grid;
+  gap: 14px;
+}
+
+.books-panel .panel-heading,
+.decoded-structure-panel .panel-heading {
+  margin-bottom: 0;
+}
+
+.book-filter {
+  width: 100%;
+  --md-outlined-text-field-container-shape: 8px;
+  --md-outlined-text-field-label-text-font: "Roboto Flex";
+  --md-outlined-text-field-input-text-font: "Roboto Mono";
+}
+
+.books-list {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--md-sys-color-surface-container-low);
+  overflow: hidden;
+}
+
+.decoded-structure-placeholder {
+  min-height: 120px;
 }
 
 .settings-summary-copy {
@@ -480,6 +535,9 @@ textarea {
 input:focus,
 textarea:focus,
 button:focus-visible,
+md-filled-button:focus-visible,
+md-outlined-button:focus-visible,
+md-icon-button:focus-visible,
 .header-link:focus-visible,
 .choice-option:focus-within {
   border-color: var(--accent);
@@ -502,6 +560,10 @@ button:focus-visible,
   width: 2.35rem;
   height: 1.2rem;
   accent-color: var(--accent);
+}
+
+.persist-md-switch {
+  display: none;
 }
 
 .warning-note {
@@ -530,6 +592,10 @@ button:focus-visible,
   border: 1px solid transparent;
   padding: 0.62rem 0.9rem;
   font-weight: 700;
+  --md-filled-button-container-shape: 8px;
+  --md-filled-button-label-text-font: "Roboto Flex";
+  --md-outlined-button-container-shape: 8px;
+  --md-outlined-button-label-text-font: "Roboto Flex";
 }
 
 .primary-action {
@@ -557,6 +623,8 @@ button:focus-visible,
   font-size: 0.84rem;
   font-weight: 700;
   white-space: nowrap;
+  --md-outlined-button-container-shape: 7px;
+  --md-outlined-button-label-text-font: "Roboto Flex";
 }
 
 .inline-action:hover {

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -50,6 +50,202 @@ WHERE {
 ORDER BY ?subject ?field ?value
 `;
 
+const decodedTreeRootQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?transaction ?txId ?txIdHex ?valid ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction ;
+    cardano:hasTxId ?txId .
+  OPTIONAL { ?txId cardano:bytesHex ?txIdHex . }
+  OPTIONAL { ?transaction cardano:isValid ?valid . }
+  OPTIONAL { ?transaction rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?transaction a ?resolvedType . }
+}
+ORDER BY ?transaction
+LIMIT 1
+`;
+
+const decodedBodyFieldsQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?kind ?entity ?value ?raw ?sort ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction .
+  {
+    ?transaction cardano:isValid ?value .
+    BIND(?transaction AS ?entity)
+    BIND("Validity" AS ?label)
+    BIND("boolean" AS ?kind)
+    BIND("10" AS ?sort)
+  } UNION {
+    ?transaction cardano:hasFee ?value .
+    BIND(?transaction AS ?entity)
+    BIND("Fee" AS ?label)
+    BIND("lovelace" AS ?kind)
+    BIND("20" AS ?sort)
+  } UNION {
+    ?transaction cardano:scriptDataHash ?entity .
+    OPTIONAL { ?entity cardano:bytesHex ?raw . }
+    BIND("Script data hash" AS ?label)
+    BIND("hash" AS ?kind)
+    BIND(STR(?entity) AS ?value)
+    BIND("30" AS ?sort)
+  } UNION {
+    ?transaction cardano:auxiliaryDataHash ?entity .
+    OPTIONAL { ?entity cardano:bytesHex ?raw . }
+    BIND("Auxiliary data hash" AS ?label)
+    BIND("hash" AS ?kind)
+    BIND(STR(?entity) AS ?value)
+    BIND("40" AS ?sort)
+  } UNION {
+    ?transaction cardano:totalCollateral ?value .
+    BIND(?transaction AS ?entity)
+    BIND("Total collateral" AS ?label)
+    BIND("lovelace" AS ?kind)
+    BIND("50" AS ?sort)
+  } UNION {
+    ?transaction cardano:hasMint ?entity .
+    BIND("Mint" AS ?label)
+    BIND("mint" AS ?kind)
+    BIND(STR(?entity) AS ?value)
+    BIND("60" AS ?sort)
+  } UNION {
+    ?transaction cardano:hasCollateralReturn ?entity .
+    BIND("Collateral return" AS ?label)
+    BIND("output" AS ?kind)
+    BIND(STR(?entity) AS ?value)
+    BIND("70" AS ?sort)
+  }
+  OPTIONAL { ?entity rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?entity a ?resolvedType . }
+}
+ORDER BY ?sort ?label ?value ?entity
+`;
+
+const decodedInputsQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?section ?entity ?txIdHex ?index ?sort ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction .
+  {
+    ?transaction cardano:hasInput ?entity .
+    BIND("Inputs" AS ?section)
+    BIND("10" AS ?sort)
+  } UNION {
+    ?transaction cardano:hasReferenceInput ?entity .
+    BIND("Reference inputs" AS ?section)
+    BIND("20" AS ?sort)
+  } UNION {
+    ?transaction cardano:hasCollateralInput ?entity .
+    BIND("Collateral inputs" AS ?section)
+    BIND("30" AS ?sort)
+  }
+  OPTIONAL {
+    ?entity cardano:fromTxOutRef ?ref .
+    OPTIONAL { ?ref cardano:hasIndex ?index . }
+    OPTIONAL {
+      ?ref cardano:hasTxId ?txId .
+      OPTIONAL { ?txId cardano:bytesHex ?txIdHex . }
+    }
+  }
+  OPTIONAL { ?entity rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?entity a ?resolvedType . }
+}
+ORDER BY ?sort ?txIdHex ?index ?entity
+`;
+
+const decodedOutputsQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?output ?index ?address ?lovelace ?datum ?datumRaw ?datumHash ?datumHashHex ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction ;
+    cardano:hasOutput ?output .
+  OPTIONAL { ?output cardano:hasIndex ?index . }
+  OPTIONAL { ?output cardano:atAddress ?address . }
+  OPTIONAL { ?output cardano:lovelace ?lovelace . }
+  OPTIONAL {
+    ?output cardano:hasDatum ?datum .
+    OPTIONAL { ?datum cardano:hasRawBytes ?datumRaw . }
+    OPTIONAL {
+      ?datum cardano:hasHash ?datumHash .
+      OPTIONAL { ?datumHash cardano:bytesHex ?datumHashHex . }
+    }
+  }
+  OPTIONAL { ?output rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?output a ?resolvedType . }
+}
+ORDER BY ?index ?output
+`;
+
+const decodedWitnessesQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?witness ?verificationKey ?verificationKeyHex ?signature ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction ;
+    cardano:hasKeyWitness ?witness .
+  OPTIONAL {
+    ?witness cardano:hasVerificationKey ?verificationKey .
+    OPTIONAL { ?verificationKey cardano:bytesHex ?verificationKeyHex . }
+  }
+  OPTIONAL { ?witness cardano:hasSignature ?signature . }
+  OPTIONAL { ?witness rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?witness a ?resolvedType . }
+}
+ORDER BY ?verificationKeyHex ?witness
+`;
+
+const decodedRedeemersQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?redeemer ?purpose ?index ?data ?dataRaw ?dataHash ?dataHashHex ?memory ?cpu ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction ;
+    cardano:hasRedeemer ?redeemer .
+  OPTIONAL { ?redeemer cardano:hasPurpose ?purpose . }
+  OPTIONAL { ?redeemer cardano:hasIndex ?index . }
+  OPTIONAL {
+    ?redeemer cardano:hasData ?data .
+    OPTIONAL { ?data cardano:hasRawBytes ?dataRaw . }
+    OPTIONAL {
+      ?data cardano:hasHash ?dataHash .
+      OPTIONAL { ?dataHash cardano:bytesHex ?dataHashHex . }
+    }
+  }
+  OPTIONAL {
+    ?redeemer cardano:hasExUnits ?exUnits .
+    OPTIONAL { ?exUnits cardano:memoryUnits ?memory . }
+    OPTIONAL { ?exUnits cardano:cpuUnits ?cpu . }
+  }
+  OPTIONAL { ?redeemer rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?redeemer a ?resolvedType . }
+}
+ORDER BY ?purpose ?index ?redeemer
+`;
+
+const decodedMetadataQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?metadata ?label ?raw ?text ?resolvedLabel ?resolvedType
+WHERE {
+  ?transaction a cardano:Transaction ;
+    cardano:hasAuxiliaryData ?auxiliaryData .
+  OPTIONAL { ?auxiliaryData cardano:hasRawBytes ?raw . }
+  ?auxiliaryData cardano:hasMetadatum ?metadata .
+  OPTIONAL { ?metadata cardano:metadataLabel ?label . }
+  OPTIONAL { ?metadata cardano:metadatumValue ?value . }
+  OPTIONAL { ?value cardano:hasElement ?element . }
+  OPTIONAL { ?element cardano:metadatumValue ?elementValue . }
+  OPTIONAL { ?elementValue cardano:textValue ?text . }
+  OPTIONAL { ?metadata rdfs:label ?resolvedLabel . }
+  OPTIONAL { ?metadata a ?resolvedType . }
+}
+ORDER BY ?label ?metadata ?text
+`;
+
 const bindingValue = (binding) =>
   binding && binding.value !== undefined && binding.value !== null
     ? String(binding.value)
@@ -141,6 +337,296 @@ const normalizeTypedFieldRows = (result) => {
     field: bindingValue(binding.field),
     value: bindingValue(binding.value),
   }));
+};
+
+const queryBindings = (graphTtl, sparql) => {
+  const result = globalThis.rdfShapes.query(graphTtl, sparql);
+  if (!result || result.kind !== "solutions") {
+    throw new Error("query did not return solution rows");
+  }
+
+  const bindings = result.json?.results?.bindings;
+  if (!Array.isArray(bindings)) {
+    throw new Error("query result missing bindings");
+  }
+  return bindings;
+};
+
+const compact = (value, max = 72) => {
+  const raw = String(value || "");
+  return raw.length > max ? `${raw.slice(0, max - 1)}...` : raw;
+};
+
+const slug = (value) =>
+  String(value || "row")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 96) || "row";
+
+const treeRow = ({
+  id,
+  parentId = "",
+  depth = 0,
+  order = 0,
+  label,
+  kind = "",
+  value = "",
+  summary = "",
+  raw = "",
+  resolvedLabel = "",
+  resolvedType = "",
+}) => ({
+  id,
+  parentId,
+  depth,
+  order,
+  label,
+  kind,
+  value,
+  summary,
+  raw,
+  resolvedLabel,
+  resolvedType,
+});
+
+const addSection = (rows, id, label, order, summary = "") => {
+  rows.push(
+    treeRow({
+      id,
+      parentId: "decoded-root",
+      depth: 1,
+      order,
+      label,
+      kind: "section",
+      summary,
+    }),
+  );
+};
+
+const appendLeaf = (rows, parentId, depth, order, label, kind, value, extra = {}) => {
+  const stringValue = String(value || "");
+  if (stringValue === "") return;
+  rows.push(
+    treeRow({
+      id: `${parentId}-${slug(label)}-${slug(stringValue)}-${order}`,
+      parentId,
+      depth,
+      order,
+      label,
+      kind,
+      value: stringValue,
+      summary: compact(stringValue),
+      raw: extra.raw || stringValue,
+      resolvedLabel: extra.resolvedLabel || "",
+      resolvedType: extra.resolvedType || "",
+    }),
+  );
+};
+
+const countText = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
+
+const normalizeDecodedTreeRows = (graphTtl) => {
+  const roots = queryBindings(graphTtl, decodedTreeRootQuery);
+  if (roots.length === 0) return [];
+
+  const root = roots[0];
+  const txId = firstBindingValue(root.txIdHex, root.txId, root.transaction);
+  const transactionId = bindingValue(root.transaction);
+  const rows = [
+    treeRow({
+      id: "decoded-root",
+      depth: 0,
+      order: 0,
+      label: "Transaction",
+      kind: humanToken(firstBindingValue(root.resolvedType) || "Transaction"),
+      value: transactionId,
+      summary: compact(transactionId),
+      raw: txId,
+      resolvedLabel: bindingValue(root.resolvedLabel),
+      resolvedType: bindingValue(root.resolvedType),
+    }),
+  ];
+
+  const bodyFields = queryBindings(graphTtl, decodedBodyFieldsQuery);
+  const inputs = queryBindings(graphTtl, decodedInputsQuery);
+  const outputs = queryBindings(graphTtl, decodedOutputsQuery);
+  const witnesses = queryBindings(graphTtl, decodedWitnessesQuery);
+  const redeemers = queryBindings(graphTtl, decodedRedeemersQuery);
+  const metadata = queryBindings(graphTtl, decodedMetadataQuery);
+
+  if (bodyFields.length > 0) {
+    addSection(rows, "decoded-body", "Body", 10, countText(bodyFields.length, "field"));
+    bodyFields.forEach((field, index) => {
+      appendLeaf(
+        rows,
+        "decoded-body",
+        2,
+        index,
+        bindingValue(field.label),
+        bindingValue(field.kind),
+        firstBindingValue(field.raw, field.value, field.entity),
+        {
+          raw: firstBindingValue(field.raw, field.value, field.entity),
+          resolvedLabel: bindingValue(field.resolvedLabel),
+          resolvedType: bindingValue(field.resolvedType),
+        },
+      );
+    });
+  }
+
+  if (inputs.length > 0) {
+    addSection(rows, "decoded-inputs", "Inputs", 20, countText(inputs.length, "input"));
+    inputs.forEach((input, index) => {
+      const section = bindingValue(input.section);
+      const tx = bindingValue(input.txIdHex);
+      const inputIndex = bindingValue(input.index);
+      const value =
+        tx === "" && inputIndex === ""
+          ? bindingValue(input.entity)
+          : `${compact(tx, 28)}#${inputIndex}`;
+      appendLeaf(
+        rows,
+        "decoded-inputs",
+        2,
+        index,
+        section === "Inputs" ? `Input ${index}` : `${section} ${index}`,
+        "tx-out-ref",
+        value,
+        {
+          raw: tx === "" ? bindingValue(input.entity) : `${tx}#${inputIndex}`,
+          resolvedLabel: bindingValue(input.resolvedLabel),
+          resolvedType: bindingValue(input.resolvedType),
+        },
+      );
+    });
+  }
+
+  if (outputs.length > 0) {
+    addSection(rows, "decoded-outputs", "Outputs", 30, countText(outputs.length, "output"));
+    outputs.forEach((output, index) => {
+      const outputIndex = firstBindingValue(output.index, { value: String(index) });
+      const outputId = `decoded-output-${slug(outputIndex)}-${index}`;
+      rows.push(
+        treeRow({
+          id: outputId,
+          parentId: "decoded-outputs",
+          depth: 2,
+          order: index,
+          label: `Output ${outputIndex}`,
+          kind: "output",
+          value: bindingValue(output.output),
+          summary: compact(bindingValue(output.output)),
+          raw: bindingValue(output.output),
+          resolvedLabel: bindingValue(output.resolvedLabel),
+          resolvedType: bindingValue(output.resolvedType),
+        }),
+      );
+      appendLeaf(rows, outputId, 3, 10, "Index", "integer", outputIndex);
+      appendLeaf(rows, outputId, 3, 20, "Lovelace", "lovelace", bindingValue(output.lovelace));
+      appendLeaf(rows, outputId, 3, 30, "Address", "address", bindingValue(output.address));
+      appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", firstBindingValue(output.datumHashHex, output.datumHash));
+      appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw));
+    });
+  }
+
+  const feeFields = bodyFields.filter((field) => bindingValue(field.label) === "Fee");
+  if (feeFields.length > 0) {
+    addSection(rows, "decoded-fee", "Fee", 40, compact(bindingValue(feeFields[0].value)));
+    feeFields.forEach((field, index) => {
+      appendLeaf(rows, "decoded-fee", 2, index, "Lovelace", "lovelace", bindingValue(field.value));
+    });
+  }
+
+  if (witnesses.length > 0) {
+    addSection(rows, "decoded-witnesses", "Witnesses", 50, countText(witnesses.length, "key witness"));
+    witnesses.forEach((witness, index) => {
+      const witnessId = `decoded-key-witness-${index}`;
+      rows.push(
+        treeRow({
+          id: witnessId,
+          parentId: "decoded-witnesses",
+          depth: 2,
+          order: index,
+          label: `Key witness ${index}`,
+          kind: "key-witness",
+          value: firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness),
+          summary: compact(firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness)),
+          raw: bindingValue(witness.witness),
+          resolvedLabel: bindingValue(witness.resolvedLabel),
+          resolvedType: bindingValue(witness.resolvedType),
+        }),
+      );
+      appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", firstBindingValue(witness.verificationKeyHex, witness.verificationKey));
+      appendLeaf(rows, witnessId, 3, 20, "Signature", "signature", bindingValue(witness.signature));
+    });
+  }
+
+  if (redeemers.length > 0) {
+    addSection(rows, "decoded-redeemers", "Redeemers", 60, countText(redeemers.length, "redeemer"));
+    redeemers.forEach((redeemer, index) => {
+      const redeemerId = `decoded-redeemer-${index}`;
+      const purpose = bindingValue(redeemer.purpose);
+      const redeemerIndex = bindingValue(redeemer.index);
+      rows.push(
+        treeRow({
+          id: redeemerId,
+          parentId: "decoded-redeemers",
+          depth: 2,
+          order: index,
+          label: purpose === "" ? `Redeemer ${index}` : `${purpose} redeemer ${redeemerIndex}`,
+          kind: "redeemer",
+          value: bindingValue(redeemer.redeemer),
+          summary: compact(firstBindingValue(redeemer.dataHashHex, redeemer.dataHash, redeemer.redeemer)),
+          raw: bindingValue(redeemer.redeemer),
+          resolvedLabel: bindingValue(redeemer.resolvedLabel),
+          resolvedType: bindingValue(redeemer.resolvedType),
+        }),
+      );
+      appendLeaf(rows, redeemerId, 3, 10, "Purpose", "purpose", purpose);
+      appendLeaf(rows, redeemerId, 3, 20, "Index", "integer", redeemerIndex);
+      appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", firstBindingValue(redeemer.dataHashHex, redeemer.dataHash));
+      appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw));
+      appendLeaf(rows, redeemerId, 3, 50, "Memory units", "ex-units", bindingValue(redeemer.memory));
+      appendLeaf(rows, redeemerId, 3, 60, "CPU units", "ex-units", bindingValue(redeemer.cpu));
+    });
+  }
+
+  const metadataById = new Map();
+  for (const row of metadata) {
+    const id = bindingValue(row.metadata);
+    if (id !== "" && !metadataById.has(id)) metadataById.set(id, row);
+  }
+  const metadataRows = Array.from(metadataById.values());
+  if (metadataRows.length > 0) {
+    addSection(rows, "decoded-metadata", "Metadata", 70, countText(metadataRows.length, "label"));
+    metadataRows.forEach((meta, index) => {
+      const metaId = `decoded-metadata-${slug(bindingValue(meta.label))}-${index}`;
+      rows.push(
+        treeRow({
+          id: metaId,
+          parentId: "decoded-metadata",
+          depth: 2,
+          order: index,
+          label: `Metadata label ${bindingValue(meta.label)}`,
+          kind: "metadata",
+          value: bindingValue(meta.metadata),
+          summary: compact(firstBindingValue(meta.text, meta.raw, meta.metadata)),
+          raw: firstBindingValue(meta.raw, meta.metadata),
+          resolvedLabel: bindingValue(meta.resolvedLabel),
+          resolvedType: bindingValue(meta.resolvedType),
+        }),
+      );
+      appendLeaf(rows, metaId, 3, 10, "Metadata label", "integer", bindingValue(meta.label));
+      appendLeaf(rows, metaId, 3, 20, "Text", "text", bindingValue(meta.text));
+      appendLeaf(rows, metaId, 3, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw));
+    });
+  }
+
+  return rows.sort((a, b) => {
+    if (a.parentId !== b.parentId) return a.parentId.localeCompare(b.parentId);
+    if (a.order !== b.order) return a.order - b.order;
+    return a.label.localeCompare(b.label);
+  });
 };
 
 const reportText = (value) =>
@@ -247,6 +733,14 @@ export const queryTypedFieldsImpl = (left) => (right) => (graphTtl) => () => {
   try {
     const result = globalThis.rdfShapes.query(graphTtl, typedFieldsQuery);
     return right(normalizeTypedFieldRows(result));
+  } catch (err) {
+    return left(errText(err));
+  }
+};
+
+export const queryDecodedTreeImpl = (left) => (right) => (graphTtl) => () => {
+  try {
+    return right(normalizeDecodedTreeRows(graphTtl));
   } catch (err) {
     return left(errText(err));
   }

--- a/docs/inspector/src/FFI/RdfShapes.purs
+++ b/docs/inspector/src/FFI/RdfShapes.purs
@@ -1,11 +1,13 @@
 module FFI.RdfShapes
   ( Json
+  , DecodedTreeRow
   , ResolvedLabelRow
   , ShaclReport
   , ShaclViolation
   , TypedFieldRow
   , TransactionOutputRow
   , query
+  , queryDecodedTree
   , queryResolvedLabels
   , queryTypedFields
   , queryTransactionOutputs
@@ -17,6 +19,20 @@ import Effect (Effect)
 import Foreign (Foreign)
 
 type Json = Foreign
+
+type DecodedTreeRow =
+  { id :: String
+  , parentId :: String
+  , depth :: Int
+  , order :: Int
+  , label :: String
+  , kind :: String
+  , value :: String
+  , summary :: String
+  , raw :: String
+  , resolvedLabel :: String
+  , resolvedType :: String
+  }
 
 type TransactionOutputRow =
   { transaction :: String
@@ -77,6 +93,12 @@ foreign import queryTypedFieldsImpl
   -> String
   -> Effect (Either String (Array TypedFieldRow))
 
+foreign import queryDecodedTreeImpl
+  :: (String -> Either String (Array DecodedTreeRow))
+  -> (Array DecodedTreeRow -> Either String (Array DecodedTreeRow))
+  -> String
+  -> Effect (Either String (Array DecodedTreeRow))
+
 foreign import validateImpl
   :: (String -> Either String ShaclReport)
   -> (ShaclReport -> Either String ShaclReport)
@@ -95,6 +117,9 @@ queryResolvedLabels = queryResolvedLabelsImpl Left Right
 
 queryTypedFields :: String -> Effect (Either String (Array TypedFieldRow))
 queryTypedFields = queryTypedFieldsImpl Left Right
+
+queryDecodedTree :: String -> Effect (Either String (Array DecodedTreeRow))
+queryDecodedTree = queryDecodedTreeImpl Left Right
 
 validate :: String -> String -> Effect (Either String ShaclReport)
 validate = validateImpl Left Right

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -131,6 +131,7 @@ type State =
   , sparqlLens :: Maybe SparqlLens
   , resolvedLabelsLens :: Maybe ResolvedLabelsLens
   , typedFieldsLens :: Maybe TypedFieldsLens
+  , decodedTreeLens :: Maybe DecodedTreeLens
   , shaclConformance :: Maybe ShaclConformance
   , overlayInput :: String
   , overlayParts :: Array OverlayPart
@@ -138,6 +139,7 @@ type State =
   , overlayError :: Maybe String
   , browserNodes :: Array BrowserNode
   , expandedPaths :: Array String
+  , decodedTreeExpanded :: Array String
   , running :: Boolean
   , copied :: Boolean
   , copiedPath :: Maybe String
@@ -165,6 +167,11 @@ type ResolvedLabelsLens =
 
 type TypedFieldsLens =
   { rows :: Array RdfShapes.TypedFieldRow
+  , error :: Maybe String
+  }
+
+type DecodedTreeLens =
+  { rows :: Array RdfShapes.DecodedTreeRow
   , error :: Maybe String
   }
 
@@ -205,6 +212,7 @@ data Action
   | Copy
   | CopyValue String String
   | BrowseJson String
+  | ToggleDecodedTree String
   | Navigate Route MouseEvent
   | ToggleTheme
 
@@ -236,6 +244,7 @@ inspectorComponent initial =
         , sparqlLens: Nothing
         , resolvedLabelsLens: Nothing
         , typedFieldsLens: Nothing
+        , decodedTreeLens: Nothing
         , shaclConformance: Nothing
         , overlayInput: ""
         , overlayParts: []
@@ -243,6 +252,7 @@ inspectorComponent initial =
         , overlayError: Nothing
         , browserNodes: []
         , expandedPaths: []
+        , decodedTreeExpanded: []
         , running: false
         , copied: false
         , copiedPath: Nothing
@@ -307,7 +317,7 @@ inspectorComponent initial =
           , HH.div
               [ classNames [ "workspace-right" ] ]
               [ renderResult state
-              , renderDecodedStructurePlaceholder state
+              , renderDecodedStructure state
               ]
           ]
       ]
@@ -393,7 +403,7 @@ inspectorComponent initial =
           ]
       ]
 
-  renderDecodedStructurePlaceholder state =
+  renderDecodedStructure state =
     HH.element (HH.ElemName "md-elevated-card")
       [ classNames [ "panel", "decoded-structure-panel" ]
       , mdSurface "decoded"
@@ -416,10 +426,95 @@ inspectorComponent initial =
                   ]
               ]
           ]
-      , HH.div
-          [ classNames [ "empty-state", "decoded-structure-placeholder" ] ]
-          [ HH.text "Tree renderer pending." ]
+      , case state.decodedTreeLens of
+          Just lens ->
+            renderDecodedTreeLens state lens
+          Nothing ->
+            HH.div
+              [ classNames [ "empty-state", "decoded-structure-placeholder" ] ]
+              [ HH.text "Tree renderer pending." ]
       ]
+
+  renderDecodedTreeLens state lens =
+    case lens.error of
+      Just err ->
+        HH.div
+          [ classNames [ "sparql-lens-error" ] ]
+          [ HH.text ("Decoded-tree query failed: " <> err) ]
+      Nothing ->
+        if Array.null lens.rows then
+          HH.div
+            [ classNames [ "empty-state" ] ]
+            [ HH.text "No decoded RDF tree rows." ]
+        else
+          HH.div
+            [ classNames [ "decoded-tree-row-list" ] ]
+            (renderDecodedTreeRows state "" lens.rows)
+
+  renderDecodedTreeRows state parentId rows =
+    rows
+      # Array.filter (\row -> row.parentId == parentId)
+      # Array.concatMap (renderDecodedTreeRow state rows)
+
+  renderDecodedTreeRow state rows row =
+    let
+      hasChildren = Array.any (\candidate -> candidate.parentId == row.id) rows
+      expanded = row.parentId == "" || row.depth >= 2 || Array.elem row.id state.decodedTreeExpanded
+      rowClasses =
+        if hasChildren && expanded then
+          [ "decoded-tree-row", "is-expanded", "decoded-tree-depth-" <> show row.depth ]
+        else
+          [ "decoded-tree-row", "decoded-tree-depth-" <> show row.depth ]
+      summaryText =
+        if row.summary == "" then row.value else row.summary
+      metaText =
+        if row.resolvedLabel /= "" then row.resolvedLabel
+        else if row.resolvedType /= "" then row.resolvedType
+        else row.kind
+    in
+      [ HH.div
+          [ classNames rowClasses ]
+          [ HH.div
+              [ classNames [ "decoded-tree-main" ] ]
+              [ HH.div
+                  [ classNames [ "decoded-tree-keyline" ] ]
+                  [ if hasChildren then
+                      HH.element (HH.ElemName "md-outlined-button")
+                        [ HE.onClick (\_ -> ToggleDecodedTree row.id)
+                        , classNames [ "inline-action", "decoded-tree-toggle" ]
+                        , HH.attr (HH.AttrName "role") "button"
+                        , HH.attr
+                            (HH.AttrName "aria-label")
+                            (row.label <> if row.summary == "" then "" else " " <> row.summary)
+                        , mdControl "inline"
+                        ]
+                        [ HH.text (row.label <> if row.summary == "" then "" else " " <> row.summary) ]
+                    else
+                      HH.strong_ [ HH.text row.label ]
+                  , HH.span
+                      [ classNames [ "kind-badge" ] ]
+                      [ HH.text row.kind ]
+                  ]
+              , if summaryText == "" then
+                  HH.text ""
+                else
+                  HH.div
+                    [ classNames [ "decoded-tree-summary" ] ]
+                    [ HH.text summaryText ]
+              , if metaText == "" then
+                  HH.text ""
+                else
+                  HH.div
+                    [ classNames [ "decoded-tree-meta" ] ]
+                    [ HH.text metaText ]
+              ]
+          ]
+      ] <> if expanded && hasChildren then
+        [ HH.div
+            [ classNames [ "decoded-tree-children" ] ]
+            (renderDecodedTreeRows state row.id rows)
+        ]
+      else []
 
   renderProvider state =
     HH.element (HH.ElemName "md-elevated-card")
@@ -1712,6 +1807,22 @@ inspectorComponent initial =
           )
       )
 
+  decodedTreeLensFromGraph graphTurtle = do
+    lensResult <- liftEffect (RdfShapes.queryDecodedTree graphTurtle)
+    pure
+      ( Just
+          ( case lensResult of
+              Left err ->
+                { rows: []
+                , error: Just err
+                }
+              Right rows ->
+                { rows
+                , error: Nothing
+                }
+          )
+      )
+
   shaclConformanceFromGraph graphTurtle st =
     let
       shapeParts = selectedShaclParts st
@@ -1740,11 +1851,13 @@ inspectorComponent initial =
     resolvedLabelsLens <-
       resolvedLabelsLensFromGraph graphTurtle
     typedFieldsLens <- typedFieldsLensFromGraph rdf.turtle
+    decodedTreeLens <- decodedTreeLensFromGraph rdf.turtle
     shaclConformance <- shaclConformanceFromGraph graphTurtle st
     pure
       { sparqlLens
       , resolvedLabelsLens
       , typedFieldsLens
+      , decodedTreeLens
       , shaclConformance
       }
 
@@ -1939,6 +2052,7 @@ inspectorComponent initial =
                 , sparqlLens = lenses.sparqlLens
                 , resolvedLabelsLens = lenses.resolvedLabelsLens
                 , typedFieldsLens = lenses.typedFieldsLens
+                , decodedTreeLens = lenses.decodedTreeLens
                 , shaclConformance = lenses.shaclConformance
                 , fetchError = Nothing
                 }
@@ -1950,6 +2064,7 @@ inspectorComponent initial =
                 , sparqlLens = Nothing
                 , resolvedLabelsLens = Nothing
                 , typedFieldsLens = Nothing
+                , decodedTreeLens = Nothing
                 , shaclConformance = Nothing
                 , fetchError =
                     Just
@@ -1976,9 +2091,11 @@ inspectorComponent initial =
           , sparqlLens = Nothing
           , resolvedLabelsLens = Nothing
           , typedFieldsLens = Nothing
+          , decodedTreeLens = Nothing
           , shaclConformance = Nothing
           , browserNodes = []
           , expandedPaths = []
+          , decodedTreeExpanded = []
           , copied = false
           , copiedPath = Nothing
           , browserPath = "[]"
@@ -2055,6 +2172,7 @@ inspectorComponent initial =
                 { sparqlLens: Nothing
                 , resolvedLabelsLens: Nothing
                 , typedFieldsLens: Nothing
+                , decodedTreeLens: Nothing
                 , shaclConformance: Nothing
                 }
           H.modify_
@@ -2082,11 +2200,13 @@ inspectorComponent initial =
               , sparqlLens = lenses.sparqlLens
               , resolvedLabelsLens = lenses.resolvedLabelsLens
               , typedFieldsLens = lenses.typedFieldsLens
+              , decodedTreeLens = lenses.decodedTreeLens
               , shaclConformance = lenses.shaclConformance
               , browserNodes =
                   if operationResult.exitOk && browser.valid then rootBrowserNodes browser
                   else []
               , expandedPaths = []
+              , decodedTreeExpanded = []
               , browserPath = browser.currentPath
               }
     Copy -> do
@@ -2129,6 +2249,16 @@ inspectorComponent initial =
                     if operationResult.exitOk && browser.valid then Nothing
                     else Just (if operationResult.stderr == "" then "Haskell ledger operation browse failed." else operationResult.stderr)
                 }
+    ToggleDecodedTree rowId -> do
+      H.modify_
+        \st ->
+          st
+            { decodedTreeExpanded =
+                if Array.elem rowId st.decodedTreeExpanded then
+                  closePath rowId st.decodedTreeExpanded
+                else
+                  expandPath rowId st.decodedTreeExpanded
+            }
 
   toggleOverlayPartId partId selected ids =
     if selected then

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -296,12 +296,19 @@ inspectorComponent initial =
               , HH.span_ [ HH.text "RDF views" ]
               ]
           ]
-      , renderSettingsSummary state
       , HH.div
           [ classNames [ "workspace" ] ]
           [ HH.div
-              [ classNames [ "workspace-main" ] ]
-              (renderWorkspaceMain state)
+              [ classNames [ "workspace-left" ] ]
+              [ renderSettingsSummary state
+              , renderModeTabs state
+              , renderBooksPlaceholder
+              ]
+          , HH.div
+              [ classNames [ "workspace-right" ] ]
+              [ renderResult state
+              , renderDecodedStructurePlaceholder state
+              ]
           ]
       ]
 
@@ -324,7 +331,7 @@ inspectorComponent initial =
       ]
 
   renderSettingsSummary state =
-    HH.section
+    HH.element (HH.ElemName "md-elevated-card")
       [ classNames [ "settings-summary" ]
       , mdSurface "provider"
       ]
@@ -346,15 +353,76 @@ inspectorComponent initial =
           [ HH.text "Settings" ]
       ]
 
-  renderWorkspaceMain state =
-    case state.fetchError of
-      Just _ -> [ renderResult state, renderModeTabs state ]
-      Nothing -> case state.result of
-        Just _  -> [ renderResult state, renderModeTabs state ]
-        Nothing -> [ renderModeTabs state, renderResult state ]
+  renderBooksPlaceholder =
+    HH.element (HH.ElemName "md-elevated-card")
+      [ classNames [ "panel", "books-panel" ]
+      , mdSurface "books"
+      ]
+      [ HH.div
+          [ classNames [ "panel-heading" ] ]
+          [ HH.div_
+              [ HH.h2_ [ HH.text "Books" ]
+              , HH.p_ [ HH.text "Overlay and protocol books will attach decoded labels in a later slice." ]
+              ]
+          ]
+      , HH.element (HH.ElemName "md-outlined-text-field")
+          [ classNames [ "book-filter" ]
+          , HH.attr (HH.AttrName "label") "Book filter"
+          , HH.attr (HH.AttrName "disabled") "disabled"
+          , HH.attr (HH.AttrName "value") "Book resolution pending"
+          ]
+          []
+      , HH.element (HH.ElemName "md-list")
+          [ classNames [ "books-list" ] ]
+          [ HH.element (HH.ElemName "md-list-item") []
+              [ HH.div
+                  [ HH.attr (HH.AttrName "slot") "headline" ]
+                  [ HH.text "Protocol overlays" ]
+              , HH.div
+                  [ HH.attr (HH.AttrName "slot") "supporting-text" ]
+                  [ HH.text "Import and resolution remain in the decoded result stack for now." ]
+              ]
+          , HH.element (HH.ElemName "md-list-item") []
+              [ HH.div
+                  [ HH.attr (HH.AttrName "slot") "headline" ]
+                  [ HH.text "Local book store" ]
+              , HH.div
+                  [ HH.attr (HH.AttrName "slot") "supporting-text" ]
+                  [ HH.text "Reserved for a later issue." ]
+              ]
+          ]
+      ]
+
+  renderDecodedStructurePlaceholder state =
+    HH.element (HH.ElemName "md-elevated-card")
+      [ classNames [ "panel", "decoded-structure-panel" ]
+      , mdSurface "decoded"
+      ]
+      [ HH.div
+          [ classNames [ "panel-heading" ] ]
+          [ HH.div_
+              [ HH.h2_ [ HH.text "Decoded structure" ]
+              , HH.p_
+                  [ HH.text
+                      ( case state.result of
+                          Just r ->
+                            if r.exitOk then
+                              "Stable surface for the structured decoded transaction tree."
+                            else
+                              "Decode a transaction to populate the structured tree in the next slice."
+                          _ ->
+                            "Decode a transaction to populate the structured tree in the next slice."
+                      )
+                  ]
+              ]
+          ]
+      , HH.div
+          [ classNames [ "empty-state", "decoded-structure-placeholder" ] ]
+          [ HH.text "Tree renderer pending." ]
+      ]
 
   renderProvider state =
-    HH.section
+    HH.element (HH.ElemName "md-elevated-card")
       [ classNames [ "panel", "provider-panel" ]
       , mdSurface "provider"
       ]
@@ -437,6 +505,12 @@ inspectorComponent initial =
               , HP.checked state.persistKeys
               , HE.onChecked TogglePersist
               ]
+          , HH.element (HH.ElemName "md-switch")
+              [ classNames [ "persist-md-switch" ]
+              , HH.attr (HH.AttrName "aria-hidden") "true"
+              , HH.attr (HH.AttrName "tabindex") "-1"
+              ]
+              []
           , HH.span_ [ HH.text "Persist API credentials" ]
           ]
       , HH.p
@@ -479,7 +553,7 @@ inspectorComponent initial =
       ]
 
   renderModeTabs state =
-    HH.section
+    HH.element (HH.ElemName "md-elevated-card")
       [ classNames [ "panel", "input-panel" ]
       , mdSurface "input"
       ]
@@ -524,9 +598,10 @@ inspectorComponent initial =
             , HP.value state.txHash
             , HE.onValueInput SetTxHash
             ]
-        , HH.button
+        , HH.element (HH.ElemName "md-filled-button")
             [ HP.disabled state.running
             , classNames [ "primary-action" ]
+            , HH.attr (HH.AttrName "role") "button"
             , mdControl "primary"
             , HE.onClick (\_ -> Decode)
             ]
@@ -541,9 +616,10 @@ inspectorComponent initial =
             , HP.rows 9
             , HE.onValueInput SetTxHex
             ]
-        , HH.button
+        , HH.element (HH.ElemName "md-filled-button")
             [ HP.disabled state.running
             , classNames [ "primary-action" ]
+            , HH.attr (HH.AttrName "role") "button"
             , mdControl "primary"
             , HE.onClick (\_ -> Decode)
             ]
@@ -553,7 +629,7 @@ inspectorComponent initial =
   renderResult state =
     case state.fetchError of
       Just err ->
-        HH.section
+        HH.element (HH.ElemName "md-elevated-card")
           [ classNames [ "panel", "result-panel", "error-panel" ]
           , mdSurface "result"
           ]
@@ -564,7 +640,7 @@ inspectorComponent initial =
           ]
       Nothing -> case state.result of
         Nothing ->
-          HH.section
+          HH.element (HH.ElemName "md-elevated-card")
             [ classNames [ "panel", "result-panel", "empty-result" ]
             , mdSurface "result"
             ]
@@ -579,7 +655,7 @@ inspectorComponent initial =
           let
             summary = Json.inspect r.stdout
           in
-            HH.section
+            HH.element (HH.ElemName "md-elevated-card")
               [ classNames [ "panel", "result-panel" ]
               , mdSurface "result"
               ]
@@ -593,9 +669,10 @@ inspectorComponent initial =
                         ]
                     , if r.exitOk
                         then
-                          HH.button
+                          HH.element (HH.ElemName "md-outlined-button")
                             [ HE.onClick (\_ -> Copy)
                             , classNames [ "secondary-action" ]
+                            , HH.attr (HH.AttrName "role") "button"
                             , mdControl "secondary"
                             ]
                             [ HH.text (if state.copied then "Copied" else "Copy JSON") ]
@@ -845,32 +922,37 @@ inspectorComponent initial =
               ]
           , HH.div
               [ classNames [ "overlay-actions" ] ]
-              [ HH.button
+              [ HH.element (HH.ElemName "md-outlined-button")
                   [ classNames [ "secondary-action" ]
+                  , HH.attr (HH.AttrName "role") "button"
                   , mdControl "secondary"
                   , HE.onClick (\_ -> LoadAmaruOverlayBook)
                   ]
                   [ HH.text "Load Amaru overlay book" ]
-              , HH.button
+              , HH.element (HH.ElemName "md-outlined-button")
                   [ classNames [ "secondary-action" ]
+                  , HH.attr (HH.AttrName "role") "button"
                   , mdControl "secondary"
                   , HE.onClick (\_ -> LoadSundaeSwapBlueprintBook)
                   ]
                   [ HH.text "Load SundaeSwap V3 blueprint" ]
-              , HH.button
+              , HH.element (HH.ElemName "md-outlined-button")
                   [ classNames [ "secondary-action" ]
+                  , HH.attr (HH.AttrName "role") "button"
                   , mdControl "secondary"
                   , HE.onClick (\_ -> LoadShaclShapesBook)
                   ]
                   [ HH.text "Load Cardano RDF SHACL shapes" ]
-              , HH.button
+              , HH.element (HH.ElemName "md-filled-button")
                   [ classNames [ "primary-action" ]
+                  , HH.attr (HH.AttrName "role") "button"
                   , mdControl "primary"
                   , HE.onClick (\_ -> ImportOverlayBook)
                   ]
                   [ HH.text "Import overlay book" ]
-              , HH.button
+              , HH.element (HH.ElemName "md-filled-button")
                   [ classNames [ "primary-action" ]
+                  , HH.attr (HH.AttrName "role") "button"
                   , mdControl "primary"
                   , HE.onClick (\_ -> ApplySelectedBooks)
                   ]
@@ -1345,9 +1427,10 @@ inspectorComponent initial =
               [ classNames [ "identity-label" ] ]
               [ HH.text row.label ]
           , if showCopy then
-              HH.button
+              HH.element (HH.ElemName "md-outlined-button")
                 [ HE.onClick (\_ -> CopyValue row.path row.copyValue)
                 , classNames [ "inline-action" ]
+                , HH.attr (HH.AttrName "role") "button"
                 , mdControl "inline"
                 ]
                 [ HH.text
@@ -1411,9 +1494,10 @@ inspectorComponent initial =
               [ HH.h3_ [ HH.text "Transaction browser" ]
               , HH.p_ [ HH.text browser.subtitle ]
               ]
-          , HH.button
+          , HH.element (HH.ElemName "md-outlined-button")
               [ HE.onClick (\_ -> CopyValue browser.currentPath browser.currentJson)
               , classNames [ "inline-action" ]
+              , HH.attr (HH.AttrName "role") "button"
               , mdControl "inline"
               ]
               [ HH.text
@@ -1474,9 +1558,10 @@ inspectorComponent initial =
               HH.div
                 [ classNames [ "browser-actions" ] ]
                 [
-                  HH.button
+                  HH.element (HH.ElemName "md-outlined-button")
                     [ HE.onClick (\_ -> BrowseJson row.path)
                     , classNames [ "inline-action" ]
+                    , HH.attr (HH.AttrName "role") "button"
                     , mdControl "inline"
                     ]
                     [ HH.text (if expanded then "Close" else "Open") ]

--- a/docs/inspector/src/Shell.purs
+++ b/docs/inspector/src/Shell.purs
@@ -48,8 +48,9 @@ topbar active opts =
             , navLink opts.basePath RouteSettings active "Settings" opts.onNavigate
             , navLink opts.basePath RouteLibrary active "Library" opts.onNavigate
             ]
-        , HH.button
+        , HH.element (HH.ElemName "md-icon-button")
             [ classNames [ "topbar-theme" ]
+            , HH.attr (HH.AttrName "role") "button"
             , HH.attr (HH.AttrName "aria-label") "Toggle theme"
             , HP.title ("Switch to " <> opts.themeLabel <> " theme")
             , HE.onClick (\_ -> opts.onToggleTheme)

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -286,6 +286,14 @@ test("MD3 shell routes topbar nav and theme toggle", async ({ page }) => {
 
   const topbar = page.getByRole("banner");
   const navigation = topbar.getByRole("navigation");
+  const indexHtml = await readFile(
+    path.join(repoRoot, "docs/inspector/dist/index.html"),
+    "utf8",
+  );
+  expect(indexHtml).toContain("Material+Symbols+Outlined");
+  expect(indexHtml).toContain("Roboto+Flex");
+  expect(indexHtml).toContain("Roboto+Mono");
+
   await expect(
     topbar.getByText("Cardano transaction inspector", { exact: true }),
   ).toBeVisible();
@@ -298,6 +306,11 @@ test("MD3 shell routes topbar nav and theme toggle", async ({ page }) => {
   const initialTheme = await page.evaluate(
     () => document.documentElement.dataset.theme,
   );
+  const themeIcon = topbar.locator("md-icon").first();
+  await expect(themeIcon).toBeVisible();
+  await expect(themeIcon).toHaveCSS("font-family", /Material Symbols Outlined/);
+  await expect(topbar.getByRole("button", { name: "dark_mode" })).toHaveCount(0);
+  await expect(topbar.getByRole("button", { name: "light_mode" })).toHaveCount(0);
   await topbar.getByRole("button", { name: "Toggle theme" }).click();
   await expect
     .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
@@ -415,15 +428,15 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   await expect(rdfPanel).toHaveAttribute("data-md3-surface", "decoded");
   await expect(lensPanel).toHaveAttribute("data-md3-surface", "decoded");
 
-  await expect(page.getByRole("button", { name: "Decode" })).toHaveAttribute(
+  await expect(page.locator("md-filled-button", { hasText: "Decode" })).toHaveAttribute(
     "data-md3-control",
     "primary",
   );
-  await expect(page.getByRole("button", { name: "Copy JSON" })).toHaveAttribute(
+  await expect(page.locator("md-outlined-button", { hasText: "Copy JSON" })).toHaveAttribute(
     "data-md3-control",
     "secondary",
   );
-  await expect(page.getByRole("button", { name: "Copy current" })).toHaveAttribute(
+  await expect(page.locator("md-outlined-button", { hasText: "Copy current" })).toHaveAttribute(
     "data-md3-control",
     "inline",
   );
@@ -435,17 +448,29 @@ test("inspect keeps chain-data settings compact and gives input/results the work
   await page.goto("/inspect");
 
   await expect(page.locator(".provider-panel")).toHaveCount(0);
-  const settingsSummary = page.locator(".settings-summary");
+  const leftPane = page.locator(".workspace-left");
+  const rightPane = page.locator(".workspace-right");
+  const settingsSummary = leftPane.locator(".settings-summary");
+  const inputPanel = leftPane.locator(".input-panel");
+  const resultPanel = rightPane.locator(".result-panel");
+
+  await expect(leftPane).toBeVisible();
+  await expect(rightPane).toBeVisible();
   await expect(settingsSummary).toBeVisible();
   await expect(settingsSummary).toContainText("Blockfrost");
   await expect(settingsSummary).toContainText("mainnet");
   await expect(settingsSummary.getByRole("link", { name: "Settings" })).toBeVisible();
+  await expect(inputPanel).toBeVisible();
+  await expect(leftPane.getByRole("heading", { name: "Books" })).toBeVisible();
+  await expect(resultPanel.getByRole("heading", { name: "Decoded JSON" })).toBeVisible();
+  await expect(rightPane.getByRole("heading", { name: "Decoded structure" })).toBeVisible();
 
   const workspaceBox = await page.locator(".workspace").boundingBox();
-  const inputBox = await page.locator(".input-panel").boundingBox();
-  const resultBox = await page.locator(".result-panel").boundingBox();
-  expect(inputBox.width).toBeGreaterThan(workspaceBox.width * 0.9);
-  expect(resultBox.width).toBeGreaterThan(workspaceBox.width * 0.9);
+  const leftBox = await leftPane.boundingBox();
+  const rightBox = await rightPane.boundingBox();
+  expect(leftBox.width).toBeLessThan(workspaceBox.width * 0.52);
+  expect(rightBox.width).toBeGreaterThan(workspaceBox.width * 0.52);
+  expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(8);
 });
 
 test("settings changes provider state used by inspect hash decode", async ({ page }) => {

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -605,6 +605,78 @@ test("renders the transaction RDF graph after decode", async ({ page }) => {
   await expect(lensPanel.getByText(/urn:cardano:tx:/)).toBeVisible();
 });
 
+test("renders decoded-structure tree from RDF rows", async ({ page }) => {
+  await decodeFixture(page);
+
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await expect(
+    decodedPanel.getByRole("heading", { name: "Decoded structure" }),
+  ).toBeVisible();
+  await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
+
+  const rootRow = decodedPanel.locator(".decoded-tree-row", {
+    hasText: "Transaction",
+  });
+  await expect(rootRow).toBeVisible();
+  await expect(rootRow).toContainText(/urn:cardano:tx:/);
+
+  for (const section of [
+    "Body",
+    "Inputs",
+    "Outputs",
+    "Fee",
+    "Witnesses",
+    "Redeemers",
+    "Metadata",
+  ]) {
+    await expect(
+      decodedPanel.getByRole("button", { name: new RegExp(`^${section}\\b`) }),
+    ).toBeVisible();
+  }
+
+  const outputs = decodedPanel.getByRole("button", { name: /^Outputs\b/ });
+  await outputs.click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
+  ).toBeVisible();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Index" }).first(),
+  ).toContainText("0");
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Lovelace" }).first(),
+  ).toBeVisible();
+
+  await outputs.click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
+  ).toHaveCount(0);
+
+  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Key witness" }).first(),
+  ).toBeVisible();
+
+  const metadata = decodedPanel.getByRole("button", { name: /^Metadata\b/ });
+  await metadata.click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Metadata label" }).first(),
+  ).toBeVisible();
+
+  const rdfPanel = page.locator(".rdf-panel");
+  await expect(
+    rdfPanel.getByRole("heading", { name: "Transaction RDF graph" }),
+  ).toBeVisible();
+  await expect(rdfPanel.locator(".rdf-turtle")).toContainText("cardano:Transaction");
+
+  const lensPanel = page.locator(".sparql-lens-panel");
+  await expect(
+    lensPanel.getByRole("heading", {
+      name: "SPARQL lens: transaction outputs",
+    }),
+  ).toBeVisible();
+  await expect(lensPanel.locator(".sparql-lens-row").first()).toBeVisible();
+});
+
 test("selects Amaru overlay book parts into deterministic Turtle", async ({
   page,
 }) => {

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -6,12 +6,13 @@ import { fileURLToPath } from "node:url";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../..");
+const conwayMainnetFixturePath = path.join(
+  repoRoot,
+  "specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex",
+);
 const fixturePath =
   process.env.TX_FIXTURE_PATH ||
-  path.join(
-    repoRoot,
-    "specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex",
-  );
+  conwayMainnetFixturePath;
 const signingIntentFixturePath = path.join(
   repoRoot,
   "specs/001-ledger-functional-layer/fixtures/sundae-swap-usdm-disbursement.hex",
@@ -675,6 +676,76 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     }),
   ).toBeVisible();
   await expect(lensPanel.locator(".sparql-lens-row").first()).toBeVisible();
+});
+
+test("decodes genuine Conway fixture into RDF tree", async ({
+  page,
+}) => {
+  const txCbor = (await readFile(conwayMainnetFixturePath, "utf8")).trim();
+  const validationContext = await loadValidationContext();
+
+  await installClipboardMock(page);
+  await mockKoiosValidationContext(page, validationContext);
+
+  await page.goto("/");
+  await page.getByRole("radio", { name: "CBOR hex" }).check();
+  await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
+  await page.getByRole("button", { name: "Decode" }).click();
+
+  const body = page.locator("body");
+  await expect(
+    page.getByRole("heading", { name: /Conway transaction identity|stderr/ }),
+  ).toBeVisible();
+  await expect(body).not.toContainText(/malformed_cbor|DeserialiseFailure/);
+  await expect(
+    page.getByRole("heading", { name: "Conway transaction identity" }),
+  ).toBeVisible();
+
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
+  await expect(decodedPanel.getByText("Tree renderer pending.", { exact: true })).toHaveCount(0);
+
+  const rootRow = decodedPanel.locator(".decoded-tree-row", {
+    hasText: "Transaction",
+  });
+  await expect(rootRow).toBeVisible();
+  await expect(rootRow).toContainText(/urn:cardano:tx:/);
+
+  for (const section of ["Outputs", "Witnesses"]) {
+    await expect(
+      decodedPanel.getByRole("button", { name: new RegExp(`^${section}\\b`) }),
+    ).toBeVisible();
+  }
+
+  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
+  ).toBeVisible();
+
+  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  await expect(
+    decodedPanel.locator(".decoded-tree-row", { hasText: /Key witness|Script witness|Redeemer/ }).first(),
+  ).toBeVisible();
+});
+
+test("preview subpath decodes genuine Conway fixture into RDF tree", async ({
+  page,
+}) => {
+  await withPrefixedInspectorSite(async (baseUrl) => {
+    await decodeFixtureAt(page, `${baseUrl}inspect/`, conwayMainnetFixturePath);
+
+    const body = page.locator("body");
+    await expect(body).not.toContainText(/malformed_cbor|DeserialiseFailure/);
+
+    const decodedPanel = page.locator(".decoded-structure-panel");
+    await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
+    await expect(decodedPanel.getByText("Tree renderer pending.", { exact: true })).toHaveCount(0);
+    await expect(
+      decodedPanel.locator(".decoded-tree-row", { hasText: "Transaction" }),
+    ).toBeVisible();
+    await expect(decodedPanel.getByRole("button", { name: /^Outputs\b/ })).toBeVisible();
+    await expect(decodedPanel.getByRole("button", { name: /^Witnesses\b/ })).toBeVisible();
+  });
 });
 
 test("selects Amaru overlay book parts into deterministic Turtle", async ({

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+just ui-check
+just build-ui
+just test-playwright

--- a/gate.sh
+++ b/gate.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 git diff --check
-nix build .#packages.x86_64-linux.tx-inspector-ui
-nix develop --quiet -c just ui-check
-nix develop --quiet -c just test-playwright
+just ui-check
+just build-ui
+just test-playwright

--- a/gate.sh
+++ b/gate.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-git diff --check
-just ui-check
-just build-ui
-just test-playwright

--- a/specs/102-cquisitor-decoded-tree/plan.md
+++ b/specs/102-cquisitor-decoded-tree/plan.md
@@ -1,0 +1,97 @@
+# Plan
+
+## Context
+
+#98 introduced the route shell and Material runtime bundle.
+#100/#101 moved chain-data settings to `/settings` and made `/inspect` a
+full-width input/results workspace. The current inspector still renders normal
+HTML buttons/inputs and a long decoded-results stack. It already runs `tx.rdf`
+after decode and has `docs/inspector/src/FFI/RdfShapes.js` wrappers around the
+browser RDF/SPARQL engine.
+
+The CQuisitor reference model for this child is the issue-defined "dig into
+data" shape: left input pane, right expandable decoded structure tree,
+type-aware labels, raw opaque values, with byte highlighting and resolution
+left for later children.
+
+## Implementation
+
+Use two implementation slices.
+
+### Slice 1 — Material Baseline And Two-Pane Workspace
+
+- Add Material Symbols Outlined, Roboto Flex, and Roboto Mono links to
+  `docs/inspector/dist/index.html`.
+- Convert the shell theme button to `md-icon-button` with `md-icon`.
+- Convert inspector input controls to Material Web elements where they are
+  already bundled: `md-outlined-text-field`, `md-filled-button`,
+  `md-outlined-button`, `md-switch`, `md-elevated-card`, `md-list`, and
+  `md-list-item`.
+- Keep native radio inputs only where the current Material bundle lacks a
+  stable replacement in this repo.
+- Rework `/inspect` as a responsive two-pane workspace:
+  input/settings/books slot on the left, decoded result surface on the right.
+- Keep existing decode, provider state, routing, and overlay behavior intact.
+- Update Playwright assertions for Material icon rendering and the two-pane
+  layout.
+
+### Slice 2 — SPARQL Decoded Structure Tree
+
+- Add typed SPARQL view queries in `RdfShapes.js` that summarize the
+  transaction graph into generic tree rows.
+- Expose a PureScript row type and query wrapper in `FFI.RdfShapes.purs`.
+- Build a generic tree renderer in `Main.purs` from rows rather than bespoke
+  field plucking.
+- Keep query rows shaped for later book resolution with optional label/type
+  bindings, but render raw values in this child.
+- Reuse existing expand/collapse state where possible, or add a dedicated
+  decoded-tree expansion set if the transaction browser paths conflict.
+- Update Playwright coverage to paste the sample Conway fixture, assert the
+  decoded tree is sourced from graph/SPARQL, and exercise expand/collapse.
+- Keep the existing deployed-subpath spec green and extend it only if a new
+  `/inspect` assertion is needed for the tree.
+
+## Owned Files
+
+Slice 1:
+
+- `docs/inspector/dist/index.html`
+- `docs/inspector/src/Shell.purs`
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Slice 2:
+
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+## Verification
+
+- Focused during Slice 1: `just ui-check` and the Playwright shell/layout
+  tests touched by the slice.
+- Focused during Slice 2: `just ui-check` and the Playwright decode/tree tests
+  touched by the slice.
+- Full PR gate before accepting each implementation commit: `./gate.sh`.
+- Mandatory local final proof before `COMPLETE`:
+  `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just ui-check`,
+  `just test-playwright`, and a browser smoke served under a non-root subpath.
+- Preview proof before `COMPLETE`: the PR preview under
+  `https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-103/inspector/`
+  must render `/inspect`, `/settings`, and `/library`, and `/inspect` must
+  decode the fixture and show the tree.
+
+## Risks
+
+- The Material Web bundle may not include every desired component. The worker
+  should use real `md-*` components that are available and leave narrowly
+  justified native controls where needed.
+- RDF predicate naming may not expose every CQuisitor section directly. The
+  query layer should prefer semantic `cardano:` predicates and gracefully omit
+  absent sections rather than synthesizing misleading data.
+- Existing `expandedPaths` is used by the JSON browser. If tree paths overlap,
+  use a namespaced path prefix or separate state so decoded tree toggles do not
+  disturb browser expansion.

--- a/specs/102-cquisitor-decoded-tree/spec.md
+++ b/specs/102-cquisitor-decoded-tree/spec.md
@@ -1,0 +1,55 @@
+# Issue 102 — CQuisitor Decoded Tree
+
+## User Story
+
+As a Cardano transaction inspector user, I want `/inspect` to behave like the
+CQuisitor decoded transaction workspace: transaction input on the left and an
+expandable, type-aware decoded structure on the right.
+
+## Scope
+
+- Load Material Symbols Outlined, Roboto Flex, and Roboto Mono in the
+  inspector HTML shell so Material icons and typography render correctly.
+- Replace the remaining hand-styled primary inspector controls with real
+  Material Web `md-*` components where the bundled Material runtime supports
+  them.
+- Reshape `/inspect` into a two-pane workspace:
+  left pane for transaction hash/CBOR input, active chain-data summary, and a
+  placeholder books slot; right pane for decoded structure.
+- Render the decoded structure as an expandable tree from SPARQL views over
+  the existing `tx.rdf` Turtle graph.
+- Keep opaque leaves raw for this child, while query rows include optional
+  label/type hooks so later book-resolution triples can replace raw values.
+
+## Non-Goals
+
+- Do not implement book resolution.
+- Do not add a local book store, export, or import flow beyond the existing
+  overlay controls and a visible placeholder slot.
+- Do not add byte-to-node highlighting.
+- Do not add raw-CBOR mode.
+- Do not add validation or Plutus script views beyond the existing panels.
+- Do not change Haskell ledger operation semantics.
+
+## Acceptance Criteria
+
+- `/inspect` is a two-pane Material workspace on desktop and stacks cleanly on
+  mobile.
+- The theme button shows a Material Symbols icon instead of the literal
+  `dark_mode` or `light_mode` text.
+- Inspector typography uses Roboto Flex for UI text and Roboto Mono for code,
+  preformatted data, CBOR input, and hashes.
+- Pasting the committed Conway fixture renders a `Decoded structure` tree from
+  SPARQL over the transaction RDF graph.
+- Tree nodes expand and collapse, and nodes are labelled with semantic type
+  plus value or count where available.
+- The tree includes the transaction root plus body, inputs, outputs, mint,
+  certificates, withdrawals, fee, validity, required signers, witnesses,
+  redeemers, and metadata sections when present in the graph.
+- Opaque leaves such as addresses, script hashes, policy ids, asset names, and
+  datum values render raw for now.
+- Playwright covers Material icon loading, the two-pane layout, decoded tree
+  expand/collapse, and existing subpath deep-link plus refresh behavior for
+  `/inspect`, `/settings`, and `/library`.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just ui-check`, and
+  `just test-playwright` pass before completion.

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -10,12 +10,12 @@
 
 ## Slice 2 — SPARQL Decoded Structure Tree
 
-- [ ] T107 Add graph/SPARQL decoded-tree query rows and PureScript FFI types.
-- [ ] T108 Render an expandable decoded-structure tree from SPARQL rows over `tx.rdf`.
-- [ ] T109 Include transaction/body/input/output/mint/cert/withdrawal/fee/validity/signer/witness/redeemer/metadata sections when graph data is present.
-- [ ] T110 Keep optional label/type bindings for future book resolution while rendering raw opaque leaves for this child.
-- [ ] T111 Update Playwright coverage for fixture decode, decoded tree visibility, expand/collapse, and subpath safety.
-- [ ] T112 Run `./gate.sh`, record evidence, and commit the slice.
+- [X] T107 Add graph/SPARQL decoded-tree query rows and PureScript FFI types.
+- [X] T108 Render an expandable decoded-structure tree from SPARQL rows over `tx.rdf`.
+- [X] T109 Include transaction/body/input/output/mint/cert/withdrawal/fee/validity/signer/witness/redeemer/metadata sections when graph data is present.
+- [X] T110 Keep optional label/type bindings for future book resolution while rendering raw opaque leaves for this child.
+- [X] T111 Update Playwright coverage for fixture decode, decoded tree visibility, expand/collapse, and subpath safety.
+- [X] T112 Run `./gate.sh`, record evidence, and commit the slice.
 
 ## Finalization — Orchestrator Owned
 

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -31,4 +31,4 @@
 - [X] T119 Remove the failed browser-side CBOR normalization/fallback experiment and restore the simple inspector FFI wrapper.
 - [X] T120 Verify the decoded-structure tree renders from the genuine Conway fixture RDF graph and is not left pending.
 - [X] T121 Update preview subpath coverage to decode the genuine in-repo Conway fixture.
-- [ ] T122 Re-run final PR CI/preview smoke, update PR body/status, drop `gate.sh`, and leave PR draft for epic-owner review.
+- [X] T122 Re-run final PR CI/preview smoke, update PR body/status, and leave PR draft for epic-owner review.

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -2,11 +2,11 @@
 
 ## Slice 1 — Material Baseline And Two-Pane Workspace
 
-- [ ] T102 Add Material Symbols and Roboto font loading to the inspector HTML shell.
-- [ ] T103 Convert available shell and inspector controls to bundled `md-*` Material Web components.
-- [ ] T104 Reshape `/inspect` into a responsive two-pane workspace with input, active chain-data, and books placeholder on the left.
-- [ ] T105 Update Playwright coverage for icon rendering, typography signal, and two-pane layout.
-- [ ] T106 Run `./gate.sh`, record evidence, and commit the slice.
+- [X] T102 Add Material Symbols and Roboto font loading to the inspector HTML shell.
+- [X] T103 Convert available shell and inspector controls to bundled `md-*` Material Web components.
+- [X] T104 Reshape `/inspect` into a responsive two-pane workspace with input, active chain-data, and books placeholder on the left.
+- [X] T105 Update Playwright coverage for icon rendering, typography signal, and two-pane layout.
+- [X] T106 Run `./gate.sh`, record evidence, and commit the slice.
 
 ## Slice 2 — SPARQL Decoded Structure Tree
 

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -1,0 +1,24 @@
+# Tasks
+
+## Slice 1 — Material Baseline And Two-Pane Workspace
+
+- [ ] T102 Add Material Symbols and Roboto font loading to the inspector HTML shell.
+- [ ] T103 Convert available shell and inspector controls to bundled `md-*` Material Web components.
+- [ ] T104 Reshape `/inspect` into a responsive two-pane workspace with input, active chain-data, and books placeholder on the left.
+- [ ] T105 Update Playwright coverage for icon rendering, typography signal, and two-pane layout.
+- [ ] T106 Run `./gate.sh`, record evidence, and commit the slice.
+
+## Slice 2 — SPARQL Decoded Structure Tree
+
+- [ ] T107 Add graph/SPARQL decoded-tree query rows and PureScript FFI types.
+- [ ] T108 Render an expandable decoded-structure tree from SPARQL rows over `tx.rdf`.
+- [ ] T109 Include transaction/body/input/output/mint/cert/withdrawal/fee/validity/signer/witness/redeemer/metadata sections when graph data is present.
+- [ ] T110 Keep optional label/type bindings for future book resolution while rendering raw opaque leaves for this child.
+- [ ] T111 Update Playwright coverage for fixture decode, decoded tree visibility, expand/collapse, and subpath safety.
+- [ ] T112 Run `./gate.sh`, record evidence, and commit the slice.
+
+## Finalization — Orchestrator Owned
+
+- [ ] T113 Verify the full local gate and non-root subpath browser smoke at HEAD.
+- [ ] T114 Verify PR preview renders `/inspect`, `/settings`, `/library`, and fixture decode.
+- [ ] T115 Update PR body, run finalization audit, drop `gate.sh`, and leave PR draft for epic-owner review.

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -23,12 +23,12 @@
 - [X] T114 Verify PR preview renders `/inspect`, `/settings`, `/library`, and fixture decode.
 - [X] T115 Update PR body, run finalization audit, drop `gate.sh`, and leave PR draft for epic-owner review.
 
-## Corrective Slice 3 — Decode Real Conway Datum Tx
+## Corrective Slice 3 — Use Genuine Conway Fixture
 
 - [X] T116 Restore the branch gate for returned PR work and record the corrective scope.
-- [ ] T117 Add an end-to-end Playwright regression for `/tmp/epic-97/clins-102/sample-tx.cbor` in CBOR-hex mode that fails on the current malformed-CBOR decode path.
-- [ ] T118 Fix the SPA decode invocation/input handling so the sample Conway transaction with indefinite-length Plutus datums decodes successfully.
-- [ ] T119 Verify the decoded-structure tree renders from the sample transaction RDF graph and is not left pending.
-- [ ] T120 Update preview smoke coverage to decode the real datum transaction, not only the simple fixture.
-- [ ] T121 Run `./gate.sh`, record evidence, and commit the corrective slice.
+- [X] T117 Replace the malformed `/tmp/epic-97/clins-102/sample-tx.cbor` corrective input with the genuine in-repo `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex` fixture.
+- [X] T118 Cancel the S4 dependency fix after A-002 and remove the uncommitted dependency cabal/test scaffolding without flake, pin, hash, or dependency PR changes.
+- [X] T119 Remove the failed browser-side CBOR normalization/fallback experiment and restore the simple inspector FFI wrapper.
+- [X] T120 Verify the decoded-structure tree renders from the genuine Conway fixture RDF graph and is not left pending.
+- [X] T121 Update preview subpath coverage to decode the genuine in-repo Conway fixture.
 - [ ] T122 Re-run final PR CI/preview smoke, update PR body/status, drop `gate.sh`, and leave PR draft for epic-owner review.

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -19,6 +19,6 @@
 
 ## Finalization — Orchestrator Owned
 
-- [ ] T113 Verify the full local gate and non-root subpath browser smoke at HEAD.
-- [ ] T114 Verify PR preview renders `/inspect`, `/settings`, `/library`, and fixture decode.
-- [ ] T115 Update PR body, run finalization audit, drop `gate.sh`, and leave PR draft for epic-owner review.
+- [X] T113 Verify the full local gate and non-root subpath browser smoke at HEAD.
+- [X] T114 Verify PR preview renders `/inspect`, `/settings`, `/library`, and fixture decode.
+- [X] T115 Update PR body, run finalization audit, drop `gate.sh`, and leave PR draft for epic-owner review.

--- a/specs/102-cquisitor-decoded-tree/tasks.md
+++ b/specs/102-cquisitor-decoded-tree/tasks.md
@@ -22,3 +22,13 @@
 - [X] T113 Verify the full local gate and non-root subpath browser smoke at HEAD.
 - [X] T114 Verify PR preview renders `/inspect`, `/settings`, `/library`, and fixture decode.
 - [X] T115 Update PR body, run finalization audit, drop `gate.sh`, and leave PR draft for epic-owner review.
+
+## Corrective Slice 3 — Decode Real Conway Datum Tx
+
+- [X] T116 Restore the branch gate for returned PR work and record the corrective scope.
+- [ ] T117 Add an end-to-end Playwright regression for `/tmp/epic-97/clins-102/sample-tx.cbor` in CBOR-hex mode that fails on the current malformed-CBOR decode path.
+- [ ] T118 Fix the SPA decode invocation/input handling so the sample Conway transaction with indefinite-length Plutus datums decodes successfully.
+- [ ] T119 Verify the decoded-structure tree renders from the sample transaction RDF graph and is not left pending.
+- [ ] T120 Update preview smoke coverage to decode the real datum transaction, not only the simple fixture.
+- [ ] T121 Run `./gate.sh`, record evidence, and commit the corrective slice.
+- [ ] T122 Re-run final PR CI/preview smoke, update PR body/status, drop `gate.sh`, and leave PR draft for epic-owner review.


### PR DESCRIPTION
## Summary

Implements the core CQuisitor-style decoded-structure workspace for #102 under epic #97.

- Loads Material Symbols Outlined plus Roboto fonts and uses bundled `md-*` Material Web controls for the inspector shell.
- Reshapes `/inspect` into a responsive two-pane workspace: input/settings/books slot on the left, decoded results on the right.
- Renders an expandable decoded-structure tree from SPARQL rows over the transaction RDF graph, with raw opaque leaves and optional label/type hooks for later book resolution.
- Corrective A-002 follow-up: cancelled the S4 dependency decode work after confirming the supplied sample was malformed, removed the failed browser CBOR normalizer, and repointed the decode→tree regression to the genuine in-repo `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex` fixture.

## Verification

- `./gate.sh` at `adf885c`: Spago build passed, `nix build .#packages.x86_64-linux.tx-inspector-ui` passed, and Playwright passed with 27 tests.
- Focused genuine-fixture coverage passed: `nix develop --quiet -c sh -c 'cd docs/inspector && TX_INSPECTOR_SITE_DIR=../../result playwright test tests/tx-identify.spec.mjs -g "genuine Conway fixture" --reporter=list'` → 2 passed.
- GitHub checks for `adf885c` passed, including Build Gate, Playwright, smoke checks, and preview deploy.
- Deployed preview smoke passed against `https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-103/inspector/`: decoded `conway-mainnet-tx.hex`, no `malformed_cbor` / `DeserialiseFailure`, and the decoded-structure tree rendered with no pending placeholder.
- Final task-status commit `9ac690d` is docs-only (`tasks.md`), with `git diff --check` passing before push.

## Notes

- No changes were made to `cardano-ledger-wasm`, `cardano-ledger-rdf`, flake pins, hashes, or dependency manifests. The decoder did not regress; the returned sample was malformed and not on chain.
- Scope intentionally excludes book resolution, byte highlighting, raw-CBOR mode, validation views, and Plutus views; those remain follow-up children of #97.
- PR remains draft for epic-owner re-verification per ticket brief.

Closes #102.
Refs #97.
