### PR TITLE
Book resolution: decoded tree resolves merged books

### DIFF
--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -159,12 +159,15 @@ ORDER BY ?sort ?txIdHex ?index ?entity
 const decodedOutputsQuery = `
 PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT ?output ?index ?address ?lovelace ?datum ?datumRaw ?datumHash ?datumHashHex ?resolvedLabel ?resolvedType
+SELECT ?output ?index ?address ?addressBech32 ?lovelace ?datum ?datumRaw ?datumHash ?datumHashHex ?resolvedLabel ?resolvedType
 WHERE {
   ?transaction a cardano:Transaction ;
     cardano:hasOutput ?output .
   OPTIONAL { ?output cardano:hasIndex ?index . }
-  OPTIONAL { ?output cardano:atAddress ?address . }
+  OPTIONAL {
+    ?output cardano:atAddress ?address .
+    OPTIONAL { ?address cardano:bech32 ?addressBech32 . }
+  }
   OPTIONAL { ?output cardano:lovelace ?lovelace . }
   OPTIONAL {
     ?output cardano:hasDatum ?datum .
@@ -244,6 +247,25 @@ WHERE {
   OPTIONAL { ?metadata a ?resolvedType . }
 }
 ORDER BY ?label ?metadata ?text
+`;
+
+const decodedLabelMatchesQuery = `
+PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?entity ?label ?type ?bech32 ?bytesHex ?fromTxOutRef ?rawBytes ?datumHashHex
+WHERE {
+  ?entity rdfs:label ?label .
+  OPTIONAL { ?entity a ?type . }
+  OPTIONAL { ?entity cardano:bech32 ?bech32 . }
+  OPTIONAL { ?entity cardano:bytesHex ?bytesHex . }
+  OPTIONAL { ?entity cardano:fromTxOutRef ?fromTxOutRef . }
+  OPTIONAL { ?entity cardano:hasRawBytes ?rawBytes . }
+  OPTIONAL {
+    ?entity cardano:hasHash ?datumHash .
+    OPTIONAL { ?datumHash cardano:bytesHex ?datumHashHex . }
+  }
+}
+ORDER BY ?label ?entity
 `;
 
 const bindingValue = (binding) =>
@@ -357,6 +379,11 @@ const compact = (value, max = 72) => {
   return raw.length > max ? `${raw.slice(0, max - 1)}...` : raw;
 };
 
+const txOutRefFromUtxoUri = (value) => {
+  const match = String(value || "").match(/^urn:cardano:utxo:([0-9a-f]{64}):([0-9]+)$/i);
+  return match ? `${match[1]}#${match[2]}` : "";
+};
+
 const slug = (value) =>
   String(value || "row")
     .replace(/[^A-Za-z0-9]+/g, "-")
@@ -423,15 +450,70 @@ const appendLeaf = (rows, parentId, depth, order, label, kind, value, extra = {}
   );
 };
 
+const addMatchValue = (matches, value, row) => {
+  const key = String(value || "");
+  if (key !== "" && !matches.has(key)) matches.set(key, row);
+};
+
+const decodedLabelMatches = (graphTtl) => {
+  const matches = new Map();
+  let rows = [];
+  try {
+    rows = queryBindings(graphTtl, decodedLabelMatchesQuery);
+  } catch (_) {
+    return matches;
+  }
+
+  for (const row of rows) {
+    const match = {
+      resolvedLabel: bindingValue(row.label),
+      resolvedType: bindingValue(row.type),
+    };
+    addMatchValue(matches, bindingValue(row.entity), match);
+    addMatchValue(matches, bindingValue(row.bech32), match);
+    addMatchValue(matches, bindingValue(row.bytesHex), match);
+    addMatchValue(matches, bindingValue(row.fromTxOutRef), match);
+    addMatchValue(matches, bindingValue(row.rawBytes), match);
+    addMatchValue(matches, bindingValue(row.datumHashHex), match);
+  }
+
+  return matches;
+};
+
+const resolvedFrom = (matches, directLabel, directType, ...values) => {
+  const resolved = {
+    resolvedLabel: directLabel || "",
+    resolvedType: directType || "",
+  };
+  if (resolved.resolvedLabel !== "" || resolved.resolvedType !== "") {
+    return resolved;
+  }
+
+  for (const value of values) {
+    const match = matches.get(String(value || ""));
+    if (match) return match;
+  }
+
+  return resolved;
+};
+
 const countText = (count, noun) => `${count} ${noun}${count === 1 ? "" : "s"}`;
 
 const normalizeDecodedTreeRows = (graphTtl) => {
   const roots = queryBindings(graphTtl, decodedTreeRootQuery);
   if (roots.length === 0) return [];
 
+  const labelMatches = decodedLabelMatches(graphTtl);
   const root = roots[0];
   const txId = firstBindingValue(root.txIdHex, root.txId, root.transaction);
   const transactionId = bindingValue(root.transaction);
+  const rootResolved = resolvedFrom(
+    labelMatches,
+    bindingValue(root.resolvedLabel),
+    bindingValue(root.resolvedType),
+    txId,
+    transactionId,
+  );
   const rows = [
     treeRow({
       id: "decoded-root",
@@ -442,8 +524,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       value: transactionId,
       summary: compact(transactionId),
       raw: txId,
-      resolvedLabel: bindingValue(root.resolvedLabel),
-      resolvedType: bindingValue(root.resolvedType),
+      resolvedLabel: rootResolved.resolvedLabel,
+      resolvedType: rootResolved.resolvedType,
     }),
   ];
 
@@ -457,6 +539,15 @@ const normalizeDecodedTreeRows = (graphTtl) => {
   if (bodyFields.length > 0) {
     addSection(rows, "decoded-body", "Body", 10, countText(bodyFields.length, "field"));
     bodyFields.forEach((field, index) => {
+      const raw = firstBindingValue(field.raw, field.value, field.entity);
+      const resolved = resolvedFrom(
+        labelMatches,
+        bindingValue(field.resolvedLabel),
+        bindingValue(field.resolvedType),
+        raw,
+        bindingValue(field.value),
+        bindingValue(field.entity),
+      );
       appendLeaf(
         rows,
         "decoded-body",
@@ -464,11 +555,11 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         index,
         bindingValue(field.label),
         bindingValue(field.kind),
-        firstBindingValue(field.raw, field.value, field.entity),
+        raw,
         {
-          raw: firstBindingValue(field.raw, field.value, field.entity),
-          resolvedLabel: bindingValue(field.resolvedLabel),
-          resolvedType: bindingValue(field.resolvedType),
+          raw,
+          resolvedLabel: resolved.resolvedLabel,
+          resolvedType: resolved.resolvedType,
         },
       );
     });
@@ -484,6 +575,14 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         tx === "" && inputIndex === ""
           ? bindingValue(input.entity)
           : `${compact(tx, 28)}#${inputIndex}`;
+      const raw = tx === "" ? bindingValue(input.entity) : `${tx}#${inputIndex}`;
+      const resolved = resolvedFrom(
+        labelMatches,
+        bindingValue(input.resolvedLabel),
+        bindingValue(input.resolvedType),
+        raw,
+        bindingValue(input.entity),
+      );
       appendLeaf(
         rows,
         "decoded-inputs",
@@ -493,9 +592,9 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         "tx-out-ref",
         value,
         {
-          raw: tx === "" ? bindingValue(input.entity) : `${tx}#${inputIndex}`,
-          resolvedLabel: bindingValue(input.resolvedLabel),
-          resolvedType: bindingValue(input.resolvedType),
+          raw,
+          resolvedLabel: resolved.resolvedLabel,
+          resolvedType: resolved.resolvedType,
         },
       );
     });
@@ -506,6 +605,14 @@ const normalizeDecodedTreeRows = (graphTtl) => {
     outputs.forEach((output, index) => {
       const outputIndex = firstBindingValue(output.index, { value: String(index) });
       const outputId = `decoded-output-${slug(outputIndex)}-${index}`;
+      const outputValue = bindingValue(output.output);
+      const outputResolved = resolvedFrom(
+        labelMatches,
+        bindingValue(output.resolvedLabel),
+        bindingValue(output.resolvedType),
+        outputValue,
+        txOutRefFromUtxoUri(outputValue),
+      );
       rows.push(
         treeRow({
           id: outputId,
@@ -514,18 +621,48 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           order: index,
           label: `Output ${outputIndex}`,
           kind: "output",
-          value: bindingValue(output.output),
-          summary: compact(bindingValue(output.output)),
-          raw: bindingValue(output.output),
-          resolvedLabel: bindingValue(output.resolvedLabel),
-          resolvedType: bindingValue(output.resolvedType),
+          value: outputValue,
+          summary: compact(outputValue),
+          raw: outputValue,
+          resolvedLabel: outputResolved.resolvedLabel,
+          resolvedType: outputResolved.resolvedType,
         }),
       );
       appendLeaf(rows, outputId, 3, 10, "Index", "integer", outputIndex);
       appendLeaf(rows, outputId, 3, 20, "Lovelace", "lovelace", bindingValue(output.lovelace));
-      appendLeaf(rows, outputId, 3, 30, "Address", "address", bindingValue(output.address));
-      appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", firstBindingValue(output.datumHashHex, output.datumHash));
-      appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw));
+      appendLeaf(rows, outputId, 3, 30, "Address", "address", bindingValue(output.address), {
+        resolvedLabel: resolvedFrom(
+          labelMatches,
+          "",
+          "",
+          bindingValue(output.addressBech32),
+          bindingValue(output.address),
+        ).resolvedLabel,
+        resolvedType: resolvedFrom(
+          labelMatches,
+          "",
+          "",
+          bindingValue(output.addressBech32),
+          bindingValue(output.address),
+        ).resolvedType,
+      });
+      const datumHash = firstBindingValue(output.datumHashHex, output.datumHash);
+      const datumHashResolved = resolvedFrom(
+        labelMatches,
+        "",
+        "",
+        bindingValue(output.datumHashHex),
+        bindingValue(output.datumHash),
+      );
+      appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", datumHash, {
+        resolvedLabel: datumHashResolved.resolvedLabel,
+        resolvedType: datumHashResolved.resolvedType,
+      });
+      const datumRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(output.datumRaw));
+      appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw), {
+        resolvedLabel: datumRawResolved.resolvedLabel,
+        resolvedType: datumRawResolved.resolvedType,
+      });
     });
   }
 
@@ -541,6 +678,14 @@ const normalizeDecodedTreeRows = (graphTtl) => {
     addSection(rows, "decoded-witnesses", "Witnesses", 50, countText(witnesses.length, "key witness"));
     witnesses.forEach((witness, index) => {
       const witnessId = `decoded-key-witness-${index}`;
+      const witnessValue = firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness);
+      const witnessResolved = resolvedFrom(
+        labelMatches,
+        bindingValue(witness.resolvedLabel),
+        bindingValue(witness.resolvedType),
+        witnessValue,
+        bindingValue(witness.witness),
+      );
       rows.push(
         treeRow({
           id: witnessId,
@@ -549,15 +694,24 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           order: index,
           label: `Key witness ${index}`,
           kind: "key-witness",
-          value: firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness),
-          summary: compact(firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness)),
+          value: witnessValue,
+          summary: compact(witnessValue),
           raw: bindingValue(witness.witness),
-          resolvedLabel: bindingValue(witness.resolvedLabel),
-          resolvedType: bindingValue(witness.resolvedType),
+          resolvedLabel: witnessResolved.resolvedLabel,
+          resolvedType: witnessResolved.resolvedType,
         }),
       );
-      appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", firstBindingValue(witness.verificationKeyHex, witness.verificationKey));
-      appendLeaf(rows, witnessId, 3, 20, "Signature", "signature", bindingValue(witness.signature));
+      const keyValue = firstBindingValue(witness.verificationKeyHex, witness.verificationKey);
+      const keyResolved = resolvedFrom(labelMatches, "", "", keyValue);
+      appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", keyValue, {
+        resolvedLabel: keyResolved.resolvedLabel,
+        resolvedType: keyResolved.resolvedType,
+      });
+      const signatureResolved = resolvedFrom(labelMatches, "", "", bindingValue(witness.signature));
+      appendLeaf(rows, witnessId, 3, 20, "Signature", "signature", bindingValue(witness.signature), {
+        resolvedLabel: signatureResolved.resolvedLabel,
+        resolvedType: signatureResolved.resolvedType,
+      });
     });
   }
 
@@ -567,6 +721,14 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       const redeemerId = `decoded-redeemer-${index}`;
       const purpose = bindingValue(redeemer.purpose);
       const redeemerIndex = bindingValue(redeemer.index);
+      const redeemerResolved = resolvedFrom(
+        labelMatches,
+        bindingValue(redeemer.resolvedLabel),
+        bindingValue(redeemer.resolvedType),
+        bindingValue(redeemer.redeemer),
+        bindingValue(redeemer.dataHashHex),
+        bindingValue(redeemer.dataRaw),
+      );
       rows.push(
         treeRow({
           id: redeemerId,
@@ -578,14 +740,29 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: bindingValue(redeemer.redeemer),
           summary: compact(firstBindingValue(redeemer.dataHashHex, redeemer.dataHash, redeemer.redeemer)),
           raw: bindingValue(redeemer.redeemer),
-          resolvedLabel: bindingValue(redeemer.resolvedLabel),
-          resolvedType: bindingValue(redeemer.resolvedType),
+          resolvedLabel: redeemerResolved.resolvedLabel,
+          resolvedType: redeemerResolved.resolvedType,
         }),
       );
       appendLeaf(rows, redeemerId, 3, 10, "Purpose", "purpose", purpose);
       appendLeaf(rows, redeemerId, 3, 20, "Index", "integer", redeemerIndex);
-      appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", firstBindingValue(redeemer.dataHashHex, redeemer.dataHash));
-      appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw));
+      const dataHashValue = firstBindingValue(redeemer.dataHashHex, redeemer.dataHash);
+      const dataHashResolved = resolvedFrom(
+        labelMatches,
+        "",
+        "",
+        bindingValue(redeemer.dataHashHex),
+        bindingValue(redeemer.dataHash),
+      );
+      appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", dataHashValue, {
+        resolvedLabel: dataHashResolved.resolvedLabel,
+        resolvedType: dataHashResolved.resolvedType,
+      });
+      const dataRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(redeemer.dataRaw));
+      appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw), {
+        resolvedLabel: dataRawResolved.resolvedLabel,
+        resolvedType: dataRawResolved.resolvedType,
+      });
       appendLeaf(rows, redeemerId, 3, 50, "Memory units", "ex-units", bindingValue(redeemer.memory));
       appendLeaf(rows, redeemerId, 3, 60, "CPU units", "ex-units", bindingValue(redeemer.cpu));
     });
@@ -601,6 +778,13 @@ const normalizeDecodedTreeRows = (graphTtl) => {
     addSection(rows, "decoded-metadata", "Metadata", 70, countText(metadataRows.length, "label"));
     metadataRows.forEach((meta, index) => {
       const metaId = `decoded-metadata-${slug(bindingValue(meta.label))}-${index}`;
+      const metaResolved = resolvedFrom(
+        labelMatches,
+        bindingValue(meta.resolvedLabel),
+        bindingValue(meta.resolvedType),
+        bindingValue(meta.raw),
+        bindingValue(meta.metadata),
+      );
       rows.push(
         treeRow({
           id: metaId,
@@ -612,8 +796,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: bindingValue(meta.metadata),
           summary: compact(firstBindingValue(meta.text, meta.raw, meta.metadata)),
           raw: firstBindingValue(meta.raw, meta.metadata),
-          resolvedLabel: bindingValue(meta.resolvedLabel),
-          resolvedType: bindingValue(meta.resolvedType),
+          resolvedLabel: metaResolved.resolvedLabel,
+          resolvedType: metaResolved.resolvedType,
         }),
       );
       appendLeaf(rows, metaId, 3, 10, "Metadata label", "integer", bindingValue(meta.label));

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -1851,7 +1851,7 @@ inspectorComponent initial =
     resolvedLabelsLens <-
       resolvedLabelsLensFromGraph graphTurtle
     typedFieldsLens <- typedFieldsLensFromGraph rdf.turtle
-    decodedTreeLens <- decodedTreeLensFromGraph rdf.turtle
+    decodedTreeLens <- decodedTreeLensFromGraph graphTurtle
     shaclConformance <- shaclConformanceFromGraph graphTurtle st
     pure
       { sparqlLens
@@ -1878,6 +1878,16 @@ inspectorComponent initial =
           shaclConformanceFromGraph
             (mergedRdfTurtle rdf.turtle (selectedOverlayTurtle st))
             st
+        else
+          pure Nothing
+      Nothing -> pure Nothing
+
+  decodedTreeLensForState st =
+    case st.rdf of
+      Just rdf ->
+        if rdf.valid then
+          decodedTreeLensFromGraph
+            (mergedRdfTurtle rdf.turtle (selectedOverlayTurtle st))
         else
           pure Nothing
       Nothing -> pure Nothing
@@ -1939,6 +1949,7 @@ inspectorComponent initial =
           st <- H.get
           let nextState = st { overlayParts = book.parts, selectedOverlayPartIds = [] }
           resolvedLabelsLens <- resolvedLabelsLensForState nextState
+          decodedTreeLens <- decodedTreeLensForState nextState
           shaclConformance <- shaclConformanceForState nextState
           H.modify_
             _
@@ -1946,6 +1957,7 @@ inspectorComponent initial =
               , selectedOverlayPartIds = []
               , overlayError = Nothing
               , resolvedLabelsLens = resolvedLabelsLens
+              , decodedTreeLens = decodedTreeLens
               , shaclConformance = shaclConformance
               }
     LoadAmaruOverlayBook -> do
@@ -1958,6 +1970,7 @@ inspectorComponent initial =
           st <- H.get
           let nextState = st { overlayParts = book.parts, selectedOverlayPartIds = [] }
           resolvedLabelsLens <- resolvedLabelsLensForState nextState
+          decodedTreeLens <- decodedTreeLensForState nextState
           shaclConformance <- shaclConformanceForState nextState
           H.modify_
             _
@@ -1966,6 +1979,7 @@ inspectorComponent initial =
               , selectedOverlayPartIds = []
               , overlayError = Nothing
               , resolvedLabelsLens = resolvedLabelsLens
+              , decodedTreeLens = decodedTreeLens
               , shaclConformance = shaclConformance
               }
     LoadSundaeSwapBlueprintBook -> do
@@ -1978,6 +1992,7 @@ inspectorComponent initial =
           st <- H.get
           let nextState = st { overlayParts = book.parts, selectedOverlayPartIds = [] }
           resolvedLabelsLens <- resolvedLabelsLensForState nextState
+          decodedTreeLens <- decodedTreeLensForState nextState
           shaclConformance <- shaclConformanceForState nextState
           H.modify_
             _
@@ -1986,6 +2001,7 @@ inspectorComponent initial =
               , selectedOverlayPartIds = []
               , overlayError = Nothing
               , resolvedLabelsLens = resolvedLabelsLens
+              , decodedTreeLens = decodedTreeLens
               , shaclConformance = shaclConformance
               }
     LoadShaclShapesBook -> do
@@ -2002,6 +2018,7 @@ inspectorComponent initial =
           ]
         nextState = st { overlayParts = parts, selectedOverlayPartIds = [] }
       resolvedLabelsLens <- resolvedLabelsLensForState nextState
+      decodedTreeLens <- decodedTreeLensForState nextState
       shaclConformance <- shaclConformanceForState nextState
       H.modify_
         _
@@ -2010,6 +2027,7 @@ inspectorComponent initial =
           , selectedOverlayPartIds = []
           , overlayError = Nothing
           , resolvedLabelsLens = resolvedLabelsLens
+          , decodedTreeLens = decodedTreeLens
           , shaclConformance = shaclConformance
           }
     ToggleOverlayPart partId selected -> do
@@ -2019,11 +2037,13 @@ inspectorComponent initial =
           toggleOverlayPartId partId selected st.selectedOverlayPartIds
         nextState = st { selectedOverlayPartIds = selectedOverlayPartIds }
       resolvedLabelsLens <- resolvedLabelsLensForState nextState
+      decodedTreeLens <- decodedTreeLensForState nextState
       shaclConformance <- shaclConformanceForState nextState
       H.modify_
         _
           { selectedOverlayPartIds = selectedOverlayPartIds
           , resolvedLabelsLens = resolvedLabelsLens
+          , decodedTreeLens = decodedTreeLens
           , shaclConformance = shaclConformance
           }
     ApplySelectedBooks -> do
@@ -2031,10 +2051,12 @@ inspectorComponent initial =
       case st.txCbor of
         Nothing -> do
           resolvedLabelsLens <- resolvedLabelsLensForState st
+          decodedTreeLens <- decodedTreeLensForState st
           shaclConformance <- shaclConformanceForState st
           H.modify_
             _
               { resolvedLabelsLens = resolvedLabelsLens
+              , decodedTreeLens = decodedTreeLens
               , shaclConformance = shaclConformance
               , overlayError = Nothing
               }

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -794,6 +794,75 @@ test("selects Amaru overlay book parts into deterministic Turtle", async ({
   ).toBeVisible();
 });
 
+test("resolves decoded-tree address rows from selected Turtle overlay books", async ({
+  page,
+}) => {
+  await decodeFixture(page, conwayMainnetFixturePath);
+
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+
+  const addressRow = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Address" })
+    .first();
+  await expect(addressRow).toBeVisible();
+
+  const rawAddress = await addressRow.locator(".decoded-tree-summary").innerText();
+  expect(rawAddress).toMatch(/^[0-9a-f]{32}$/);
+
+  const turtleText = await page.locator(".rdf-panel .rdf-turtle").innerText();
+  const address = await page.evaluate((graph) => {
+    const result = globalThis.rdfShapes.query(
+      graph,
+      `
+        PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+        SELECT ?bech32 WHERE {
+          ?transaction a cardano:Transaction ;
+            cardano:hasOutput ?output .
+          ?output cardano:hasIndex 0 ;
+            cardano:atAddress ?address .
+          ?address cardano:bech32 ?bech32 .
+        }
+        LIMIT 1
+      `,
+    );
+    return result.json.results.bindings[0].bech32.value;
+  }, turtleText);
+  expect(address).toMatch(/^addr1/);
+
+  const resolvedLabel = "Fixture decoded treasury address";
+  await expect(decodedPanel.getByText(resolvedLabel, { exact: true })).toHaveCount(0);
+  await expect(addressRow).toContainText(rawAddress);
+
+  const overlayTurtle = `
+@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fixture: <https://example.test/cardano-ledger-inspector/fixture#> .
+
+fixture:decodedTreasuryAddress
+  rdfs:label "${resolvedLabel}" ;
+  cardano:bech32 "${address}" .
+`;
+
+  const overlayPanel = page.locator(".overlay-book-panel");
+  await overlayPanel.getByLabel(/Overlay Turtle.*JSON/).fill(overlayTurtle);
+  await overlayPanel.getByRole("button", { name: /Import .*book/ }).click();
+  await overlayPanel.getByLabel("Pasted Turtle").check();
+  await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
+
+  const resolvedAddressRow = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Address" })
+    .filter({ hasText: resolvedLabel })
+    .first();
+  await expect(resolvedAddressRow).toContainText(resolvedLabel);
+  const resolvedRawAddress = await resolvedAddressRow
+    .locator(".decoded-tree-summary")
+    .innerText();
+  expect(resolvedRawAddress).toMatch(/^[0-9a-f]{32}$/);
+});
+
 test("imports a SundaeSwap blueprint book and applies typed RDF fields", async ({
   page,
 }) => {

--- a/gate.sh
+++ b/gate.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 git diff --check
+just format-check
+just hlint
 just ui-check
 just build-ui
 just test-playwright

--- a/specs/104-book-resolution/plan.md
+++ b/specs/104-book-resolution/plan.md
@@ -1,0 +1,52 @@
+# Plan
+
+## Context
+
+The merged decode-to-tree work already has a decoded-tree SPARQL layer in `docs/inspector/src/FFI/RdfShapes.js` and a renderer in `docs/inspector/src/Main.purs`. The current state computes resolved-label and SHACL lenses from `mergedRdfTurtle`, but the decoded-tree lens is still computed from the raw transaction RDF. That prevents selected books from affecting the tree.
+
+## Design
+
+Use the same merged graph already used by the overlay lenses as the decoded-tree input. Extend the decoded-tree queries and row construction only where a row has a generic graph identity to resolve:
+
+- preserve the raw transaction value in `raw`;
+- show `rdfs:label` / RDF type metadata when present;
+- add generic OPTIONAL joins from value nodes, addresses, hashes, datums, redeemers, scripts, and outputs to book-provided labeled entities;
+- keep fallback rows unchanged when the optional joins are absent.
+
+No protocol-specific renderer branch is allowed. Book-specific facts must arrive as RDF triples from `OverlayBook` parsing or blueprint application.
+
+## Slice Breakdown
+
+## Slice 1 - Generic Decoded-Tree Resolution
+
+Owned files:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Tasks:
+
+- Add a failing Playwright regression proving a selected book resolves a decoded-tree row while the unbooked tree keeps raw fallback.
+- Feed the decoded-tree query with merged RDF after selected books are applied.
+- Extend the SPARQL/normalization layer generically enough for address/hash/datum/redeemer/output rows to pick up `rdfs:label` and type metadata from the merged graph.
+- Preserve raw values in the row data and visible fallback behavior.
+- Keep the existing preview subpath test green.
+
+Focused gate:
+
+- `just test-playwright`
+- `just build-ui`
+- `just format-check`
+- `just hlint`
+- `just ui-check`
+
+Commit:
+
+- `feat: resolve decoded tree rows from books`
+- `Tasks: T1041, T1042`
+
+## Finalization
+
+The ticket orchestrator verifies the slice commit, pushes the draft PR, waits for CI, smokes the PR preview under the non-root `/inspector/` path, then drops `gate.sh` only when ready for epic-owner review.

--- a/specs/104-book-resolution/spec.md
+++ b/specs/104-book-resolution/spec.md
@@ -1,0 +1,29 @@
+# Issue 104: Book Resolution In The Decoded Tree
+
+## User Story
+
+As a Cardano transaction investigator, I want imported books that are merged into the transaction RDF graph to resolve opaque decoded-tree nodes, so script hashes, addresses, datum/redeemer data, and related entities become familiar names or typed fields without protocol-specific renderer code.
+
+## Functional Requirements
+
+- FR1: The decoded-structure tree must query the transaction graph after selected overlay/blueprint book triples are merged.
+- FR2: Any tree row whose backing graph entity has `rdfs:label` must surface that label in the row metadata while preserving the raw value.
+- FR3: Address, datum, redeemer, script/hash, policy, and output leaves must remain raw when no loaded book provides matching triples.
+- FR4: Resolution must be generic over RDF triples in the merged graph. The renderer must not hardcode Amaru, SundaeSwap, or other protocol-specific matching rules.
+- FR5: At least one representative book must demonstrate that a previously opaque decoded-tree node resolves after the book is selected and applied.
+- FR6: The browser test suite must include a Playwright regression that loads a book, applies it, and asserts a decoded-tree row displays the resolved familiar value.
+- FR7: Existing subpath routing and refresh behavior must remain covered by Playwright.
+
+## Non-Goals
+
+- Local book persistence, import/export library UX, and catalog backends.
+- Byte-to-node highlighting.
+- Raw-CBOR mode.
+- Protocol-specific renderer branches.
+
+## Acceptance
+
+- Without selected books, the decoded tree shows raw fallback values.
+- With a representative book selected and applied, a previously opaque decoded-tree node shows a familiar label or typed field from merged triples.
+- `just build-ui`, `just format-check`, `just hlint`, `just ui-check`, and `just test-playwright` pass locally.
+- Preview is published and browser-smoked under `/lambdasistemi/cardano-ledger-inspector/pr-<N>/inspector/`.

--- a/specs/104-book-resolution/tasks.md
+++ b/specs/104-book-resolution/tasks.md
@@ -6,8 +6,8 @@
 
 ## Slice 1 - Generic Decoded-Tree Resolution
 
-- [ ] T1041 Add a Playwright RED test that loads a representative book and expects a decoded-tree opaque row to resolve from merged RDF.
-- [ ] T1042 Implement generic decoded-tree book resolution with raw fallback and no protocol-specific renderer logic.
+- [X] T1041 Add a Playwright RED test that loads a representative book and expects a decoded-tree opaque row to resolve from merged RDF.
+- [X] T1042 Implement generic decoded-tree book resolution with raw fallback and no protocol-specific renderer logic.
 
 ## Final Verification
 

--- a/specs/104-book-resolution/tasks.md
+++ b/specs/104-book-resolution/tasks.md
@@ -11,4 +11,4 @@
 
 ## Final Verification
 
-- [ ] T1043 Run local gate, push the branch, verify CI, smoke the preview subpath, and leave the PR draft for epic-owner review.
+- [X] T1043 Run local gate, push the branch, verify CI, smoke the preview subpath, and leave the PR draft for epic-owner review.

--- a/specs/104-book-resolution/tasks.md
+++ b/specs/104-book-resolution/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## Bootstrap
+
+- [X] T1040 Create the worktree, branch, gate, spec, plan, task contract, and draft PR.
+
+## Slice 1 - Generic Decoded-Tree Resolution
+
+- [ ] T1041 Add a Playwright RED test that loads a representative book and expects a decoded-tree opaque row to resolve from merged RDF.
+- [ ] T1042 Implement generic decoded-tree book resolution with raw fallback and no protocol-specific renderer logic.
+
+## Final Verification
+
+- [ ] T1043 Run local gate, push the branch, verify CI, smoke the preview subpath, and leave the PR draft for epic-owner review.


### PR DESCRIPTION
Part of #97. Fixes #104.

## Scope
- Resolve decoded-tree opaque rows from triples in the merged transaction + selected-book RDF graph.
- Preserve raw fallback when no book is selected or no optional book triple matches.
- Prove the behavior with a representative loaded-book Playwright regression and keep preview subpath coverage green.

## Verification
- `./gate.sh` passed locally on the implementation head: format-check, hlint, ui-check, `nix build .#packages.x86_64-linux.tx-inspector-ui`, and 28 Playwright tests.
- GitHub checks are green on final head `06e690ddf62360ae07e576487d172d9ee831d74a`.
- Live preview smoke passed at `https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-105/inspector/`: decoded genuine Conway fixture, imported a pasted Turtle book, applied it, and observed the decoded-tree address row resolve to `Fixture decoded treasury address`.

Draft remains for epic-owner re-verification.
