### PR TITLE
Tabbed inspect result with tree-primary layout

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -836,9 +836,74 @@ md-icon-button:focus-visible,
   align-items: center;
 }
 
+.result-panel {
+  display: grid;
+  gap: 14px;
+  overflow: hidden;
+}
+
 .inspection-summary {
   display: grid;
-  gap: 16px;
+  gap: 12px;
+}
+
+.result-summary {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--md-sys-color-surface-container-low);
+  padding: 12px;
+}
+
+.result-summary-title {
+  display: grid;
+  gap: 0.18rem;
+}
+
+.result-summary-title h3,
+.result-summary-title p {
+  margin: 0;
+}
+
+.summary-identity-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.result-tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.result-tab {
+  appearance: none;
+  border: 0;
+  border-bottom: 3px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  padding: 0.62rem 0.78rem 0.5rem;
+  font-weight: 750;
+}
+
+.result-tab:hover,
+.result-tab:focus-visible {
+  color: var(--accent-strong);
+}
+
+.result-tab.is-selected {
+  border-bottom-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.result-tab-panel {
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+  max-height: min(76vh, 820px);
+  overflow: auto;
+  padding-right: 2px;
 }
 
 .identity-panel,

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -102,6 +102,10 @@ data Mode = ByHash | ByHex
 
 derive instance eqMode :: Eq Mode
 
+data ResultTab = StructureTab | WitnessTab | ValidationTab | GraphRdfTab
+
+derive instance eqResultTab :: Eq ResultTab
+
 type State =
   { provider :: Provider
   , blockfrostKey :: String
@@ -112,6 +116,7 @@ type State =
   , txHash :: String
   , txHex :: String
   , result :: Maybe InspectorResult
+  , resultTab :: ResultTab
   , txCbor :: Maybe String
   , operationArgs :: String
   , browser :: Maybe Json.Browser
@@ -240,6 +245,7 @@ data Action
   | CopyValue String String
   | BrowseJson String
   | ToggleDecodedTree String
+  | SelectResultTab ResultTab
   | Navigate Route MouseEvent
   | ToggleTheme
 
@@ -260,6 +266,7 @@ inspectorComponent initial =
         , txHash: ""
         , txHex: ""
         , result: Nothing
+        , resultTab: StructureTab
         , txCbor: Nothing
         , operationArgs: "{}"
         , browser: Nothing
@@ -345,9 +352,7 @@ inspectorComponent initial =
               ]
           , HH.div
               [ classNames [ "workspace-right" ] ]
-              [ renderResult state
-              , renderDecodedStructure state
-              ]
+              [ renderResult state ]
           ]
       ]
 
@@ -1268,17 +1273,17 @@ inspectorComponent initial =
                         else HH.text ""
                     ]
                 ]
-              <> renderIntentMaybe state
               <> ( if r.exitOk && summary.valid
-                     then renderInspection summary
+                     then [ renderResultSummary state summary ]
                      else []
                  )
-              <> renderIdentificationMaybe state
-              <> renderWitnessPlanMaybe state
-              <> renderValidationMaybe state
-              <> renderRdfMaybe state r.exitOk
-              <> renderBrowserMaybe state r.exitOk
-              <> [ renderRawJson r.stdout ]
+              <> ( if r.exitOk then
+                     [ renderResultTabs state
+                     , renderSelectedResultTab state r.stdout
+                     ]
+                   else
+                     [ renderRawJson r.stdout ]
+                 )
               <> renderStderr r.stderr
               )
 
@@ -1328,6 +1333,137 @@ inspectorComponent initial =
         if exitOk && browser.valid then [ renderBrowser state browser ]
         else []
       Nothing -> []
+
+  renderResultSummary state summary =
+    HH.div
+      [ classNames [ "inspection-summary", "result-summary" ] ]
+      ( [ renderResultSummaryTitle state summary
+        , HH.div
+            [ classNames [ "metric-grid" ] ]
+            (map renderMetric summary.metrics)
+        ]
+          <> renderSummaryIdentity state
+          <> renderSummaryWarnings state
+      )
+
+  renderResultSummaryTitle state summary =
+    case state.identification of
+      Just identification | identification.valid ->
+        HH.div
+          [ classNames [ "result-summary-title" ] ]
+          [ HH.h3_ [ HH.text identification.title ]
+          , HH.p_ [ HH.text identification.subtitle ]
+          ]
+      _ -> case state.intent of
+        Just intent | intent.valid ->
+          HH.div
+            [ classNames [ "result-summary-title" ] ]
+            [ HH.h3_ [ HH.text intent.title ]
+            , HH.p_ [ HH.text intent.subtitle ]
+            ]
+        _ ->
+          HH.div
+            [ classNames [ "result-summary-title" ] ]
+            [ HH.h3_ [ HH.text summary.title ] ]
+
+  renderSummaryIdentity state =
+    case state.identification of
+      Just identification ->
+        if identification.valid then
+          [ HH.div
+              [ classNames [ "summary-identity-grid" ] ]
+              (map (renderIdentityRow state) identification.primary)
+          ]
+        else []
+      Nothing -> []
+
+  renderSummaryWarnings state =
+    [ renderIntentWarnings state.intent
+    , renderWitnessPlanWarnings state.witnessPlan
+    , renderValidationWarnings state.validation
+    ]
+
+  renderIntentWarnings intent =
+    case intent of
+      Just value | value.valid -> renderWitnessWarnings value.warnings
+      _ -> HH.text ""
+
+  renderWitnessPlanWarnings witnessPlan =
+    case witnessPlan of
+      Just value | value.valid -> renderWitnessWarnings value.warnings
+      _ -> HH.text ""
+
+  renderValidationWarnings validation =
+    case validation of
+      Just value | value.valid -> renderWitnessWarnings value.warnings
+      _ -> HH.text ""
+
+  renderResultTabs state =
+    HH.div
+      [ classNames [ "result-tab-bar" ]
+      , HH.attr (HH.AttrName "role") "tablist"
+      , HH.attr (HH.AttrName "aria-label") "Inspect result views"
+      ]
+      (map (renderResultTabButton state.resultTab) resultTabs)
+
+  resultTabs =
+    [ StructureTab, WitnessTab, ValidationTab, GraphRdfTab ]
+
+  renderResultTabButton selectedTab tab =
+    let
+      selected = selectedTab == tab
+    in
+      HH.button
+        [ classNames
+            ( if selected then
+                [ "result-tab", "is-selected" ]
+              else
+                [ "result-tab" ]
+            )
+        , HH.attr (HH.AttrName "role") "tab"
+        , HH.attr (HH.AttrName "aria-selected") (if selected then "true" else "false")
+        , HE.onClick (\_ -> SelectResultTab tab)
+        ]
+        [ HH.text (resultTabLabel tab) ]
+
+  renderSelectedResultTab state stdout =
+    HH.div
+      [ classNames [ "result-tab-panel" ]
+      , HH.attr (HH.AttrName "role") "tabpanel"
+      , HH.attr (HH.AttrName "aria-label") (resultTabLabel state.resultTab)
+      ]
+      ( case state.resultTab of
+          StructureTab ->
+            [ renderDecodedStructure state ]
+          WitnessTab ->
+            renderIntentMaybe state
+              <> renderWitnessPlanMaybe state
+          ValidationTab ->
+            renderValidationMaybe state
+              <> renderShaclConformanceMaybe state.shaclConformance
+          GraphRdfTab ->
+            renderGraphRdfMaybe state
+              <> renderBrowserMaybe state true
+              <> [ renderRawJson stdout ]
+      )
+
+  renderGraphRdfMaybe state =
+    case state.rdf of
+      Just rdf ->
+        if rdf.valid then
+          [ renderRdfGraph rdf, renderOverlayBooks state ]
+            <> renderResolvedLabelsLensMaybe state.resolvedLabelsLens
+            <> renderTypedFieldsLensMaybe state.typedFieldsLens
+            <> renderSparqlLensMaybe state.sparqlLens
+        else []
+      Nothing -> []
+
+  resultTabLabel tab =
+    case tab of
+      StructureTab -> "Structure"
+      WitnessTab -> "Witness"
+      ValidationTab -> "Validation"
+      GraphRdfTab -> "Graph / RDF"
 
   renderInspection summary =
     [ HH.div
@@ -2644,6 +2780,7 @@ inspectorComponent initial =
         _
           { running = true
           , result = Nothing
+          , resultTab = StructureTab
           , txCbor = Nothing
           , operationArgs = "{}"
           , browser = Nothing
@@ -2824,6 +2961,8 @@ inspectorComponent initial =
                 else
                   expandPath rowId st.decodedTreeExpanded
             }
+    SelectResultTab tab ->
+      H.modify_ _ { resultTab = tab }
 
   updateAnnotationDraft update =
     H.modify_ \st -> st { annotationDraft = map update st.annotationDraft }

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -197,13 +197,83 @@ async function decodeFixtureAt(page, route, txFixturePath = fixturePath) {
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  const resultPanel = page.locator(".result-panel");
   await expect(
-    page.getByRole("heading", { name: "Conway transaction identity" }),
+    resultPanel.getByRole("tab", { name: "Structure" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(
+    resultPanel
+      .getByRole("tabpanel", { name: "Structure" })
+      .locator(".decoded-tree-row", { hasText: "Transaction" }),
   ).toBeVisible();
 }
 
 async function decodeFixture(page, txFixturePath = fixturePath) {
   await decodeFixtureAt(page, "/", txFixturePath);
+}
+
+async function expectTabbedInspectResult(page) {
+  const resultPanel = page.locator(".result-panel");
+  await expect(resultPanel).toBeVisible();
+
+  const tabs = resultPanel.getByRole("tablist", { name: "Inspect result views" });
+  await expect(tabs).toBeVisible();
+
+  const structureTab = tabs.getByRole("tab", { name: "Structure" });
+  await expect(structureTab).toHaveAttribute("aria-selected", "true");
+
+  const structurePanel = resultPanel.getByRole("tabpanel", { name: "Structure" });
+  await expect(structurePanel).toBeVisible();
+  await expect(
+    structurePanel.getByRole("heading", { name: "Decoded structure" }),
+  ).toBeVisible();
+  await expect(
+    structurePanel.locator(".decoded-tree-row", { hasText: "Transaction" }),
+  ).toBeVisible();
+
+  const documentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
+  const viewportHeight = await page.evaluate(() => window.innerHeight);
+  expect(documentHeight).toBeLessThan(viewportHeight * 4);
+
+  await tabs.getByRole("tab", { name: "Witness" }).click();
+  const witnessPanel = resultPanel.getByRole("tabpanel", { name: "Witness" });
+  await expect(witnessPanel.getByRole("heading", { name: /Intent|Witness plan/ })).toBeVisible();
+  await expect(witnessPanel.getByRole("heading", { name: "Witness plan" })).toBeVisible();
+
+  await tabs.getByRole("tab", { name: "Validation" }).click();
+  const validationPanel = resultPanel.getByRole("tabpanel", { name: "Validation" });
+  await expect(validationPanel.locator(".validation-panel")).toBeVisible();
+  await expect(
+    validationPanel.getByRole("heading", { name: "RDF SHACL conformance" }),
+  ).toBeVisible();
+
+  await tabs.getByRole("tab", { name: "Graph / RDF" }).click();
+  const graphPanel = resultPanel.getByRole("tabpanel", { name: "Graph / RDF" });
+  await expect(
+    graphPanel.getByRole("heading", { name: "Transaction RDF graph" }),
+  ).toBeVisible();
+  await expect(graphPanel.getByRole("heading", { name: "Selected books" })).toBeVisible();
+  await expect(
+    graphPanel.getByRole("heading", { name: "SPARQL lens: resolved labels" }),
+  ).toBeVisible();
+  await expect(
+    graphPanel.getByRole("heading", { name: "SPARQL lens: typed contract fields" }),
+  ).toBeVisible();
+  await expect(
+    graphPanel.getByRole("heading", { name: "SPARQL lens: transaction outputs" }),
+  ).toBeVisible();
+  await expect(
+    graphPanel.getByRole("heading", { name: "Transaction browser" }),
+  ).toBeVisible();
+  await expect(graphPanel.getByText("Raw JSON", { exact: true })).toBeVisible();
+}
+
+async function selectResultTab(page, name) {
+  const resultPanel = page.locator(".result-panel");
+  await resultPanel.getByRole("tab", { name }).click();
+  const panel = resultPanel.getByRole("tabpanel", { name });
+  await expect(panel).toBeVisible();
+  return panel;
 }
 
 async function configureChainData(page, options = {}) {
@@ -810,16 +880,21 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
 
   const inputPanel = page.locator(".input-panel");
   const resultPanel = page.locator(".result-panel");
-  const identityPanel = page.locator(".identity-panel").first();
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await selectResultTab(page, "Validation");
   const validationPanel = page.locator(".validation-panel");
+  await selectResultTab(page, "Graph / RDF");
   const rdfPanel = page.locator(".rdf-panel");
   const lensPanel = page.locator(".sparql-lens-panel").first();
 
   await expect(page.locator(".provider-panel")).toHaveCount(0);
   await expect(inputPanel).toHaveAttribute("data-md3-surface", "input");
   await expect(resultPanel).toHaveAttribute("data-md3-surface", "result");
-  await expect(identityPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await selectResultTab(page, "Structure");
+  await expect(decodedPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await selectResultTab(page, "Validation");
   await expect(validationPanel).toHaveAttribute("data-md3-surface", "decoded");
+  await selectResultTab(page, "Graph / RDF");
   await expect(rdfPanel).toHaveAttribute("data-md3-surface", "decoded");
   await expect(lensPanel).toHaveAttribute("data-md3-surface", "decoded");
 
@@ -858,7 +933,7 @@ test("inspect keeps chain-data settings compact and gives input/results the work
   await expect(inputPanel).toBeVisible();
   await expect(leftPane.getByRole("heading", { name: "Books" })).toBeVisible();
   await expect(resultPanel.getByRole("heading", { name: "Decoded JSON" })).toBeVisible();
-  await expect(rightPane.getByRole("heading", { name: "Decoded structure" })).toBeVisible();
+  await expect(rightPane.locator(".decoded-structure-panel")).toHaveCount(0);
 
   const workspaceBox = await page.locator(".workspace").boundingBox();
   const leftBox = await leftPane.boundingBox();
@@ -946,20 +1021,10 @@ test("decodes a Conway transaction and exposes compact identity values", async (
 
   await expect(page.getByText("Transaction ID", { exact: true })).toBeVisible();
   await expect(page.getByText("Body hash", { exact: true })).toBeVisible();
-  await expect(page.getByText("Witnesses", { exact: true })).toBeVisible();
-  await expect(
-    page
-      .locator(".identity-panel:not(.witness-plan):not(.validation-panel)")
-      .getByText("Redeemers", { exact: true }),
-  ).toBeVisible();
+  await expect(page.locator(".identity-panel:not(.witness-plan):not(.validation-panel)")).toHaveCount(0);
 
-  await expect(
-    page
-      .locator(".identity-panel:not(.witness-plan):not(.validation-panel)")
-      .getByRole("button"),
-  ).toHaveCount(0);
-
-  const txIdRow = page.locator(".identity-row", { hasText: "Transaction ID" });
+  const summaryIdentity = page.locator(".summary-identity-grid");
+  const txIdRow = summaryIdentity.locator(".identity-row", { hasText: "Transaction ID" });
   const txId = await txIdRow.locator("code").innerText();
   await txIdRow.locator("code").click();
   await expect(txIdRow).toHaveClass(/is-copied/);
@@ -967,7 +1032,7 @@ test("decodes a Conway transaction and exposes compact identity values", async (
     .poll(() => page.evaluate(() => navigator.clipboard.readText()))
     .toBe(txId);
 
-  const bodyHashRow = page.locator(".identity-row", { hasText: "Body hash" });
+  const bodyHashRow = summaryIdentity.locator(".identity-row", { hasText: "Body hash" });
   const bodyHash = await bodyHashRow.locator("code").innerText();
   await bodyHashRow.locator("code").click();
   await expect(bodyHashRow).toHaveClass(/is-copied/);
@@ -979,6 +1044,7 @@ test("decodes a Conway transaction and exposes compact identity values", async (
 test("renders the transaction RDF graph after decode", async ({ page }) => {
   await decodeFixture(page);
 
+  await selectResultTab(page, "Graph / RDF");
   const rdfPanel = page.locator(".rdf-panel");
   await expect(
     rdfPanel.getByRole("heading", { name: "Transaction RDF graph" }),
@@ -1057,6 +1123,7 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     decodedPanel.locator(".decoded-tree-row", { hasText: "Metadata label" }).first(),
   ).toBeVisible();
 
+  await selectResultTab(page, "Graph / RDF");
   const rdfPanel = page.locator(".rdf-panel");
   await expect(
     rdfPanel.getByRole("heading", { name: "Transaction RDF graph" }),
@@ -1142,6 +1209,16 @@ test("preview subpath decodes genuine Conway fixture into RDF tree", async ({
   });
 });
 
+test("inspect result is tree-primary tabs after genuine decode", async ({ page }) => {
+  await decodeFixtureAt(page, "/inspect", conwayMainnetFixturePath);
+  await expectTabbedInspectResult(page);
+
+  await withPrefixedInspectorSite(async (baseUrl) => {
+    await decodeFixtureAt(page, `${baseUrl}inspect/`, conwayMainnetFixturePath);
+    await expectTabbedInspectResult(page);
+  });
+});
+
 test("selected library overlay book parts produce deterministic Turtle", async ({
   page,
 }) => {
@@ -1157,6 +1234,7 @@ test("selected library overlay book parts produce deterministic Turtle", async (
 
   await decodeFixtureAt(page, "/inspect");
 
+  await selectResultTab(page, "Graph / RDF");
   const overlayPanel = page.locator(".overlay-book-panel");
   await expect(
     overlayPanel.getByRole("heading", { name: "Selected books" }),
@@ -1185,6 +1263,7 @@ test("selected library overlay book parts produce deterministic Turtle", async (
     .getByRole("checkbox", { name: "Select Amaru treasury 2026 overlay" })
     .uncheck();
   await openInspectViaShell(page);
+  await selectResultTab(page, "Graph / RDF");
   await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
 
   await expect(selectedTurtle).not.toHaveValue(/Amaru Core Development treasury/);
@@ -1216,6 +1295,7 @@ test("resolves decoded-tree address rows from selected Turtle overlay books", as
   expect(rawAddress).toMatch(/^[0-9a-f]+$/);
   expect(rawAddress.length).toBeGreaterThanOrEqual(24);
 
+  await selectResultTab(page, "Graph / RDF");
   const turtleText = await page.locator(".rdf-panel .rdf-turtle").innerText();
   const address = await page.evaluate((graph) => {
     const result = globalThis.rdfShapes.query(
@@ -1237,6 +1317,7 @@ test("resolves decoded-tree address rows from selected Turtle overlay books", as
   expect(address).toMatch(/^addr1/);
 
   const resolvedLabel = "Fixture decoded treasury address";
+  await selectResultTab(page, "Structure");
   await expect(decodedPanel.getByText(resolvedLabel, { exact: true })).toHaveCount(0);
   await expect(addressRow).toContainText(rawAddress);
 
@@ -1260,9 +1341,11 @@ fixture:decodedTreasuryAddress
   ).toBeVisible();
 
   await openInspectViaShell(page);
+  await selectResultTab(page, "Graph / RDF");
   const overlayPanel = page.locator(".overlay-book-panel");
   await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
 
+  await selectResultTab(page, "Structure");
   const resolvedAddressRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Address" })
@@ -1281,6 +1364,7 @@ test("inspect resolves decoded-tree address rows from selected library books", a
 }) => {
   await decodeFixtureAt(page, "/inspect", conwayMainnetFixturePath);
 
+  await selectResultTab(page, "Graph / RDF");
   const firstTurtleText = await page.locator(".rdf-panel .rdf-turtle").innerText();
   const address = await page.evaluate((graph) => {
     const result = globalThis.rdfShapes.query(
@@ -1334,6 +1418,7 @@ fixture:selectedLibraryAddress
     page.getByRole("heading", { name: "Conway transaction identity" }),
   ).toBeVisible();
 
+  await selectResultTab(page, "Graph / RDF");
   const overlayPanel = page.locator(".overlay-book-panel");
   const applySelectedBooks = overlayPanel.getByRole("button", {
     name: "Apply selected books",
@@ -1342,6 +1427,7 @@ fixture:selectedLibraryAddress
     await applySelectedBooks.click();
   }
 
+  await selectResultTab(page, "Structure");
   const decodedPanel = page.locator(".decoded-structure-panel");
   await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
   const resolvedAddressRow = decodedPanel
@@ -1478,6 +1564,7 @@ test("selected library blueprint book applies typed RDF fields", async ({
 
   await decodeFixtureAt(page, "/inspect", signingIntentFixturePath);
 
+  await selectResultTab(page, "Graph / RDF");
   const rdfPanel = page.locator(".rdf-panel");
   const turtle = rdfPanel.locator(".rdf-turtle");
   const typedFieldsPanel = page.locator(".typed-fields-panel");
@@ -1492,6 +1579,7 @@ test("selected library blueprint book applies typed RDF fields", async ({
     .getByRole("checkbox", { name: "Select SundaeSwap V3 blueprint" })
     .check();
   await openInspectViaShell(page);
+  await selectResultTab(page, "Graph / RDF");
   const overlayPanel = page.locator(".overlay-book-panel");
   await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
 
@@ -1529,6 +1617,7 @@ test("selected library blueprint book applies typed RDF fields", async ({
     .getByRole("checkbox", { name: "Select SundaeSwap V3 blueprint" })
     .uncheck();
   await openInspectViaShell(page);
+  await selectResultTab(page, "Graph / RDF");
   await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
 
   await expect(turtle).not.toContainText(":OrderDatum_max_protocol_fee 1280000");
@@ -1561,6 +1650,7 @@ test("lists selected library SHACL shapes as selected inspect parts", async ({ p
   const validateType = await page.evaluate(() => typeof globalThis.rdfShapes.validate);
   expect(validateType).toBe("function");
 
+  await selectResultTab(page, "Graph / RDF");
   const overlayPanel = page.locator(".overlay-book-panel");
   await expect(
     overlayPanel.locator(".book-part-row", {
@@ -1575,6 +1665,7 @@ test("renders selected library SHACL conformance for bundled Cardano RDF shapes"
 }) => {
   await decodeFixture(page);
 
+  await selectResultTab(page, "Validation");
   const conformancePanel = page.locator(".shacl-conformance-panel");
   await expect(
     conformancePanel.getByRole("heading", { name: "RDF SHACL conformance" }),
@@ -1610,6 +1701,7 @@ test("renders non-conforming SHACL violations for pasted shapes", async ({
 
   await decodeFixtureAt(page, "/inspect");
 
+  await selectResultTab(page, "Validation");
   const conformancePanel = page.locator(".shacl-conformance-panel");
   await expect(
     conformancePanel.getByRole("heading", { name: "RDF SHACL conformance" }),
@@ -1640,29 +1732,30 @@ test("keeps signer-critical intent visible in the first viewport", async ({ page
   await page.setViewportSize({ width: 1280, height: 720 });
   await decodeFixture(page, signingIntentFixturePath);
 
+  await selectResultTab(page, "Witness");
   const intentPanel = page.locator(".intent-panel");
   const intentMetric = (label, value) =>
     intentPanel
       .locator(".metric-card", { hasText: label })
       .getByText(value, { exact: true });
   await expect(intentPanel.getByRole("heading", { name: "Signing summary" })).toBeVisible();
-  await expectInFirstViewport(intentPanel.getByText("Swap ADA<->USDM", { exact: true }));
-  await expectInFirstViewport(
-    intentPanel.getByText("Required to pay Antithesis as vendor"),
-  );
-  await expectInFirstViewport(intentMetric("Signer net ADA", "unknown"));
-  await expectInFirstViewport(intentMetric("Missing signers", "2 missing required signers"));
-  await expectInFirstViewport(intentMetric("Redeemers", "2 redeemers"));
-  await expectInFirstViewport(intentMetric("Withdrawals", "1 withdrawal"));
-  await expectInFirstViewport(intentMetric("Mint/burn", "No mint/burn"));
+  await expect(intentPanel.getByText("Swap ADA<->USDM", { exact: true })).toBeVisible();
+  await expect(intentPanel.getByText("Required to pay Antithesis as vendor")).toBeVisible();
+  await expect(intentMetric("Signer net ADA", "unknown")).toBeVisible();
+  await expect(intentMetric("Missing signers", "2 missing required signers")).toBeVisible();
+  await expect(intentMetric("Redeemers", "2 redeemers")).toBeVisible();
+  await expect(intentMetric("Withdrawals", "1 withdrawal")).toBeVisible();
+  await expect(intentMetric("Mint/burn", "No mint/burn")).toBeVisible();
 });
 
 test("shows transaction-derived witness plan values", async ({ page }) => {
   await decodeFixture(page);
 
-  await expect(page.getByRole("heading", { name: "Witness plan" })).toBeVisible();
-  await expect(page.getByText("Transaction-only witness plan")).toBeVisible();
-  await expect(page.getByText("Present vkey witnesses")).toBeVisible();
+  await selectResultTab(page, "Witness");
+  const witnessPanel = page.locator(".witness-plan");
+  await expect(witnessPanel.getByRole("heading", { name: "Witness plan" })).toBeVisible();
+  await expect(witnessPanel.getByText("Transaction-only witness plan")).toBeVisible();
+  await expect(witnessPanel.getByText("Present vkey witnesses")).toBeVisible();
 
   const redeemerRow = page
     .locator(".witness-plan .witness-row")
@@ -1678,6 +1771,7 @@ test("shows transaction-derived witness plan values", async ({ page }) => {
 test("surfaces ledger validation diagnostics", async ({ page }) => {
   await decodeFixture(page);
 
+  await selectResultTab(page, "Validation");
   const validationPanel = page.locator(".validation-panel");
   await expect(
     validationPanel.getByRole("heading", { name: "Ledger validation" }),
@@ -1738,6 +1832,7 @@ test("keeps copy controls off non-value missing context rows", async ({ page }) 
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  await selectResultTab(page, "Validation");
   const missingContextSection = page
     .locator(".validation-panel .witness-section")
     .filter({ hasText: "Missing context" });
@@ -1817,12 +1912,17 @@ test("passes producer transaction CBOR into witness planning", async ({
   await expect(
     page.getByText("Producer transaction CBOR resolved every visible transaction input"),
   ).toBeVisible();
-  await expect(page.getByText("Producer txs")).toBeVisible();
+  await selectResultTab(page, "Validation");
+  await expect(
+    page.locator(".validation-panel .metric-card", { hasText: "Resolved inputs" }),
+  ).toBeVisible();
+  await selectResultTab(page, "Witness");
   await expect(
     page.locator(".witness-plan .identity-section-title", {
       hasText: "Resolved inputs",
     }),
   ).toBeVisible();
+  await selectResultTab(page, "Validation");
   await expect(
     page
       .locator(".validation-panel .identity-section-title", { hasText: "Resolved inputs" })
@@ -1838,6 +1938,7 @@ test("passes producer transaction CBOR into witness planning", async ({
   expect(protocolParameterRequests).toBe(1);
   expect(utxoRequests).toBe(0);
 
+  await selectResultTab(page, "Witness");
   const resolvedRow = page
     .locator(".witness-plan .witness-row")
     .filter({ hasText: "resolved" })
@@ -1907,6 +2008,7 @@ test("passes producer transaction CBOR into RDF resolved value flow", async ({
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  await selectResultTab(page, "Graph / RDF");
   const turtle = page.locator(".rdf-panel .rdf-turtle");
   await expect(turtle).toContainText("cardano:resolvedTo");
   await expect(turtle).toContainText("resolvedInput");
@@ -1952,6 +2054,7 @@ test("surfaces hard provider context resolution failures", async ({
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  await selectResultTab(page, "Validation");
   const providerResolution = page
     .locator(".validation-panel .witness-section")
     .filter({ hasText: "Provider resolution" });
@@ -2013,7 +2116,10 @@ test("uses the same tx CBOR provider boundary for Koios", async ({ page }) => {
   await expect(
     page.getByText("Producer transaction CBOR resolved every visible transaction input"),
   ).toBeVisible();
-  await expect(page.getByText("Producer txs")).toBeVisible();
+  await selectResultTab(page, "Validation");
+  await expect(
+    page.locator(".validation-panel .metric-card", { hasText: "Resolved inputs" }),
+  ).toBeVisible();
   await expect(
     page
       .locator(".validation-panel .metric-card", { hasText: "Status" })
@@ -2040,6 +2146,7 @@ test("opens browser rows in place without losing identity context", async ({
 }) => {
   await decodeFixture(page);
 
+  await selectResultTab(page, "Graph / RDF");
   const inputsRow = page
     .locator(".browser-row")
     .filter({ has: page.locator("code", { hasText: "inputs" }) })
@@ -2053,11 +2160,9 @@ test("opens browser rows in place without losing identity context", async ({
 
   await expect(page.locator(".browser-children").first()).toBeVisible();
   await expect(
-    page.locator(".identity-panel:not(.witness-plan):not(.validation-panel)"),
-  ).toBeVisible();
-  await expect(
     page.getByRole("heading", { name: "Conway transaction identity" }),
   ).toBeVisible();
+  await expect(page.locator(".summary-identity-grid")).toBeVisible();
 });
 
 test("keeps decoded transaction layout within the viewport", async ({ page }) => {

--- a/gate.sh
+++ b/gate.sh
@@ -1,33 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mode="${1:-quick}"
-
-nix develop --quiet -c sh -c 'cd docs/inspector && spago build'
+just format-check
+just hlint
 nix build .#packages.x86_64-linux.tx-inspector-ui
-
-if [ -d packages/purescript-rdf-editor/src ]; then
-  if rg -n 'FFI\.BookStore|FFI\.OverlayBook|Routing|module Main|cardano-ledger-inspector|BookStore|OverlayBook|BookStore\.Book' packages/purescript-rdf-editor; then
-    echo "purescript-rdf-editor contains inspector-coupled imports or vocabulary" >&2
-    exit 1
-  fi
-fi
-
-if [ "$mode" = "final" ]; then
-  test -f docs/inspector/SECURITY.md
-  rg -i 'CodeMirror|signing|key|pin|supply-chain|WASM' docs/inspector/SECURITY.md >/dev/null
-  test -d packages/purescript-rdf-editor/src
-  jq -e '
-    .dependencies
-    | to_entries
-    | map(select(.key | test("^(@codemirror/|codemirror$)")))
-    | length > 0
-  ' docs/inspector/package.json >/dev/null
-  jq -e '
-    .dependencies
-    | to_entries
-    | map(select((.key | test("^(@codemirror/|codemirror$)")) and (.value | test("^[0-9]"))))
-    | length > 0
-  ' docs/inspector/package.json >/dev/null
-  just test-playwright
-fi
+just test-playwright

--- a/specs/114-tabbed-inspect-result/plan.md
+++ b/specs/114-tabbed-inspect-result/plan.md
@@ -1,0 +1,38 @@
+# Plan
+
+## Scope
+
+This is a PureScript/Halogen presentation reorganization in the inspector workbench. The ledger operation calls and all decode/resolution data shapes stay unchanged.
+
+## Implementation Shape
+
+- Extend inspector UI state with a result tab enum and tab-switch action.
+- Move `renderDecodedStructure` into the result panel instead of rendering it after the legacy result card.
+- Replace the stacked result body with:
+  - a compact summary card using existing `tx.inspect`, `tx.intent`, `tx.identify`, `tx.witness.plan`, and `tx.validate` derived data;
+  - a tab bar with `Structure`, `Witness`, `Validation`, and `Graph / RDF`;
+  - a tab body that renders only the active tab.
+- Keep left-pane active chain data, input mode, and Books panel untouched.
+- Update CSS for compact result layout, tab controls, bounded tab panels, and scrollable advanced/RDF surfaces.
+- Update Playwright helpers and assertions that currently depend on the old standalone identity panel.
+
+## Slices
+
+### Slice 1: Tabbed Tree-Primary Result
+
+Driver owns the behavior and tests in one vertical slice:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Expected proof:
+
+- A RED Playwright assertion fails against the current stacked layout.
+- GREEN implements tabs and layout.
+- Focused Playwright checks pass for the result layout and subpath route coverage.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui` passes or the driver records a reproducible infrastructure failure.
+
+### Finalization
+
+The ticket orchestrator reviews the implementation commit, marks `tasks.md` in the same commit by amend, pushes, creates/updates the draft PR, and keeps the PR draft until local acceptance, CI, and preview smoke are verified.

--- a/specs/114-tabbed-inspect-result/spec.md
+++ b/specs/114-tabbed-inspect-result/spec.md
@@ -1,0 +1,25 @@
+# Issue 114: Tabbed Inspect Result
+
+## User Story
+
+As a transaction inspector user, I want a decoded transaction result to open on a compact summary and the decoded structure tree, so I can inspect the transaction shape first without scrolling through every legacy diagnostic panel.
+
+## Requirements
+
+- The inspect result shows a top summary card with intent/title, fee, input/output counts, and warnings when available.
+- The result uses tabs, with `Structure` as the default selected tab.
+- The `Structure` tab contains the decoded-structure tree and is visible immediately after decoding a genuine Conway fixture.
+- Legacy panels remain reachable through tabs instead of being stacked in one long page:
+  - `Witness`: signing/intent summary and witness plan.
+  - `Validation`: ledger validation and SHACL conformance.
+  - `Graph / RDF`: transaction Turtle, selected books overlay, SPARQL lenses, transaction browser, and raw JSON.
+- Conway identity is not rendered as a standalone full panel above the tree; its key facts are folded into the summary and the structure tree.
+- The Books panel and active chain-data summary stay in the left pane.
+- No transaction decoding, provider, book, resolution, validation, or route logic changes are in scope.
+
+## Acceptance
+
+- Decoding `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex` lands on the summary and `Structure` tab by default.
+- Playwright asserts the tab bar is present, `Structure` is selected by default, the decoded tree is visible, other legacy sections are reachable through their tabs, and document height stays below a small multiple of the viewport.
+- Existing `/inspect`, `/settings`, and `/library` navigation works under a non-root preview subpath, including refresh and deep links.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`, format/lint gates, and Playwright pass before the PR is marked complete.

--- a/specs/114-tabbed-inspect-result/tasks.md
+++ b/specs/114-tabbed-inspect-result/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## Slice 1 - Tabbed Tree-Primary Result
+
+- [ ] T114-S1 Add focused Playwright RED coverage for default `Structure` tab, bounded result height, tab reachability, and subpath decode.
+- [ ] T114-S1 Implement tab state/actions and render result as summary plus tabbed panels with decoded structure as the default.
+- [ ] T114-S1 Update CSS so the result lands compactly and advanced panels scroll inside their tab instead of stacking the page.
+- [ ] T114-S1 Run focused Playwright checks and `nix build .#packages.x86_64-linux.tx-inspector-ui`.
+- [ ] T114-S1 Commit one bisect-safe slice with the required `Tasks: T114-S1` trailer.
+
+## Finalization
+
+- [ ] T114-F1 Orchestrator review: verify diff scope, commit trailer, local gate, and task amendment.
+- [ ] T114-F2 Push branch and open/update draft PR linked to #114 and #113.
+- [ ] T114-F3 Verify CI and preview smoke before reporting COMPLETE.

--- a/specs/114-tabbed-inspect-result/tasks.md
+++ b/specs/114-tabbed-inspect-result/tasks.md
@@ -2,11 +2,11 @@
 
 ## Slice 1 - Tabbed Tree-Primary Result
 
-- [ ] T114-S1 Add focused Playwright RED coverage for default `Structure` tab, bounded result height, tab reachability, and subpath decode.
-- [ ] T114-S1 Implement tab state/actions and render result as summary plus tabbed panels with decoded structure as the default.
-- [ ] T114-S1 Update CSS so the result lands compactly and advanced panels scroll inside their tab instead of stacking the page.
-- [ ] T114-S1 Run focused Playwright checks and `nix build .#packages.x86_64-linux.tx-inspector-ui`.
-- [ ] T114-S1 Commit one bisect-safe slice with the required `Tasks: T114-S1` trailer.
+- [X] T114-S1 Add focused Playwright RED coverage for default `Structure` tab, bounded result height, tab reachability, and subpath decode.
+- [X] T114-S1 Implement tab state/actions and render result as summary plus tabbed panels with decoded structure as the default.
+- [X] T114-S1 Update CSS so the result lands compactly and advanced panels scroll inside their tab instead of stacking the page.
+- [X] T114-S1 Run focused Playwright checks and `nix build .#packages.x86_64-linux.tx-inspector-ui`.
+- [X] T114-S1 Commit one bisect-safe slice with the required `Tasks: T114-S1` trailer.
 
 ## Finalization
 

--- a/specs/114-tabbed-inspect-result/tasks.md
+++ b/specs/114-tabbed-inspect-result/tasks.md
@@ -10,6 +10,6 @@
 
 ## Finalization
 
-- [ ] T114-F1 Orchestrator review: verify diff scope, commit trailer, local gate, and task amendment.
-- [ ] T114-F2 Push branch and open/update draft PR linked to #114 and #113.
+- [X] T114-F1 Orchestrator review: verify diff scope, commit trailer, local gate, and task amendment.
+- [X] T114-F2 Push branch and open/update draft PR linked to #114 and #113.
 - [ ] T114-F3 Verify CI and preview smoke before reporting COMPLETE.


### PR DESCRIPTION
## Summary
- Restructure the inspect result into a compact summary plus tabs.
- Make Structure the default tab and move the decoded-structure tree into the primary result surface.
- Move legacy witness, validation, SHACL, RDF, SPARQL, browser, and raw JSON panels behind tabs.
- Keep active chain data and Books in the left pane.

Closes #114
Part of #113

## Verification
- RED Playwright coverage failed on the old layout: missing Inspect result views tablist.
- `nix build .#packages.x86_64-linux.tx-inspector-ui` passed.
- Focused Playwright tabbed-result test passed.
- `docs/inspector/tests/tx-identify.spec.mjs` passed: 36 passed.
- `./gate.sh` passed at `ec4a641` (format-check, hlint, UI build, Playwright).
- GitHub CI passed at `b6921af` (Build Gate, format, hlint, Playwright, OpenAPI, ledger smokes, Extism conformance).

## Preview
- PR preview passed and published.
- Browser smoke passed at `https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-115/inspector/` using `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`.
- Smoke evidence: Structure tab selected by default, decoded tree visible, Graph/RDF tab reachable, document height `2061` with viewport `900`.
