### PR TITLE
Make inspect look like CQuisitor

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -1,20 +1,20 @@
 :root {
   color-scheme: light dark;
-  --md-sys-color-primary: #006a70;
+  --md-sys-color-primary: #2f80cf;
   --md-sys-color-on-primary: #ffffff;
-  --md-sys-color-primary-container: #b8eef2;
-  --md-sys-color-on-primary-container: #002022;
-  --md-sys-color-surface: #fffdf8;
+  --md-sys-color-primary-container: #d9eaff;
+  --md-sys-color-on-primary-container: #143a5f;
+  --md-sys-color-surface: #ffffff;
   --md-sys-color-surface-container-low: #ffffff;
-  --md-sys-color-surface-container: #f0f4f1;
-  --md-sys-color-surface-container-high: #e6ece8;
-  --md-sys-color-on-surface: #1b1d1b;
-  --md-sys-color-surface-variant: #dce6e2;
-  --md-sys-color-on-surface-variant: #48514e;
-  --md-sys-color-outline: #707a76;
-  --md-sys-color-outline-variant: #c0cbc6;
-  --md-sys-color-background: #f6f8f4;
-  --md-sys-color-on-background: #1b1d1b;
+  --md-sys-color-surface-container: #f4f8fc;
+  --md-sys-color-surface-container-high: #e9f1f8;
+  --md-sys-color-on-surface: #203044;
+  --md-sys-color-surface-variant: #d9e5ef;
+  --md-sys-color-on-surface-variant: #65758a;
+  --md-sys-color-outline: #9baabc;
+  --md-sys-color-outline-variant: #d4dee9;
+  --md-sys-color-background: #eaf2f9;
+  --md-sys-color-on-background: #203044;
   --md-sys-color-error: #b3261e;
   --md-sys-color-error-container: #ffdad6;
   --md-sys-color-on-error-container: #410002;
@@ -37,8 +37,8 @@
   --danger-soft: var(--md-sys-color-error-container);
   --warning: var(--md-sys-color-warning);
   --warning-soft: var(--md-sys-color-warning-container);
-  --shadow: 0 14px 34px rgba(23, 33, 47, 0.08);
-  --app-radius: 8px;
+  --shadow: none;
+  --app-radius: 7px;
   font-family:
     "Roboto Flex", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
@@ -52,21 +52,21 @@
 
 :root[data-theme="dark"] {
   color-scheme: dark;
-  --md-sys-color-primary: #78dce2;
-  --md-sys-color-on-primary: #00363a;
-  --md-sys-color-primary-container: #004f54;
-  --md-sys-color-on-primary-container: #9cf0f5;
-  --md-sys-color-surface: #181c19;
-  --md-sys-color-surface-container-low: #1f2421;
-  --md-sys-color-surface-container: #252b27;
-  --md-sys-color-surface-container-high: #303833;
-  --md-sys-color-on-surface: #e2e9e4;
-  --md-sys-color-surface-variant: #3f4945;
-  --md-sys-color-on-surface-variant: #c0cbc6;
-  --md-sys-color-outline: #8a948f;
-  --md-sys-color-outline-variant: #3f4945;
-  --md-sys-color-background: #111512;
-  --md-sys-color-on-background: #e2e9e4;
+  --md-sys-color-primary: #8fc8ff;
+  --md-sys-color-on-primary: #102a43;
+  --md-sys-color-primary-container: #233f5e;
+  --md-sys-color-on-primary-container: #d9eaff;
+  --md-sys-color-surface: #151b22;
+  --md-sys-color-surface-container-low: #1b222b;
+  --md-sys-color-surface-container: #202936;
+  --md-sys-color-surface-container-high: #2a3542;
+  --md-sys-color-on-surface: #e5edf6;
+  --md-sys-color-surface-variant: #344252;
+  --md-sys-color-on-surface-variant: #bcc9d7;
+  --md-sys-color-outline: #7e8da0;
+  --md-sys-color-outline-variant: #3a4656;
+  --md-sys-color-background: #101821;
+  --md-sys-color-on-background: #e5edf6;
   --md-sys-color-error: #ffb4ab;
   --md-sys-color-error-container: #93000a;
   --md-sys-color-on-error-container: #ffdad6;
@@ -78,7 +78,7 @@
   --danger-soft: var(--md-sys-color-error-container);
   --warning: var(--md-sys-color-warning);
   --warning-soft: var(--md-sys-color-warning-container);
-  --shadow: 0 20px 55px rgba(0, 0, 0, 0.35);
+  --shadow: none;
 }
 
 * {
@@ -157,37 +157,40 @@ code {
 }
 
 .page-frame {
-  width: min(100% - 32px, 1180px);
+  width: min(100% - 16px, 1424px);
   margin-inline: auto;
 }
 
 .site-header {
-  background: color-mix(in srgb, var(--surface) 92%, transparent);
+  background: var(--md-sys-color-surface-container-high);
   border-bottom: 1px solid var(--border);
 }
 
 .topbar {
-  min-height: 64px;
+  min-height: 51px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .brand {
   display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
+  align-items: baseline;
+  gap: 0.55rem;
+  min-width: 0;
 }
 
 .brand strong {
+  color: var(--text);
   font-size: 1rem;
+  font-weight: 500;
 }
 
 .brand span,
 .site-footer {
   color: var(--muted);
-  font-size: 0.88rem;
+  font-size: 0.78rem;
 }
 
 .topbar-nav {
@@ -195,35 +198,42 @@ code {
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 2px;
 }
 
 .topbar-nav-link,
 .topbar-theme {
-  min-height: 40px;
+  min-height: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border);
-  border-radius: var(--app-radius);
-  background: var(--surface);
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
   color: var(--text);
 }
 
 .topbar-nav-link {
-  padding: 0.42rem 0.72rem;
+  padding: 0.28rem 0.82rem;
   text-decoration: none;
-  font-weight: 650;
+  font-size: 0.84rem;
+  font-weight: 500;
 }
 
 .topbar-nav-link[aria-current="page"] {
   border-color: var(--accent);
-  background: var(--accent-soft);
-  color: var(--md-sys-color-on-primary-container);
+  background: var(--accent);
+  color: var(--md-sys-color-on-primary);
 }
 
 .topbar-theme {
-  width: 40px;
+  width: 32px;
+  border-color: var(--border);
+  background: var(--surface);
   padding: 0;
   --md-icon-button-icon-color: var(--text);
   --md-icon-button-hover-icon-color: var(--accent-strong);
@@ -260,12 +270,16 @@ code {
 }
 
 .shell-main {
-  padding-block: 24px 18px;
+  padding-block: 7px 8px;
 }
 
 .app-shell {
   display: grid;
-  gap: 18px;
+  gap: 8px;
+}
+
+.inspect-shell {
+  min-height: calc(100vh - 67px);
 }
 
 .intro-strip {
@@ -314,26 +328,45 @@ fieldset {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(280px, 0.42fr) minmax(0, 0.58fr);
-  gap: 18px;
-  align-items: start;
+  grid-template-columns: minmax(320px, 1fr) minmax(0, 1fr);
+  gap: 0;
+  align-items: stretch;
+  min-height: calc(100vh - 67px);
 }
 
 .workspace-left,
 .workspace-right,
 .workspace-main {
   display: grid;
-  gap: 18px;
+  gap: 0;
+  align-content: start;
   min-width: 0;
+}
+
+.workspace-left {
+  border: 1px solid var(--border);
+  border-right: 0;
+  border-radius: 8px 0 0 8px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.workspace-right {
+  border: 1px solid var(--border);
+  border-left: 8px solid var(--md-sys-color-background);
+  border-radius: 0 8px 8px 0;
+  background: var(--surface);
+  overflow: hidden;
 }
 
 .panel {
   display: block;
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
   background: var(--surface);
   box-shadow: var(--shadow);
-  padding: 18px;
+  padding: 14px 16px;
 }
 
 .panel[data-md3-surface],
@@ -354,16 +387,17 @@ fieldset {
   justify-content: space-between;
   gap: 1rem;
   min-width: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
   background: var(--surface);
-  padding: 12px 14px;
+  padding: 10px 16px;
 }
 
 .books-panel,
 .decoded-structure-panel {
   display: grid;
-  gap: 14px;
+  gap: 10px;
 }
 
 .books-panel .panel-heading,
@@ -381,8 +415,9 @@ fieldset {
 .books-list {
   display: grid;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--md-sys-color-surface-container-low);
+  max-height: 150px;
   overflow: hidden;
 }
 
@@ -586,13 +621,28 @@ fieldset {
 }
 
 .decoded-structure-placeholder {
-  min-height: 120px;
+  min-height: 420px;
 }
 
 .settings-summary-copy {
   display: grid;
   gap: 0.18rem;
   min-width: 0;
+}
+
+.settings-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+}
+
+.settings-meta-row span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.08rem 0.36rem;
 }
 
 .settings-summary-copy strong {
@@ -606,8 +656,8 @@ fieldset {
   justify-content: space-between;
   gap: 1rem;
   border-bottom: 1px solid var(--border);
-  padding-bottom: 13px;
-  margin-bottom: 16px;
+  padding-bottom: 8px;
+  margin-bottom: 10px;
 }
 
 .provider-panel .panel-heading {
@@ -616,13 +666,16 @@ fieldset {
 }
 
 .panel-heading h2 {
-  font-size: 1.06rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 700;
   line-height: 1.25;
+  text-transform: uppercase;
 }
 
 .panel-heading p {
   color: var(--muted);
-  font-size: 0.9rem;
+  font-size: 0.78rem;
   margin-top: 0.25rem;
 }
 
@@ -650,7 +703,7 @@ legend {
 .option-stack,
 .mode-options {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 
 .mode-options {
@@ -661,18 +714,18 @@ legend {
   display: flex;
   align-items: center;
   gap: 0.58rem;
-  min-height: 42px;
+  min-height: 34px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--surface-soft);
-  padding: 0.58rem 0.68rem;
+  padding: 0.42rem 0.58rem;
   color: var(--text);
 }
 
 .choice-option.is-selected {
   border-color: var(--accent);
   background: var(--accent-soft);
-  box-shadow: inset 0 0 0 1px var(--accent);
+  box-shadow: none;
 }
 
 .choice-option input {
@@ -688,6 +741,7 @@ legend {
 }
 
 .choice-title {
+  font-size: 0.86rem;
   font-weight: 650;
 }
 
@@ -700,8 +754,10 @@ legend {
   display: flex;
   justify-content: space-between;
   gap: 0.75rem;
-  color: var(--text);
-  font-weight: 650;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-transform: uppercase;
 }
 
 input[type="text"],
@@ -727,7 +783,7 @@ input[type="password"] {
 }
 
 textarea {
-  min-height: 180px;
+  min-height: 190px;
   resize: vertical;
   font-size: 0.88rem;
 }
@@ -777,7 +833,7 @@ md-icon-button:focus-visible,
 
 .decode-form {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .hash-form {
@@ -787,7 +843,7 @@ md-icon-button:focus-visible,
 
 .primary-action,
 .secondary-action {
-  min-height: 42px;
+  min-height: 34px;
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.62rem 0.9rem;
@@ -838,8 +894,9 @@ md-icon-button:focus-visible,
 
 .result-panel {
   display: grid;
-  gap: 14px;
+  gap: 10px;
   overflow: hidden;
+  min-height: 100%;
 }
 
 .inspection-summary {
@@ -873,18 +930,22 @@ md-icon-button:focus-visible,
 .result-tab-bar {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 0;
   border-bottom: 1px solid var(--border);
+  background: var(--md-sys-color-surface-container);
+  margin-inline: -16px;
+  padding-inline: 16px;
 }
 
 .result-tab {
   appearance: none;
   border: 0;
-  border-bottom: 3px solid transparent;
+  border-bottom: 2px solid transparent;
   background: transparent;
   color: var(--muted);
-  padding: 0.62rem 0.78rem 0.5rem;
-  font-weight: 750;
+  padding: 0.62rem 1rem 0.54rem;
+  font-size: 0.84rem;
+  font-weight: 650;
 }
 
 .result-tab:hover,
@@ -901,7 +962,7 @@ md-icon-button:focus-visible,
   display: grid;
   gap: 12px;
   min-height: 0;
-  max-height: min(76vh, 820px);
+  max-height: none;
   overflow: auto;
   padding-right: 2px;
 }
@@ -915,10 +976,14 @@ md-icon-button:focus-visible,
   display: grid;
   gap: 12px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 6px;
   background: var(--md-sys-color-surface-container-low);
   padding: 12px;
-  margin-top: 14px;
+  margin-top: 0;
+}
+
+.compact-identity-panel {
+  margin-top: 12px;
 }
 
 .intent-panel {
@@ -1521,6 +1586,17 @@ pre {
     grid-template-columns: 1fr;
   }
 
+  .workspace-left {
+    border-right: 1px solid var(--border);
+    border-radius: 8px 8px 0 0;
+  }
+
+  .workspace-right {
+    border-top: 0;
+    border-left: 1px solid var(--border);
+    border-radius: 0 0 8px 8px;
+  }
+
   .metric-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -1545,7 +1621,10 @@ pre {
   }
 
   .topbar {
-    min-height: 58px;
+    min-height: 51px;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding-block: 6px;
   }
 
   .brand span {

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -325,24 +325,8 @@ inspectorComponent initial =
 
   renderInspector state =
     HH.div
-      [ classNames [ "app-shell" ] ]
-      [ HH.section
-          [ classNames [ "intro-strip" ] ]
-          [ HH.div_
-              [ HH.h1_ [ HH.text "Conway tx inspector" ]
-              , HH.p_
-                  [ HH.text
-                      "Decode, inspect, and validate Conway transaction CBOR with explicit chain-data context."
-                  ]
-              ]
-          , HH.div
-              [ classNames [ "tech-pills" ] ]
-              [ HH.span_ [ HH.text "CBOR" ]
-              , HH.span_ [ HH.text "context-aware" ]
-              , HH.span_ [ HH.text "RDF views" ]
-              ]
-          ]
-      , HH.div
+      [ classNames [ "app-shell", "inspect-shell" ] ]
+      [ HH.div
           [ classNames [ "workspace" ] ]
           [ HH.div
               [ classNames [ "workspace-left" ] ]
@@ -679,10 +663,16 @@ inspectorComponent initial =
           [ classNames [ "settings-summary-copy" ] ]
           [ HH.span
               [ classNames [ "identity-section-title" ] ]
-              [ HH.text "Active chain data" ]
+              [ HH.text "Chain data" ]
           , HH.strong_
               [ HH.text
                   (Provider.providerName state.provider <> " / " <> networkName state.network)
+              ]
+          , HH.div
+              [ classNames [ "settings-meta-row" ] ]
+              [ HH.span_ [ HH.text "Provider" ]
+              , HH.span_ [ HH.text "Network" ]
+              , HH.span_ [ HH.text "Key setting" ]
               ]
           ]
       , HH.a
@@ -709,7 +699,7 @@ inspectorComponent initial =
           [ classNames [ "panel-heading" ] ]
           [ HH.div_
               [ HH.h2_ [ HH.text "Books" ]
-              , HH.p_ [ HH.text "Selected library books resolve labels, blueprints, and SHACL checks." ]
+              , HH.p_ [ HH.text "Selected overlay, blueprint, and SHACL sources." ]
               ]
           ]
       , HH.div
@@ -1153,7 +1143,7 @@ inspectorComponent initial =
       ]
       [ HH.div
           [ classNames [ "panel-heading" ] ]
-          [ HH.h2_ [ HH.text "Input" ]
+          [ HH.h2_ [ HH.text "Paste here" ]
           , HH.p_ [ HH.text "Fetch by transaction hash or paste raw CBOR hex." ]
           ]
       , HH.fieldset
@@ -1240,7 +1230,7 @@ inspectorComponent initial =
             ]
             [ HH.div
                 [ classNames [ "panel-heading" ] ]
-                [ HH.h2_ [ HH.text "Decoded JSON" ] ]
+                [ HH.h2_ [ HH.text "Decoded structure" ] ]
             , HH.div
                 [ classNames [ "empty-state" ] ]
                 [ HH.text "No result yet." ]
@@ -1256,9 +1246,9 @@ inspectorComponent initial =
               ( [ HH.div
                     [ classNames [ "panel-heading", "result-heading" ] ]
                     [ HH.div_
-                        [ HH.h2_ [ HH.text (if r.exitOk then "Inspection" else "Error") ]
+                        [ HH.h2_ [ HH.text (if r.exitOk then "Decoded structure" else "Error") ]
                         , if r.exitOk && summary.valid
-                            then HH.p_ [ HH.text summary.title ]
+                            then HH.p_ [ HH.text "Decoded transaction" ]
                             else HH.text ""
                         ]
                     , if r.exitOk
@@ -1273,10 +1263,6 @@ inspectorComponent initial =
                         else HH.text ""
                     ]
                 ]
-              <> ( if r.exitOk && summary.valid
-                     then [ renderResultSummary state summary ]
-                     else []
-                 )
               <> ( if r.exitOk then
                      [ renderResultTabs state
                      , renderSelectedResultTab state r.stdout
@@ -1435,6 +1421,7 @@ inspectorComponent initial =
       ( case state.resultTab of
           StructureTab ->
             [ renderDecodedStructure state ]
+              <> renderCompactIdentificationMaybe state
           WitnessTab ->
             renderIntentMaybe state
               <> renderWitnessPlanMaybe state
@@ -1442,7 +1429,8 @@ inspectorComponent initial =
             renderValidationMaybe state
               <> renderShaclConformanceMaybe state.shaclConformance
           GraphRdfTab ->
-            renderGraphRdfMaybe state
+            renderCompactIdentificationMaybe state
+              <> renderGraphRdfMaybe state
               <> renderBrowserMaybe state true
               <> [ renderRawJson stdout ]
       )
@@ -1464,6 +1452,28 @@ inspectorComponent initial =
       WitnessTab -> "Witness"
       ValidationTab -> "Validation"
       GraphRdfTab -> "Graph / RDF"
+
+  renderCompactIdentificationMaybe state =
+    case state.identification of
+      Just identification | identification.valid -> [ renderCompactIdentification state identification ]
+      _ -> []
+
+  renderCompactIdentification state identification =
+    HH.div
+      [ classNames [ "identity-panel", "compact-identity-panel" ]
+      , mdSurface "decoded"
+      ]
+      [ HH.div
+          [ classNames [ "identity-heading" ] ]
+          [ HH.div_
+              [ HH.h3_ [ HH.text "Identity metadata" ]
+              , HH.p_ [ HH.text identification.subtitle ]
+              ]
+          ]
+      , HH.div
+          [ classNames [ "identity-grid" ] ]
+          (map (renderIdentityRow state) identification.primary)
+      ]
 
   renderInspection summary =
     [ HH.div

--- a/docs/inspector/src/Shell.purs
+++ b/docs/inspector/src/Shell.purs
@@ -37,8 +37,8 @@ topbar active opts =
         [ classNames [ "page-frame", "topbar" ] ]
         [ HH.div
             [ classNames [ "brand" ] ]
-            [ HH.strong_ [ HH.text "Cardano transaction inspector" ]
-            , HH.span_ [ HH.text "Decode, inspect, and validate transactions" ]
+            [ HH.strong_ [ HH.text "CQuisitor" ]
+            , HH.span_ [ HH.text "Cardano transaction inspector" ]
             ]
         , HH.nav
             [ classNames [ "topbar-nav" ]

--- a/docs/inspector/src/Shell.purs
+++ b/docs/inspector/src/Shell.purs
@@ -37,7 +37,7 @@ topbar active opts =
         [ classNames [ "page-frame", "topbar" ] ]
         [ HH.div
             [ classNames [ "brand" ] ]
-            [ HH.strong_ [ HH.text "CQuisitor" ]
+            [ HH.strong_ [ HH.text "Ledger Inspector" ]
             , HH.span_ [ HH.text "Cardano transaction inspector" ]
             ]
         , HH.nav

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -268,6 +268,74 @@ async function expectTabbedInspectResult(page) {
   await expect(graphPanel.getByText("Raw JSON", { exact: true })).toBeVisible();
 }
 
+async function expectCQuisitorInspectSurface(page, route) {
+  await decodeFixtureAt(page, route, conwayMainnetFixturePath);
+
+  const topbar = page.getByRole("banner");
+  await expect(topbar.getByText("CQuisitor", { exact: true })).toBeVisible();
+  await expect(topbar.getByRole("navigation").getByRole("link", { name: "Inspect" })).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+
+  const workspace = page.locator(".workspace");
+  const leftPane = page.locator(".workspace-left");
+  const rightPane = page.locator(".workspace-right");
+  const leftBox = await leftPane.boundingBox();
+  const rightBox = await rightPane.boundingBox();
+  const workspaceBox = await workspace.boundingBox();
+  expect(leftBox).not.toBeNull();
+  expect(rightBox).not.toBeNull();
+  expect(workspaceBox).not.toBeNull();
+
+  const leftRatio = leftBox.width / workspaceBox.width;
+  const rightRatio = rightBox.width / workspaceBox.width;
+  expect(leftRatio).toBeGreaterThan(0.46);
+  expect(leftRatio).toBeLessThan(0.54);
+  expect(rightRatio).toBeGreaterThan(0.46);
+  expect(rightRatio).toBeLessThan(0.54);
+  expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(4);
+  expect(rightBox.x - (leftBox.x + leftBox.width)).toBeLessThanOrEqual(16);
+  await expect(rightPane).toHaveCSS("border-left-width", /[1-9]px/);
+
+  await expect(leftPane.locator(".settings-summary")).toContainText(/Blockfrost|Koios/);
+  await expect(leftPane.locator(".books-panel")).toContainText(/selected|parts/);
+  const pasteInput = leftPane.getByPlaceholder("Conway tx CBOR hex...");
+  await expect(pasteInput).toBeVisible();
+  const pasteBox = await pasteInput.boundingBox();
+  expect(pasteBox.height).toBeGreaterThan(170);
+  await expect(leftPane.getByRole("button", { name: "Decode" })).toBeVisible();
+
+  const resultPanel = rightPane.locator(".result-panel");
+  const tabs = resultPanel.getByRole("tablist", { name: "Inspect result views" });
+  await expect(tabs.getByRole("tab", { name: "Structure" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  const decodedPanel = resultPanel.locator(".decoded-structure-panel");
+  await expect(decodedPanel).toBeVisible();
+  await expect(decodedPanel.getByRole("heading", { name: "Decoded structure" })).toBeVisible();
+  const transactionRow = decodedPanel.locator(".decoded-tree-row", {
+    hasText: "Transaction",
+  }).first();
+  await expect(transactionRow).toBeVisible();
+  await expect(resultPanel.getByRole("heading", { name: "Conway transaction identity" })).toHaveCount(0);
+  await expect(resultPanel.locator(".summary-identity-grid")).toHaveCount(0);
+
+  const positions = await resultPanel.evaluate((panel) => {
+    const tree = panel.querySelector(".decoded-structure-panel .decoded-tree-row");
+    const identity = panel.querySelector(".identity-panel, .summary-identity-grid");
+    return {
+      treeTop: tree?.getBoundingClientRect().top ?? null,
+      identityTop: identity?.getBoundingClientRect().top ?? null,
+    };
+  });
+  expect(positions.treeTop).not.toBeNull();
+  if (positions.identityTop !== null) {
+    expect(positions.treeTop).toBeLessThan(positions.identityTop);
+  }
+}
+
 async function selectResultTab(page, name) {
   const resultPanel = page.locator(".result-panel");
   await resultPanel.getByRole("tab", { name }).click();
@@ -757,7 +825,7 @@ test("MD3 shell routes topbar nav and theme toggle", async ({ page }) => {
   expect(indexHtml).toContain("Roboto+Mono");
 
   await expect(
-    topbar.getByText("Cardano transaction inspector", { exact: true }),
+    topbar.getByText("CQuisitor", { exact: true }),
   ).toBeVisible();
   await expect(navigation.getByRole("link", { name: "Inspect" })).toBeVisible();
   await expect(navigation.getByRole("link", { name: "Settings" })).toBeVisible();
@@ -932,14 +1000,16 @@ test("inspect keeps chain-data settings compact and gives input/results the work
   await expect(settingsSummary.getByRole("link", { name: "Settings" })).toBeVisible();
   await expect(inputPanel).toBeVisible();
   await expect(leftPane.getByRole("heading", { name: "Books" })).toBeVisible();
-  await expect(resultPanel.getByRole("heading", { name: "Decoded JSON" })).toBeVisible();
+  await expect(resultPanel.getByRole("heading", { name: "Decoded structure" })).toBeVisible();
   await expect(rightPane.locator(".decoded-structure-panel")).toHaveCount(0);
 
   const workspaceBox = await page.locator(".workspace").boundingBox();
   const leftBox = await leftPane.boundingBox();
   const rightBox = await rightPane.boundingBox();
-  expect(leftBox.width).toBeLessThan(workspaceBox.width * 0.52);
-  expect(rightBox.width).toBeGreaterThan(workspaceBox.width * 0.52);
+  expect(leftBox.width).toBeGreaterThan(workspaceBox.width * 0.46);
+  expect(leftBox.width).toBeLessThan(workspaceBox.width * 0.54);
+  expect(rightBox.width).toBeGreaterThan(workspaceBox.width * 0.46);
+  expect(rightBox.width).toBeLessThan(workspaceBox.width * 0.54);
   expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(8);
 });
 
@@ -1007,7 +1077,7 @@ test("settings changes provider state used by inspect hash decode", async ({ pag
   await page.getByRole("button", { name: "Fetch and decode" }).click();
 
   await expect(
-    page.getByRole("heading", { name: "Conway transaction identity" }),
+    page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
   expect(requestedHashes).toContain("0".repeat(64));
   expect(tipRequests).toBe(1);
@@ -1021,9 +1091,8 @@ test("decodes a Conway transaction and exposes compact identity values", async (
 
   await expect(page.getByText("Transaction ID", { exact: true })).toBeVisible();
   await expect(page.getByText("Body hash", { exact: true })).toBeVisible();
-  await expect(page.locator(".identity-panel:not(.witness-plan):not(.validation-panel)")).toHaveCount(0);
 
-  const summaryIdentity = page.locator(".summary-identity-grid");
+  const summaryIdentity = page.locator(".compact-identity-panel .identity-grid");
   const txIdRow = summaryIdentity.locator(".identity-row", { hasText: "Transaction ID" });
   const txId = await txIdRow.locator("code").innerText();
   await txIdRow.locator("code").click();
@@ -1155,11 +1224,11 @@ test("decodes genuine Conway fixture into RDF tree", async ({
 
   const body = page.locator("body");
   await expect(
-    page.getByRole("heading", { name: /Conway transaction identity|stderr/ }),
+    page.getByRole("heading", { name: /Decoded structure|stderr/ }),
   ).toBeVisible();
   await expect(body).not.toContainText(/malformed_cbor|DeserialiseFailure/);
   await expect(
-    page.getByRole("heading", { name: "Conway transaction identity" }),
+    page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
 
   const decodedPanel = page.locator(".decoded-structure-panel");
@@ -1263,6 +1332,16 @@ test("inspect result is tree-primary tabs after genuine decode", async ({ page }
   await withPrefixedInspectorSite(async (baseUrl) => {
     await decodeFixtureAt(page, `${baseUrl}inspect/`, conwayMainnetFixturePath);
     await expectTabbedInspectResult(page);
+  });
+});
+
+test("CQuisitor inspect layout keeps decoded tree primary after genuine decode and subpath", async ({
+  page,
+}) => {
+  await expectCQuisitorInspectSurface(page, "/inspect");
+
+  await withPrefixedInspectorSite(async (baseUrl) => {
+    await expectCQuisitorInspectSurface(page, `${baseUrl}inspect/`);
   });
 });
 
@@ -1462,7 +1541,7 @@ fixture:selectedLibraryAddress
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
   await expect(
-    page.getByRole("heading", { name: "Conway transaction identity" }),
+    page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
 
   await selectResultTab(page, "Graph / RDF");
@@ -1956,6 +2035,7 @@ test("passes producer transaction CBOR into witness planning", async ({
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  await selectResultTab(page, "Witness");
   await expect(
     page.getByText("Producer transaction CBOR resolved every visible transaction input"),
   ).toBeVisible();
@@ -2160,6 +2240,7 @@ test("uses the same tx CBOR provider boundary for Koios", async ({ page }) => {
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
+  await selectResultTab(page, "Witness");
   await expect(
     page.getByText("Producer transaction CBOR resolved every visible transaction input"),
   ).toBeVisible();
@@ -2207,9 +2288,9 @@ test("opens browser rows in place without losing identity context", async ({
 
   await expect(page.locator(".browser-children").first()).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Conway transaction identity" }),
+    page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
-  await expect(page.locator(".summary-identity-grid")).toBeVisible();
+  await expect(page.locator(".compact-identity-panel .identity-grid")).toBeVisible();
 });
 
 test("keeps decoded transaction layout within the viewport", async ({ page }) => {

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -272,7 +272,7 @@ async function expectCQuisitorInspectSurface(page, route) {
   await decodeFixtureAt(page, route, conwayMainnetFixturePath);
 
   const topbar = page.getByRole("banner");
-  await expect(topbar.getByText("CQuisitor", { exact: true })).toBeVisible();
+  await expect(topbar.getByText("Ledger Inspector", { exact: true })).toBeVisible();
   await expect(topbar.getByRole("navigation").getByRole("link", { name: "Inspect" })).toHaveAttribute(
     "aria-current",
     "page",
@@ -825,7 +825,7 @@ test("MD3 shell routes topbar nav and theme toggle", async ({ page }) => {
   expect(indexHtml).toContain("Roboto+Mono");
 
   await expect(
-    topbar.getByText("CQuisitor", { exact: true }),
+    topbar.getByText("Ledger Inspector", { exact: true }),
   ).toBeVisible();
   await expect(navigation.getByRole("link", { name: "Inspect" })).toBeVisible();
   await expect(navigation.getByRole("link", { name: "Settings" })).toBeVisible();

--- a/specs/119-cquisitor-inspect/plan.md
+++ b/specs/119-cquisitor-inspect/plan.md
@@ -1,0 +1,45 @@
+# Plan
+
+## Current Gap
+
+The existing inspect page still reads as a Material dashboard: a descriptive intro strip, separate card stack on the left, result heading plus summary metrics before the structure, and a teal-accent MD3 skin. CQuisitor is much flatter and denser: a 51px tool header, right-aligned mode tabs, hard 50/50 panes, uppercase labels, thin borders, low elevation, and a decoded-structure pane that owns the right half.
+
+Reference artifacts captured from the live site are stored outside git at:
+
+- `/tmp/epic-113/clins-119/reference/cquisitor-working-surface-1440.png`
+- `/tmp/epic-113/clins-119/reference/cquisitor-working-surface-snapshot.md`
+
+## Slice
+
+One presentation slice is appropriate because the acceptance surface is one coherent visual change and the touched files already share Playwright coverage.
+
+### Slice 1: CQuisitor-style inspect presentation
+
+Owned files:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/src/Shell.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- Rework `/inspect` desktop hierarchy into a hard left/right tool surface with a clear divider.
+- Remove the result summary/metrics hero above the decoded structure; keep identity only as compact secondary metadata or in existing lower-detail contexts.
+- Make decoded structure the dominant right-pane default after decode and keep Witness, Validation, and Graph/RDF secondary behind tabs.
+- Re-skin the shell and MD3 tokens toward CQuisitor: neutral blue-gray page, white surfaces, thin borders, small uppercase labels, tighter spacing, low/no shadow, compact buttons/tabs.
+- Adjust top nav to read as mode tabs with Inspect primary and Settings/Library secondary compact links.
+- Strengthen Playwright assertions for no identity hero above tree, two-pane proportions, tree dominance, compact labels, and subpath behavior.
+
+Focused proof:
+
+- `just test-playwright`
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `./gate.sh`
+- Browser smoke on `/inspect` with `conway-mainnet-tx.hex`, screenshot compared against the CQuisitor reference.
+
+## Risks
+
+- Existing tests still expect the old identity summary in a few flows. Update those expectations without weakening coverage of copy/open/identity availability.
+- PureScript formatting may be sensitive after render tree changes; run `just format-check` through the gate.
+- The CSS file is committed source for this app; do not introduce generated-only changes outside the owned stylesheet.

--- a/specs/119-cquisitor-inspect/spec.md
+++ b/specs/119-cquisitor-inspect/spec.md
@@ -1,0 +1,29 @@
+# Issue #119: CQuisitor-Style Inspect Surface
+
+## User Story
+
+As a transaction analyst using `/inspect`, I want the page to read like CQuisitor: a compact two-pane decode tool with paste input on the left and the decoded structure tree dominating the right, so I can inspect a transaction without fighting a dashboard layout or a metrics hero.
+
+## Functional Requirements
+
+- FR1: `/inspect` MUST present a hard two-pane desktop layout with a clear vertical divider: left pane for input/config/actions, right pane for decoded structure and result detail.
+- FR2: The left pane MUST make the paste/fetch input visually prominent and keep chain-data/provider/book controls compact and inline.
+- FR3: The right pane MUST lead with the decoded structure tree after a successful decode; no "Conway transaction identity" metrics-card hero may appear above the tree.
+- FR4: Identity values may remain available only as compact secondary metadata, not as a hero grid above the tree.
+- FR5: Witness, validation, RDF, browser, lenses, and book-resolution detail MUST remain available as secondary tabs or collapsible/result sections without changing decode/resolution behavior.
+- FR6: The shell/top navigation MUST read like a compact tool with mode-tab styling; Settings and Library must be visually secondary to Inspect.
+- FR7: Material components may remain in use, but the visual skin MUST be flat, compact, neutral, low-elevation, and label-dense like CQuisitor.
+
+## Acceptance Criteria
+
+- AC1: Side-by-side with `https://cardananium.github.io/cquisitor/`, `/inspect` has the same broad structure: compact header, mode-tab navigation, left input/config pane, right decoded-structure pane, and a visible divider.
+- AC2: A genuine fixture decode lands with the Structure tab selected and the decoded tree visible in the first viewport.
+- AC3: Playwright asserts no identity/metrics hero above the tree, tree dominance in the right pane, two-pane proportions, compact labels, and subpath `/inspect/` behavior.
+- AC4: `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, and `./gate.sh` pass.
+- AC5: A browser smoke using `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex` verifies the preview visually against the saved CQuisitor reference.
+
+## Non-Goals
+
+- No ledger operation, provider, book-resolution, RDF, SPARQL, witness, validation, or WASM loading behavior changes.
+- No dependency changes.
+- No generated hash or lockfile changes.

--- a/specs/119-cquisitor-inspect/tasks.md
+++ b/specs/119-cquisitor-inspect/tasks.md
@@ -2,8 +2,8 @@
 
 ## Slice 1: CQuisitor-style inspect presentation
 
-- [ ] T119-S1 Add Playwright RED assertions for CQuisitor-like `/inspect`: hard two-pane, visible divider, compact labels, decoded tree dominant, no identity/metrics hero above the tree, and subpath preservation.
-- [ ] T119-S1 Rework `Main.purs` presentation so `/inspect` leads with compact config/input left and decoded structure right, keeping result detail secondary and behavior unchanged.
-- [ ] T119-S1 Rework `Shell.purs` topbar into compact tool/mode-tab navigation with Settings/Library visually secondary.
-- [ ] T119-S1 Re-skin `styles.css` to flat/compact/neutral MD3-compatible tokens and CQuisitor-like pane density.
-- [ ] T119-S1 Run focused Playwright, UI build, `./gate.sh`, then commit one bisect-safe slice with the required `Tasks: T119-S1` trailer.
+- [X] T119-S1 Add Playwright RED assertions for CQuisitor-like `/inspect`: hard two-pane, visible divider, compact labels, decoded tree dominant, no identity/metrics hero above the tree, and subpath preservation.
+- [X] T119-S1 Rework `Main.purs` presentation so `/inspect` leads with compact config/input left and decoded structure right, keeping result detail secondary and behavior unchanged.
+- [X] T119-S1 Rework `Shell.purs` topbar into compact tool/mode-tab navigation with Settings/Library visually secondary.
+- [X] T119-S1 Re-skin `styles.css` to flat/compact/neutral MD3-compatible tokens and CQuisitor-like pane density.
+- [X] T119-S1 Run focused Playwright, UI build, `./gate.sh`, then commit one bisect-safe slice with the required `Tasks: T119-S1` trailer.

--- a/specs/119-cquisitor-inspect/tasks.md
+++ b/specs/119-cquisitor-inspect/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## Slice 1: CQuisitor-style inspect presentation
+
+- [ ] T119-S1 Add Playwright RED assertions for CQuisitor-like `/inspect`: hard two-pane, visible divider, compact labels, decoded tree dominant, no identity/metrics hero above the tree, and subpath preservation.
+- [ ] T119-S1 Rework `Main.purs` presentation so `/inspect` leads with compact config/input left and decoded structure right, keeping result detail secondary and behavior unchanged.
+- [ ] T119-S1 Rework `Shell.purs` topbar into compact tool/mode-tab navigation with Settings/Library visually secondary.
+- [ ] T119-S1 Re-skin `styles.css` to flat/compact/neutral MD3-compatible tokens and CQuisitor-like pane density.
+- [ ] T119-S1 Run focused Playwright, UI build, `./gate.sh`, then commit one bisect-safe slice with the required `Tasks: T119-S1` trailer.


### PR DESCRIPTION
Refs #119. Part of #113.

Scope: presentation-only reskin/restructure of `/inspect` to match the approved CQuisitor-class working surface: hard two-pane input/tree layout, no identity metrics hero above the tree, compact neutral Material styling, and stronger Playwright assertions. The public wordmark remains ours: `Ledger Inspector`.

Implemented:
- Left pane is now the prominent paste/config/books surface; right pane is the dominant decoded-structure tree with a hard divider.
- Removed the “Conway transaction identity” metrics hero above the tree; identity metadata is secondary below the tree.
- Top bar now reads as a compact tool surface (`Ledger Inspector / Cardano transaction inspector`) with mode-tab-style navigation.
- Material styling is flatter, tighter, neutral, and lower-elevation.
- Playwright assertions cover the reference-style layout, tree dominance, removed identity hero, subpath decode, mobile overflow, and the `Ledger Inspector` wordmark.

Verification:
- `nix build .#packages.x86_64-linux.tx-inspector-ui` passed locally at `114096c3b0972a24696a2e164deb82583916880b`.
- `just test-playwright` passed locally: `38 passed (2.4m)`.
- `just format-check` passed locally.
- `just hlint` passed locally: `No hints`.
- GitHub CI is green: Build Gate, preview, OpenAPI checks, smoke checks, Extism conformance, format, hlint, Playwright.
- Published preview smoke passed against `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`.
- Preview: https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-120/inspector/
- Reference screenshot: `/tmp/epic-113/clins-119/reference/cquisitor-working-surface-1440.png`
- Preview screenshots: `/tmp/epic-113/clins-119/preview/clins-119-preview-inspect-1440.png`, `/tmp/epic-113/clins-119/preview/clins-119-published-preview-1440.png`, `/tmp/epic-113/clins-119/preview/clins-119-rebrand-preview-114096c.png`

Published preview smoke facts at `114096c`:
- topbar text: `Ledger Inspector / Cardano transaction inspector`
- no `CQuisitor` in the topbar
- left pane `712px`, right pane `712px`, decoded tree panel `669px`
- decoded tree visible with `Body 7 fields`
- identity metadata appears below the tree
- horizontal overflow `0px`
- browser console errors `0` with provider routes mocked

Left draft for epic-owner re-verification.
