### PR TITLE
Annotate decoded-tree nodes into local books

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -1133,6 +1133,11 @@ md-icon-button:focus-visible,
   min-width: 104px;
 }
 
+.decoded-tree-annotate {
+  justify-self: start;
+  max-width: 100%;
+}
+
 .decoded-tree-summary,
 .decoded-tree-meta {
   min-width: 0;
@@ -1143,6 +1148,45 @@ md-icon-button:focus-visible,
 
 .decoded-tree-meta {
   font-size: 0.78rem;
+}
+
+.decoded-tree-annotation-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  min-width: 0;
+  border-top: 1px solid var(--border);
+  padding-top: 10px;
+}
+
+.decoded-tree-annotation-form .field-stack,
+.decoded-tree-annotation-form input,
+.decoded-tree-annotation-form select {
+  min-width: 0;
+}
+
+.annotation-book-mode {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.annotation-book-mode legend {
+  flex-basis: 100%;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.annotation-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
 }
 
 .decoded-tree-children {
@@ -1429,6 +1473,7 @@ pre {
 
   .browser-heading,
   .browser-row,
+  .decoded-tree-annotation-form,
   .library-book-heading,
   .library-book-controls,
   .overlay-selection-grid,
@@ -1469,6 +1514,10 @@ pre {
   }
 
   .overlay-actions {
+    display: grid;
+  }
+
+  .annotation-actions {
     display: grid;
   }
 

--- a/docs/inspector/src/FFI/BookStore.js
+++ b/docs/inspector/src/FFI/BookStore.js
@@ -3,6 +3,8 @@ const STORE_KIND = "cardano-ledger-inspector.books.v1";
 const text = (value) =>
   value === null || value === undefined ? "" : String(value);
 
+const literal = (value) => JSON.stringify(text(value));
+
 const invalid = (message) => {
   throw new Error(message);
 };
@@ -91,4 +93,50 @@ export const inspectImpl = (store) => {
     selectedCount: normalized.books.filter((book) => book.selected).length,
     partCount: normalized.books.reduce((total, book) => total + book.parts.length, 0),
   };
+};
+
+const hashText = (raw) => {
+  let hash = 2166136261;
+  for (let i = 0; i < raw.length; i += 1) {
+    hash ^= raw.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const localToken = (value, fallback = "Annotation") => {
+  const token = text(value)
+    .trim()
+    .replace(/[^A-Za-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (token === "") return fallback;
+  return /^[A-Za-z_]/.test(token) ? token : `${fallback}-${token}`;
+};
+
+const turtleType = (value) => {
+  const raw = text(value).trim();
+  if (raw === "") return "";
+  if (/^https?:\/\//.test(raw) || raw.startsWith("urn:")) return `<${raw}>`;
+  if (/^(cardano|rdfs|local):[A-Za-z_][A-Za-z0-9_-]*$/.test(raw)) return raw;
+  return `local:${localToken(raw, "Type")}`;
+};
+
+export const annotationTurtle = ({ label, typeName, predicate, value }) => {
+  const trimmedLabel = text(label).trim();
+  const trimmedPredicate = text(predicate).trim();
+  const trimmedValue = text(value).trim();
+  if (trimmedLabel === "" || trimmedPredicate === "" || trimmedValue === "") return "";
+
+  const subject = `local:annotation-${localToken(trimmedPredicate, "predicate").toLowerCase()}-${hashText(`${trimmedPredicate}\n${trimmedValue}`)}`;
+  const typeObject = turtleType(typeName);
+  const typeLine = typeObject === "" ? "" : `  a ${typeObject} ;\n`;
+
+  return `@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix local: <https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/local#> .
+
+${subject}
+${typeLine}  rdfs:label ${literal(trimmedLabel)} ;
+  ${trimmedPredicate} ${literal(trimmedValue)} .
+`;
 };

--- a/docs/inspector/src/FFI/BookStore.purs
+++ b/docs/inspector/src/FFI/BookStore.purs
@@ -4,6 +4,7 @@ module FFI.BookStore
   , Store
   , envelopeKind
   , inspect
+  , annotationTurtle
   , load
   , parseStore
   , save
@@ -64,6 +65,14 @@ foreign import parseStoreImpl
 foreign import serializeImpl :: Store -> String
 
 foreign import inspectImpl :: Store -> BookStoreInspection
+
+foreign import annotationTurtle
+  :: { label :: String
+     , typeName :: String
+     , predicate :: String
+     , value :: String
+     }
+  -> String
 
 serialize :: Store -> String
 serialize = serializeImpl

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -402,6 +402,8 @@ const treeRow = ({
   raw = "",
   resolvedLabel = "",
   resolvedType = "",
+  annotationPredicate = "",
+  annotationValue = "",
 }) => ({
   id,
   parentId,
@@ -414,6 +416,8 @@ const treeRow = ({
   raw,
   resolvedLabel,
   resolvedType,
+  annotationPredicate,
+  annotationValue,
 });
 
 const addSection = (rows, id, label, order, summary = "") => {
@@ -446,6 +450,8 @@ const appendLeaf = (rows, parentId, depth, order, label, kind, value, extra = {}
       raw: extra.raw || stringValue,
       resolvedLabel: extra.resolvedLabel || "",
       resolvedType: extra.resolvedType || "",
+      annotationPredicate: extra.annotationPredicate || "",
+      annotationValue: extra.annotationValue || "",
     }),
   );
 };
@@ -560,6 +566,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           raw,
           resolvedLabel: resolved.resolvedLabel,
           resolvedType: resolved.resolvedType,
+          annotationPredicate: bindingValue(field.kind) === "hash" ? "cardano:bytesHex" : "",
+          annotationValue: bindingValue(field.kind) === "hash" ? bindingValue(field.raw) : "",
         },
       );
     });
@@ -595,6 +603,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           raw,
           resolvedLabel: resolved.resolvedLabel,
           resolvedType: resolved.resolvedType,
+          annotationPredicate: raw === "" ? "" : "cardano:fromTxOutRef",
+          annotationValue: raw,
         },
       );
     });
@@ -613,6 +623,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         outputValue,
         txOutRefFromUtxoUri(outputValue),
       );
+      const outputTxOutRef = txOutRefFromUtxoUri(outputValue);
       rows.push(
         treeRow({
           id: outputId,
@@ -626,6 +637,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           raw: outputValue,
           resolvedLabel: outputResolved.resolvedLabel,
           resolvedType: outputResolved.resolvedType,
+          annotationPredicate: outputTxOutRef === "" ? "" : "cardano:fromTxOutRef",
+          annotationValue: outputTxOutRef,
         }),
       );
       appendLeaf(rows, outputId, 3, 10, "Index", "integer", outputIndex);
@@ -645,6 +658,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           bindingValue(output.addressBech32),
           bindingValue(output.address),
         ).resolvedType,
+        annotationPredicate: "cardano:bech32",
+        annotationValue: bindingValue(output.addressBech32),
       });
       const datumHash = firstBindingValue(output.datumHashHex, output.datumHash);
       const datumHashResolved = resolvedFrom(
@@ -657,11 +672,15 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", datumHash, {
         resolvedLabel: datumHashResolved.resolvedLabel,
         resolvedType: datumHashResolved.resolvedType,
+        annotationPredicate: "cardano:bytesHex",
+        annotationValue: bindingValue(output.datumHashHex),
       });
       const datumRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(output.datumRaw));
       appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw), {
         resolvedLabel: datumRawResolved.resolvedLabel,
         resolvedType: datumRawResolved.resolvedType,
+        annotationPredicate: "cardano:hasRawBytes",
+        annotationValue: bindingValue(output.datumRaw),
       });
     });
   }
@@ -706,6 +725,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", keyValue, {
         resolvedLabel: keyResolved.resolvedLabel,
         resolvedType: keyResolved.resolvedType,
+        annotationPredicate: "cardano:bytesHex",
+        annotationValue: bindingValue(witness.verificationKeyHex),
       });
       const signatureResolved = resolvedFrom(labelMatches, "", "", bindingValue(witness.signature));
       appendLeaf(rows, witnessId, 3, 20, "Signature", "signature", bindingValue(witness.signature), {
@@ -757,11 +778,15 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", dataHashValue, {
         resolvedLabel: dataHashResolved.resolvedLabel,
         resolvedType: dataHashResolved.resolvedType,
+        annotationPredicate: "cardano:bytesHex",
+        annotationValue: bindingValue(redeemer.dataHashHex),
       });
       const dataRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(redeemer.dataRaw));
       appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw), {
         resolvedLabel: dataRawResolved.resolvedLabel,
         resolvedType: dataRawResolved.resolvedType,
+        annotationPredicate: "cardano:hasRawBytes",
+        annotationValue: bindingValue(redeemer.dataRaw),
       });
       appendLeaf(rows, redeemerId, 3, 50, "Memory units", "ex-units", bindingValue(redeemer.memory));
       appendLeaf(rows, redeemerId, 3, 60, "CPU units", "ex-units", bindingValue(redeemer.cpu));
@@ -802,7 +827,10 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       );
       appendLeaf(rows, metaId, 3, 10, "Metadata label", "integer", bindingValue(meta.label));
       appendLeaf(rows, metaId, 3, 20, "Text", "text", bindingValue(meta.text));
-      appendLeaf(rows, metaId, 3, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw));
+      appendLeaf(rows, metaId, 3, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw), {
+        annotationPredicate: "cardano:hasRawBytes",
+        annotationValue: bindingValue(meta.raw),
+      });
     });
   }
 

--- a/docs/inspector/src/FFI/RdfShapes.purs
+++ b/docs/inspector/src/FFI/RdfShapes.purs
@@ -32,6 +32,8 @@ type DecodedTreeRow =
   , raw :: String
   , resolvedLabel :: String
   , resolvedType :: String
+  , annotationPredicate :: String
+  , annotationValue :: String
   }
 
 type TransactionOutputRow =

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -124,6 +124,7 @@ type State =
   , shaclConformance :: Maybe ShaclConformance
   , books :: Array BookStore.Book
   , bookNameEdits :: Array BookNameEdit
+  , annotationDraft :: Maybe AnnotationDraft
   , libraryInput :: String
   , libraryUrl :: String
   , libraryError :: Maybe String
@@ -176,6 +177,16 @@ type BookNameEdit =
   , name :: String
   }
 
+type AnnotationDraft =
+  { rowId :: String
+  , label :: String
+  , typeName :: String
+  , mode :: String
+  , bookId :: String
+  , newBookName :: String
+  , error :: Maybe String
+  }
+
 type InitialKeys =
   { bf :: String
   , koios :: String
@@ -210,6 +221,14 @@ data Action
   | SaveLibraryBookName String
   | DeleteLibraryBook String
   | ApplySelectedBooks
+  | StartDecodedTreeAnnotation RdfShapes.DecodedTreeRow
+  | SetDecodedTreeAnnotationLabel String
+  | SetDecodedTreeAnnotationType String
+  | SetDecodedTreeAnnotationMode String
+  | SetDecodedTreeAnnotationBookId String
+  | SetDecodedTreeAnnotationNewBookName String
+  | CancelDecodedTreeAnnotation
+  | SaveDecodedTreeAnnotation RdfShapes.DecodedTreeRow
   | Decode
   | Copy
   | CopyValue String String
@@ -250,6 +269,7 @@ inspectorComponent initial =
         , shaclConformance: Nothing
         , books: initial.books
         , bookNameEdits: bookNameEditsFromBooks initial.books
+        , annotationDraft: Nothing
         , libraryInput: ""
         , libraryUrl: ""
         , libraryError: Nothing
@@ -770,6 +790,7 @@ inspectorComponent initial =
                   HH.div
                     [ classNames [ "decoded-tree-meta" ] ]
                     [ HH.text metaText ]
+              , renderDecodedTreeAnnotation state row
               ]
           ]
       ] <> if expanded && hasChildren then
@@ -778,6 +799,145 @@ inspectorComponent initial =
             (renderDecodedTreeRows state row.id rows)
         ]
       else []
+
+  renderDecodedTreeAnnotation state row =
+    case state.annotationDraft of
+      Just draft | draft.rowId == row.id ->
+        renderDecodedTreeAnnotationDraft state row draft
+      _ ->
+        if row.resolvedLabel == "" && row.annotationPredicate /= "" && row.annotationValue /= "" then
+          HH.element (HH.ElemName "md-outlined-button")
+            [ classNames [ "inline-action", "decoded-tree-annotate" ]
+            , HH.attr (HH.AttrName "role") "button"
+            , mdControl "inline"
+            , HE.onClick (\_ -> StartDecodedTreeAnnotation row)
+            ]
+            [ HH.text "Label this as..." ]
+        else
+          HH.text ""
+
+  renderDecodedTreeAnnotationDraft state row draft =
+    let
+      localBooks = selectedLocalBooks state
+      hasLocalBooks = not (Array.null localBooks)
+      saveDisabled =
+        String.trim draft.label == ""
+          || row.annotationPredicate == ""
+          || row.annotationValue == ""
+          || (draft.mode == "new" && String.trim draft.newBookName == "")
+          || (draft.mode == "existing" && draft.bookId == "")
+    in
+      HH.div
+        [ classNames [ "decoded-tree-annotation-form" ] ]
+        [ HH.label
+            [ classNames [ "field-stack" ] ]
+            [ HH.span
+                [ classNames [ "field-label" ] ]
+                [ HH.text "Label" ]
+            , HH.input
+                [ HP.type_ HP.InputText
+                , HP.value draft.label
+                , HH.attr (HH.AttrName "aria-label") "Label"
+                , HE.onValueInput SetDecodedTreeAnnotationLabel
+                ]
+            ]
+        , HH.label
+            [ classNames [ "field-stack" ] ]
+            [ HH.span
+                [ classNames [ "field-label" ] ]
+                [ HH.text "Optional type" ]
+            , HH.input
+                [ HP.type_ HP.InputText
+                , HP.value draft.typeName
+                , HH.attr (HH.AttrName "aria-label") "Optional type"
+                , HE.onValueInput SetDecodedTreeAnnotationType
+                ]
+            ]
+        , HH.fieldset
+            [ classNames [ "annotation-book-mode" ] ]
+            [ HH.legend_ [ HH.text "Book" ]
+            , HH.label
+                [ choiceClass (draft.mode == "new") ]
+                [ HH.input
+                    [ HP.type_ HP.InputRadio
+                    , HP.name ("annotation-book-mode-" <> row.id)
+                    , HP.checked (draft.mode == "new")
+                    , HE.onChange (\_ -> SetDecodedTreeAnnotationMode "new")
+                    ]
+                , HH.span
+                    [ classNames [ "choice-title" ] ]
+                    [ HH.text "Create new local book" ]
+                ]
+            , HH.label
+                [ choiceClass (draft.mode == "existing") ]
+                [ HH.input
+                    [ HP.type_ HP.InputRadio
+                    , HP.name ("annotation-book-mode-" <> row.id)
+                    , HP.checked (draft.mode == "existing")
+                    , HP.disabled (not hasLocalBooks)
+                    , HE.onChange (\_ -> SetDecodedTreeAnnotationMode "existing")
+                    ]
+                , HH.span
+                    [ classNames [ "choice-title" ] ]
+                    [ HH.text "Append to existing book" ]
+                ]
+            ]
+        , if draft.mode == "existing" then
+            HH.label
+              [ classNames [ "field-stack" ] ]
+              [ HH.span
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "Target book" ]
+              , HH.select
+                  [ HP.value draft.bookId
+                  , HH.attr (HH.AttrName "aria-label") "Target book"
+                  , HE.onValueChange SetDecodedTreeAnnotationBookId
+                  ]
+                  (map renderAnnotationBookOption localBooks)
+              ]
+          else
+            HH.label
+              [ classNames [ "field-stack" ] ]
+              [ HH.span
+                  [ classNames [ "field-label" ] ]
+                  [ HH.text "New book name" ]
+              , HH.input
+                  [ HP.type_ HP.InputText
+                  , HP.value draft.newBookName
+                  , HH.attr (HH.AttrName "aria-label") "New book name"
+                  , HE.onValueInput SetDecodedTreeAnnotationNewBookName
+                  ]
+              ]
+        , case draft.error of
+            Just err ->
+              HH.div
+                [ classNames [ "sparql-lens-error" ] ]
+                [ HH.text err ]
+            Nothing -> HH.text ""
+        , HH.div
+            [ classNames [ "annotation-actions" ] ]
+            [ HH.element (HH.ElemName "md-filled-button")
+                [ classNames [ "primary-action" ]
+                , HH.attr (HH.AttrName "role") "button"
+                , mdControl "primary"
+                , HP.disabled saveDisabled
+                , HE.onClick (\_ -> SaveDecodedTreeAnnotation row)
+                ]
+                [ HH.text "Save label" ]
+            , HH.element (HH.ElemName "md-outlined-button")
+                [ classNames [ "secondary-action" ]
+                , HH.attr (HH.AttrName "role") "button"
+                , mdControl "secondary"
+                , HE.onClick (\_ -> CancelDecodedTreeAnnotation)
+                ]
+                [ HH.text "Cancel" ]
+            ]
+        ]
+
+  renderAnnotationBookOption book =
+    HH.option
+      [ HP.value book.id ]
+      [ HH.text book.name ]
 
   renderProvider state =
     HH.element (HH.ElemName "md-elevated-card")
@@ -1319,6 +1479,9 @@ inspectorComponent initial =
 
   selectedBooks state =
     BookStore.selectedBooks { kind: BookStore.envelopeKind, books: state.books }
+
+  selectedLocalBooks state =
+    Array.filter (\book -> book.selected && not book.seed) state.books
 
   selectedBookParts state =
     Array.concatMap _.parts (selectedBooks state)
@@ -2301,6 +2464,47 @@ inspectorComponent initial =
                           rdfResult.stderr
                       )
                 }
+    StartDecodedTreeAnnotation row -> do
+      st <- H.get
+      let
+        localBooks = selectedLocalBooks st
+        firstBookId =
+          case Array.head localBooks of
+            Just book -> book.id
+            Nothing   -> ""
+        mode =
+          if Array.null localBooks then "new" else "existing"
+      H.modify_
+        _
+          { annotationDraft =
+              Just
+                { rowId: row.id
+                , label: ""
+                , typeName: ""
+                , mode
+                , bookId: firstBookId
+                , newBookName: "Inline fixture annotations"
+                , error: Nothing
+                }
+          }
+    SetDecodedTreeAnnotationLabel value ->
+      updateAnnotationDraft \draft -> draft { label = value, error = Nothing }
+    SetDecodedTreeAnnotationType value ->
+      updateAnnotationDraft \draft -> draft { typeName = value, error = Nothing }
+    SetDecodedTreeAnnotationMode mode ->
+      updateAnnotationDraft \draft -> draft { mode = mode, error = Nothing }
+    SetDecodedTreeAnnotationBookId bookId ->
+      updateAnnotationDraft \draft -> draft { bookId = bookId, error = Nothing }
+    SetDecodedTreeAnnotationNewBookName value ->
+      updateAnnotationDraft \draft -> draft { newBookName = value, error = Nothing }
+    CancelDecodedTreeAnnotation ->
+      H.modify_ _ { annotationDraft = Nothing }
+    SaveDecodedTreeAnnotation row -> do
+      st <- H.get
+      case st.annotationDraft of
+        Nothing -> pure unit
+        Just draft ->
+          saveDecodedTreeAnnotation st row draft
     Decode -> do
       st <- H.get
       H.modify_
@@ -2323,6 +2527,7 @@ inspectorComponent initial =
           , browserNodes = []
           , expandedPaths = []
           , decodedTreeExpanded = []
+          , annotationDraft = Nothing
           , copied = false
           , copiedPath = Nothing
           , browserPath = "[]"
@@ -2486,6 +2691,99 @@ inspectorComponent initial =
                 else
                   expandPath rowId st.decodedTreeExpanded
             }
+
+  updateAnnotationDraft update =
+    H.modify_ \st -> st { annotationDraft = map update st.annotationDraft }
+
+  annotationError messageText =
+    updateAnnotationDraft \draft -> draft { error = Just messageText }
+
+  saveDecodedTreeAnnotation st row draft = do
+    let
+      label = String.trim draft.label
+      typeName = String.trim draft.typeName
+      targetName = String.trim draft.newBookName
+      turtle =
+        BookStore.annotationTurtle
+          { label
+          , typeName
+          , predicate: row.annotationPredicate
+          , value: row.annotationValue
+          }
+    if label == "" then
+      annotationError "Label is required."
+    else if row.annotationPredicate == "" || row.annotationValue == "" || turtle == "" then
+      annotationError "This decoded row does not expose a supported annotation identifier."
+    else if draft.mode == "existing" then
+      case Array.find (\book -> book.id == draft.bookId && book.selected && not book.seed) st.books of
+        Nothing ->
+          annotationError "Choose a selected local book."
+        Just targetBook -> do
+          let combined = appendTurtle targetBook.raw turtle
+          parsed <- liftEffect (OverlayBook.parse combined)
+          case parsed of
+            Left err ->
+              annotationError ("Generated Turtle did not parse: " <> err)
+            Right parsedBook -> do
+              let
+                books =
+                  updateBook
+                    targetBook.id
+                    ( \book ->
+                        book
+                          { raw = combined
+                          , parts = parsedBook.parts
+                          , turtle = parsedBook.turtle
+                          }
+                    )
+                    st.books
+              persistAnnotationBooks books
+    else if targetName == "" then
+      annotationError "New book name is required."
+    else do
+      parsed <- liftEffect (OverlayBook.parse turtle)
+      case parsed of
+        Left err ->
+          annotationError ("Generated Turtle did not parse: " <> err)
+        Right parsedBook -> do
+          let
+            newBook =
+              { id: nextLocalBookId st.books
+              , name: targetName
+              , source: "annotation"
+              , raw: turtle
+              , parts: parsedBook.parts
+              , turtle: parsedBook.turtle
+              , selected: true
+              , seed: false
+              }
+            books = Array.snoc st.books newBook
+          persistAnnotationBooks books
+
+  appendTurtle existing fragment =
+    if String.trim existing == "" then
+      String.trim fragment <> "\n"
+    else
+      String.trim existing <> "\n\n" <> String.trim fragment <> "\n"
+
+  persistAnnotationBooks books = do
+    let edits = bookNameEditsFromBooks books
+    liftEffect (saveBooks books)
+    st <- H.get
+    let stWithBooks = st { books = books, bookNameEdits = edits, annotationDraft = Nothing, libraryError = Nothing }
+    resolvedLabelsLens <- resolvedLabelsLensForState stWithBooks
+    decodedTreeLens <- decodedTreeLensForState stWithBooks
+    shaclConformance <- shaclConformanceForState stWithBooks
+    H.modify_
+      _
+        { books = books
+        , bookNameEdits = edits
+        , annotationDraft = Nothing
+        , libraryError = Nothing
+        , resolvedLabelsLens = resolvedLabelsLens
+        , decodedTreeLens = decodedTreeLens
+        , shaclConformance = shaclConformance
+        }
 
   importLibraryBookText raw = do
     let input = String.trim raw

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1250,6 +1250,114 @@ fixture:selectedLibraryAddress
   await expect(page.getByRole("button", { name: "Load Cardano RDF SHACL shapes" })).toHaveCount(0);
 });
 
+test("labels decoded-tree nodes into local books and resolves immediately", async ({
+  page,
+}) => {
+  await decodeFixtureAt(page, "/inspect", conwayMainnetFixturePath);
+
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+
+  const addressRows = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Address" });
+  await expect(addressRows.first()).toBeVisible();
+  expect(await addressRows.count()).toBeGreaterThan(1);
+
+  const firstAddressRow = addressRows.first();
+  const rawAddress = await firstAddressRow.locator(".decoded-tree-summary").innerText();
+  expect(rawAddress).toMatch(/^[0-9a-f]+$/);
+
+  const inlineLabel = "Inline annotated fixture address";
+  await expect(firstAddressRow).not.toContainText(inlineLabel);
+  await firstAddressRow
+    .getByRole("button", { name: "Label this as..." })
+    .click();
+  await firstAddressRow.getByLabel("Label").fill(inlineLabel);
+  await firstAddressRow.getByLabel("Optional type").fill("FixtureAddress");
+  await firstAddressRow.getByRole("radio", { name: "Create new local book" }).check();
+  await firstAddressRow.getByLabel("New book name").fill("Inline fixture annotations");
+  await firstAddressRow.getByRole("button", { name: "Save label" }).click();
+
+  await expect(firstAddressRow).toContainText(inlineLabel);
+
+  const datumHashRow = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Datum hash" })
+    .first();
+  const appendedLabel = "Existing-book annotated fixture datum hash";
+  await datumHashRow
+    .getByRole("button", { name: "Label this as..." })
+    .click();
+  await datumHashRow.getByLabel("Label").fill(appendedLabel);
+  await datumHashRow.getByRole("radio", { name: "Append to existing book" }).check();
+  await datumHashRow.getByLabel("Target book").selectOption({
+    label: "Inline fixture annotations",
+  });
+  await datumHashRow.getByRole("button", { name: "Save label" }).click();
+
+  await expect(datumHashRow).toContainText(appendedLabel);
+
+  const rawStore = await page.evaluate(
+    (key) => window.localStorage.getItem(key),
+    localBookStoreKey,
+  );
+  const store = JSON.parse(rawStore);
+  const generatedBook = store.books.find(
+    (book) => book.name === "Inline fixture annotations",
+  );
+  expect(generatedBook).toBeTruthy();
+  expect(generatedBook.seed).toBe(false);
+  expect(generatedBook.selected).toBe(true);
+  expect(generatedBook.raw).toContain("@prefix cardano:");
+  expect(generatedBook.raw).toContain("@prefix rdfs:");
+  expect(generatedBook.raw).toContain("@prefix local:");
+  expect(generatedBook.raw).toContain("cardano:bech32");
+  expect(generatedBook.raw).toContain(inlineLabel);
+  expect(generatedBook.raw).toContain(appendedLabel);
+
+  await page.getByRole("banner").getByRole("link", { name: "Library" }).click();
+  await expect(page).toHaveURL(/\/library$/);
+  const [selectedDownload] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: "Export selected books" }).click(),
+  ]);
+  const selectedPath = await selectedDownload.path();
+  expect(selectedPath).not.toBeNull();
+  const selectedJson = await readFile(selectedPath, "utf8");
+
+  const browser = page.context().browser();
+  expect(browser).not.toBeNull();
+  const cleanContext = await browser.newContext();
+  try {
+    const cleanPage = await cleanContext.newPage();
+    await cleanPage.goto("/library");
+    await cleanPage.getByLabel("Book store JSON file").setInputFiles({
+      name: "generated-annotations.json",
+      mimeType: "application/json",
+      buffer: Buffer.from(selectedJson),
+    });
+    await expect(
+      cleanPage
+        .locator(".library-book", { hasText: "Inline fixture annotations" })
+        .getByRole("checkbox", { name: "Select Inline fixture annotations" }),
+    ).toBeChecked();
+
+    await decodeFixtureAt(cleanPage, "/inspect", conwayMainnetFixturePath);
+    const cleanDecodedPanel = cleanPage.locator(".decoded-structure-panel");
+    await cleanDecodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+    await expect(
+      cleanDecodedPanel
+        .locator(".decoded-tree-row")
+        .filter({ hasText: "Address" })
+        .filter({ hasText: inlineLabel })
+        .first(),
+    ).toContainText(inlineLabel);
+  } finally {
+    await cleanContext.close();
+  }
+});
+
 test("selected library blueprint book applies typed RDF fields", async ({
   page,
 }) => {

--- a/gate.sh
+++ b/gate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git diff --check
+nix build .#packages.x86_64-linux.tx-inspector-ui
+nix develop --quiet -c just format-check
+nix develop --quiet -c just hlint
+nix develop --quiet -c just test-playwright

--- a/specs/109-annotate-tree-node/plan.md
+++ b/specs/109-annotate-tree-node/plan.md
@@ -1,0 +1,43 @@
+# Plan
+
+## Context
+
+#102 renders the decoded RDF tree from `docs/inspector/src/FFI/RdfShapes.js`. #104 resolves decoded-tree rows by matching local book labels against identifier predicates such as `cardano:bech32`, `cardano:bytesHex`, `cardano:fromTxOutRef`, and `cardano:hasRawBytes`. #106 stores parsed books in `localStorage`, exports/imports that store, and wires selected books into the inspect page's merge path.
+
+#109 should use those merged paths rather than inventing new resolution rules. The only new behavior is authoring a valid local book entry from a concrete decoded-tree node.
+
+## Design
+
+- Extend decoded-tree row data enough for annotation targets. The UI needs the display row plus the canonical identifier predicate/value to emit Turtle. Prefer deriving this in `RdfShapes.js`, where the SPARQL bindings already know bech32, bytes hex, UTxO references, and raw bytes.
+- Keep predicate inference generic and data-driven by row kind and available RDF bindings. Do not branch on a protocol, contract, address, or fixture-specific value.
+- Add a small book-authoring helper around the existing store shape. It should produce a parseable overlay Turtle fragment and append it to either:
+  - a chosen existing local book, or
+  - a new selected local book created inline.
+- The generated book source remains ordinary Turtle. Existing export/import and selected-book merge logic should not need a parallel path.
+- Use `ApplySelectedBooks`-equivalent lens recomputation after saving so the selected book merge is visible immediately.
+- Keep the UI compact inside each decoded-tree row. A button opens inline controls/dialog state; it must not push rows into unstable widths on mobile.
+
+## Slice 1 - Decoded-Tree Annotation Flow
+
+Implement the full vertical path in one bisect-safe commit.
+
+Owned files:
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/src/FFI/BookStore.js`
+- `docs/inspector/src/FFI/BookStore.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Expected behavior:
+- A supported opaque decoded-tree row exposes `Label this as...`.
+- The flow can append to an existing selected book and can create a new selected local book inline.
+- Generated Turtle parses via the existing overlay book parser and carries a label plus inferred identifier predicate.
+- Saving updates `localStorage`, visible book summary data, and decoded-tree resolution immediately.
+- Export/import round-trip preserves the annotation.
+- Subpath navigation/deep-link/refresh coverage remains green.
+
+## Finalization
+
+After the slice lands, run the full gate locally. The PR stays draft until CI, preview publication, and browser smoke at the preview URL are verified.

--- a/specs/109-annotate-tree-node/spec.md
+++ b/specs/109-annotate-tree-node/spec.md
@@ -1,0 +1,44 @@
+# Annotate Decoded-Tree Nodes Into Local Books
+
+## User Story
+
+As a transaction inspector user who recognizes an opaque decoded-tree value, I want to label that node in the app so that the label is saved into a local book, applied immediately, and exportable without hand-writing Turtle.
+
+## Scope
+
+- Add a per-node `Label this as...` affordance to opaque decoded-tree leaves.
+- Let the user enter a label, choose an existing local book, or create a new local book inline.
+- Infer the RDF identifier predicate from the decoded-tree row kind, using the predicates already matched by `docs/inspector/src/FFI/RdfShapes.js`.
+- Append guaranteed-valid Turtle to the target local book with `rdfs:label`, the inferred `cardano:` identifier predicate, and optional `a <type>`.
+- Save through the existing #106 local book store and keep export/import round-trip behavior intact.
+- Recompute the RDF lenses immediately so the annotated node renders as resolved without requiring a manual `Apply selected books` click or reload.
+
+## Functional Requirements
+
+- FR-001 Opaque decoded-tree rows for supported node kinds expose `Label this as...`; already-resolved rows and non-identifier scalar rows do not need the affordance.
+- FR-002 Supported identifier mappings include at least:
+  - address rows -> `cardano:bech32` using the bech32 address from RDF, while preserving the current raw hex display fallback.
+  - script-hash, policy, datum hash, verification-key-like hash rows -> `cardano:bytesHex`.
+  - input/UTxO reference rows -> `cardano:fromTxOutRef`.
+  - datum raw bytes rows -> `cardano:hasRawBytes`.
+- FR-003 The annotation flow rejects empty labels and unsupported/empty identifiers before saving.
+- FR-004 The generated Turtle contains stable prefixes for `cardano:`, `rdfs:`, and a local namespace, and parses through the existing overlay-book parser.
+- FR-005 Appending to an existing book preserves its prior source text, parts, selected state, and export shape.
+- FR-006 Creating a new book inline creates a selected, non-seed local book in the same store envelope used by `/library`.
+- FR-007 After save, the decoded tree re-runs against the merged graph and the annotated node renders the new label immediately.
+- FR-008 Export selected/all books and JSON import retain the generated annotation.
+- FR-009 Existing `/inspect`, `/settings`, and `/library` routes continue to navigate, refresh, and deep-link under a non-root deployment prefix.
+
+## Non-Goals
+
+- Standalone manual book authoring forms in `/library`; that is a separate #108 child.
+- User-authored arbitrary Turtle editing in the annotation dialog.
+- New RDF vocabulary, resolver semantics, or protocol-specific labels.
+- Backend persistence or remote book publishing.
+
+## Acceptance
+
+- A Playwright flow decodes a genuine fixture, labels an opaque decoded-tree address row, observes the row resolve immediately, exports the book, imports it into a clean context, and observes the label resolve again.
+- The flow also proves inline new-book creation or selected-book append, whichever is not covered by the first path.
+- The non-root subpath Playwright coverage still asserts navigation, refresh, and fixture decode under the preview-style prefix.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`, format check, hlint, and Playwright are green locally.

--- a/specs/109-annotate-tree-node/tasks.md
+++ b/specs/109-annotate-tree-node/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## Bootstrap
+
+- [X] T109-B Create the #109 worktree, branch, gate, spec, plan, task contract, and draft PR.
+
+## Slice 1 - Decoded-Tree Annotation Flow
+
+- [ ] T109-S1 Add Playwright RED coverage for labeling an opaque decoded-tree node from a genuine fixture.
+- [ ] T109-S1 Infer annotation predicates and values from decoded-tree row data without protocol-specific branching.
+- [ ] T109-S1 Add the per-row `Label this as...` flow for label, optional type, existing-book selection, and inline new-book creation.
+- [ ] T109-S1 Append parseable Turtle to the chosen/new local book through the #106 store shape.
+- [ ] T109-S1 Recompute merged RDF lenses immediately so the row resolves without manual reload or apply.
+- [ ] T109-S1 Prove export/import round-trip preserves the generated book annotation.
+- [ ] T109-S1 Keep the non-root subpath `/inspect`, `/settings`, and `/library` route spec green.
+- [ ] T109-S1 Run `./gate.sh` and commit `feat(inspector): label decoded tree nodes into books`.
+
+## Finalization - Orchestrator Owned
+
+- [ ] T109-F1 Review the slice diff, commit message, and task trailer; amend this task file into the accepted slice commit.
+- [ ] T109-F2 Push the branch and verify CI is green.
+- [ ] T109-F3 Verify the PR preview under `/inspector/`: label a node, observe immediate resolution, and export/import the generated book.
+- [ ] T109-F4 Update PR body with delivered behavior and proof, then leave the PR draft for epic-owner review.

--- a/specs/109-annotate-tree-node/tasks.md
+++ b/specs/109-annotate-tree-node/tasks.md
@@ -6,18 +6,18 @@
 
 ## Slice 1 - Decoded-Tree Annotation Flow
 
-- [ ] T109-S1 Add Playwright RED coverage for labeling an opaque decoded-tree node from a genuine fixture.
-- [ ] T109-S1 Infer annotation predicates and values from decoded-tree row data without protocol-specific branching.
-- [ ] T109-S1 Add the per-row `Label this as...` flow for label, optional type, existing-book selection, and inline new-book creation.
-- [ ] T109-S1 Append parseable Turtle to the chosen/new local book through the #106 store shape.
-- [ ] T109-S1 Recompute merged RDF lenses immediately so the row resolves without manual reload or apply.
-- [ ] T109-S1 Prove export/import round-trip preserves the generated book annotation.
-- [ ] T109-S1 Keep the non-root subpath `/inspect`, `/settings`, and `/library` route spec green.
-- [ ] T109-S1 Run `./gate.sh` and commit `feat(inspector): label decoded tree nodes into books`.
+- [X] T109-S1 Add Playwright RED coverage for labeling an opaque decoded-tree node from a genuine fixture.
+- [X] T109-S1 Infer annotation predicates and values from decoded-tree row data without protocol-specific branching.
+- [X] T109-S1 Add the per-row `Label this as...` flow for label, optional type, existing-book selection, and inline new-book creation.
+- [X] T109-S1 Append parseable Turtle to the chosen/new local book through the #106 store shape.
+- [X] T109-S1 Recompute merged RDF lenses immediately so the row resolves without manual reload or apply.
+- [X] T109-S1 Prove export/import round-trip preserves the generated book annotation.
+- [X] T109-S1 Keep the non-root subpath `/inspect`, `/settings`, and `/library` route spec green.
+- [X] T109-S1 Run `./gate.sh` and commit `feat(inspector): label decoded tree nodes into books`.
 
 ## Finalization - Orchestrator Owned
 
-- [ ] T109-F1 Review the slice diff, commit message, and task trailer; amend this task file into the accepted slice commit.
+- [X] T109-F1 Review the slice diff, commit message, and task trailer; amend this task file into the accepted slice commit.
 - [ ] T109-F2 Push the branch and verify CI is green.
 - [ ] T109-F3 Verify the PR preview under `/inspector/`: label a node, observe immediate resolution, and export/import the generated book.
 - [ ] T109-F4 Update PR body with delivered behavior and proof, then leave the PR draft for epic-owner review.


### PR DESCRIPTION
Closes #109
Part of #108

## Delivered
- Adds a per-node `Label this as...` flow on supported opaque decoded-tree rows.
- Infers book identifier predicates from row data (`cardano:bech32`, `cardano:bytesHex`, `cardano:fromTxOutRef`, `cardano:hasRawBytes`).
- Appends parseable generated Turtle to a selected existing local book or an inline-created selected local book.
- Recomputes merged RDF lenses immediately so the annotated row resolves without reload or manual apply.
- Preserves selected/all book export and clean-context import round-trip behavior.

## Verification
- Local `./gate.sh` passed after the accepted slice commit: format-check, hlint, `nix build .#packages.x86_64-linux.tx-inspector-ui`, and Playwright: 34 passed.
- GitHub CI is green on `6ec870f`.
- Preview job passed.
- Live preview browser smoke passed at https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-110/inspector/: decoded genuine fixture, labeled an address node, observed immediate resolution, exported selected books, imported into a clean context, decoded again, and observed the imported label resolve.

Draft for epic-owner re-verification.