### PR TITLE
Inspect view: vertical layout, linked CURIEs, edit-icon annotations + resolution, field-type badges

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -328,12 +328,13 @@ fieldset {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(320px, 1fr) minmax(0, 1fr);
-  gap: 0;
-  align-items: stretch;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  align-items: start;
   min-height: calc(100vh - 67px);
 }
 
+.load-form-stack,
 .workspace-left,
 .workspace-right,
 .workspace-main {
@@ -341,6 +342,19 @@ fieldset {
   gap: 0;
   align-content: start;
   min-width: 0;
+}
+
+.load-form-stack,
+.workspace-main {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.load-form-stack > .panel:last-child,
+.workspace-main > .panel:last-child {
+  border-bottom: 0;
 }
 
 .workspace-left {
@@ -361,13 +375,7 @@ fieldset {
 
 .loaded-workspace {
   grid-template-columns: 1fr;
-  grid-template-rows: auto minmax(0, 1fr);
   gap: 8px;
-}
-
-.loaded-workspace .workspace-right {
-  border-left: 1px solid var(--border);
-  border-radius: 8px;
 }
 
 .loaded-inspector-header {
@@ -485,6 +493,12 @@ fieldset {
   gap: 10px;
 }
 
+.workspace > .books-panel {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
 .books-panel .panel-heading,
 .decoded-structure-panel .panel-heading {
   margin-bottom: 0;
@@ -502,8 +516,8 @@ fieldset {
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--md-sys-color-surface-container-low);
-  max-height: 150px;
-  overflow: hidden;
+  max-height: none;
+  overflow: visible;
 }
 
 .book-summary-row,

--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -1409,7 +1409,11 @@ md-icon-button:focus-visible,
 
 .decoded-tree-annotate {
   justify-self: start;
+  width: 32px;
+  height: 32px;
   max-width: 100%;
+  --md-icon-button-state-layer-width: 32px;
+  --md-icon-button-state-layer-height: 32px;
 }
 
 .decoded-tree-summary,
@@ -1422,6 +1426,31 @@ md-icon-button:focus-visible,
 
 .decoded-tree-meta {
   font-size: 0.78rem;
+}
+
+.decoded-tree-iri {
+  color: var(--accent-strong);
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.decoded-tree-iri:hover {
+  text-decoration: underline;
+}
+
+.decoded-tree-subject {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: copy;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
+.decoded-tree-subject:hover {
+  color: var(--accent-strong);
 }
 
 .decoded-tree-annotation-form {

--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -359,6 +359,91 @@ fieldset {
   overflow: hidden;
 }
 
+.loaded-workspace {
+  grid-template-columns: 1fr;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 8px;
+}
+
+.loaded-workspace .workspace-right {
+  border-left: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.loaded-inspector-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 10px 12px;
+}
+
+.loaded-inspector-context {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(96px, auto)) minmax(180px, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.loaded-context-item {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.loaded-context-item span {
+  color: var(--muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.loaded-context-item strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 0.88rem;
+}
+
+.loaded-context-hash code {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.loaded-book-context,
+.loaded-inspector-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.loaded-book-context {
+  justify-content: center;
+}
+
+.loaded-book-context span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-soft);
+  padding: 0.18rem 0.45rem;
+  color: var(--muted);
+  font-size: 0.76rem;
+  white-space: nowrap;
+}
+
+.loaded-inspector-actions {
+  justify-content: end;
+}
+
 .panel {
   display: block;
   border: 0;
@@ -1586,6 +1671,20 @@ pre {
     grid-template-columns: 1fr;
   }
 
+  .loaded-inspector-header {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .loaded-inspector-context {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .loaded-book-context,
+  .loaded-inspector-actions {
+    justify-content: start;
+  }
+
   .workspace-left {
     border-right: 1px solid var(--border);
     border-radius: 8px 8px 0 0;
@@ -1659,6 +1758,15 @@ pre {
 
   .mode-options,
   .hash-form {
+    grid-template-columns: 1fr;
+  }
+
+  .loaded-inspector-context {
+    grid-template-columns: 1fr;
+  }
+
+  .loaded-inspector-actions {
+    display: grid;
     grid-template-columns: 1fr;
   }
 

--- a/docs/inspector/src/FFI/BookStore.js
+++ b/docs/inspector/src/FFI/BookStore.js
@@ -95,15 +95,6 @@ export const inspectImpl = (store) => {
   };
 };
 
-const hashText = (raw) => {
-  let hash = 2166136261;
-  for (let i = 0; i < raw.length; i += 1) {
-    hash ^= raw.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
-  }
-  return (hash >>> 0).toString(36);
-};
-
 const localToken = (value, fallback = "Annotation") => {
   const token = text(value)
     .trim()
@@ -121,13 +112,22 @@ const turtleType = (value) => {
   return `local:${localToken(raw, "Type")}`;
 };
 
-export const annotationTurtle = ({ label, typeName, predicate, value }) => {
+const turtleSubject = (value) => {
+  const raw = text(value).trim();
+  if (raw === "") return "";
+  if (/[<>"{}|\\^`]/.test(raw)) return "";
+  if (/^https?:\/\//.test(raw) || raw.startsWith("urn:")) return `<${raw}>`;
+  if (/^(cardano|rdfs|local):[A-Za-z_][A-Za-z0-9_-]*$/.test(raw)) return raw;
+  return "";
+};
+
+export const annotationTurtle = ({ label, typeName, entityIri, predicate, value }) => {
   const trimmedLabel = text(label).trim();
+  const subject = turtleSubject(entityIri);
   const trimmedPredicate = text(predicate).trim();
   const trimmedValue = text(value).trim();
-  if (trimmedLabel === "" || trimmedPredicate === "" || trimmedValue === "") return "";
+  if (trimmedLabel === "" || subject === "" || trimmedPredicate === "" || trimmedValue === "") return "";
 
-  const subject = `local:annotation-${localToken(trimmedPredicate, "predicate").toLowerCase()}-${hashText(`${trimmedPredicate}\n${trimmedValue}`)}`;
   const typeObject = turtleType(typeName);
   const typeLine = typeObject === "" ? "" : `  a ${typeObject} ;\n`;
 

--- a/docs/inspector/src/FFI/BookStore.purs
+++ b/docs/inspector/src/FFI/BookStore.purs
@@ -69,6 +69,7 @@ foreign import inspectImpl :: Store -> BookStoreInspection
 foreign import annotationTurtle
   :: { label :: String
      , typeName :: String
+     , entityIri :: String
      , predicate :: String
      , value :: String
      }

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -74,18 +74,21 @@ WHERE {
   ?transaction a cardano:Transaction .
   {
     ?transaction cardano:isValid ?value .
-    BIND(?transaction AS ?entity)
+    BIND(cardano:isValid AS ?resolveEntity)
+    BIND(cardano:isValid AS ?resolvedType)
     BIND("Validity" AS ?label)
     BIND("boolean" AS ?kind)
     BIND("10" AS ?sort)
   } UNION {
     ?transaction cardano:hasFee ?value .
-    BIND(?transaction AS ?entity)
+    BIND(cardano:hasFee AS ?resolveEntity)
+    BIND(cardano:hasFee AS ?resolvedType)
     BIND("Fee" AS ?label)
     BIND("lovelace" AS ?kind)
     BIND("20" AS ?sort)
   } UNION {
     ?transaction cardano:scriptDataHash ?entity .
+    BIND(?entity AS ?resolveEntity)
     OPTIONAL { ?entity cardano:bytesHex ?raw . }
     BIND("Script data hash" AS ?label)
     BIND("hash" AS ?kind)
@@ -93,6 +96,7 @@ WHERE {
     BIND("30" AS ?sort)
   } UNION {
     ?transaction cardano:auxiliaryDataHash ?entity .
+    BIND(?entity AS ?resolveEntity)
     OPTIONAL { ?entity cardano:bytesHex ?raw . }
     BIND("Auxiliary data hash" AS ?label)
     BIND("hash" AS ?kind)
@@ -100,25 +104,34 @@ WHERE {
     BIND("40" AS ?sort)
   } UNION {
     ?transaction cardano:totalCollateral ?value .
-    BIND(?transaction AS ?entity)
+    BIND(cardano:totalCollateral AS ?resolveEntity)
+    BIND(cardano:totalCollateral AS ?resolvedType)
     BIND("Total collateral" AS ?label)
     BIND("lovelace" AS ?kind)
     BIND("50" AS ?sort)
   } UNION {
     ?transaction cardano:hasMint ?entity .
+    BIND(?entity AS ?resolveEntity)
     BIND("Mint" AS ?label)
     BIND("mint" AS ?kind)
     BIND(STR(?entity) AS ?value)
     BIND("60" AS ?sort)
   } UNION {
     ?transaction cardano:hasCollateralReturn ?entity .
+    BIND(?entity AS ?resolveEntity)
     BIND("Collateral return" AS ?label)
     BIND("output" AS ?kind)
     BIND(STR(?entity) AS ?value)
     BIND("70" AS ?sort)
   }
-  OPTIONAL { ?entity rdfs:label ?resolvedLabel . }
-  OPTIONAL { ?entity a ?resolvedType . }
+  OPTIONAL {
+    FILTER(BOUND(?resolveEntity))
+    ?resolveEntity rdfs:label ?resolvedLabel .
+  }
+  OPTIONAL {
+    FILTER(BOUND(?resolveEntity))
+    ?resolveEntity a ?resolvedType .
+  }
 }
 ORDER BY ?sort ?label ?value ?entity
 `;

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -384,6 +384,15 @@ const txOutRefFromUtxoUri = (value) => {
   return match ? `${match[1]}#${match[2]}` : "";
 };
 
+const isIri = (value) => /^https?:\/\//.test(String(value || "")) || String(value || "").startsWith("urn:");
+
+const annotationEntityIri = (entity, kind, value) => {
+  const entityValue = String(entity || "");
+  if (isIri(entityValue)) return entityValue;
+  const rawValue = String(value || "");
+  return rawValue === "" ? "" : `urn:cardano:id:${kind}:${rawValue}`;
+};
+
 const slug = (value) =>
   String(value || "row")
     .replace(/[^A-Za-z0-9]+/g, "-")
@@ -400,6 +409,7 @@ const treeRow = ({
   value = "",
   summary = "",
   raw = "",
+  entityIri = "",
   resolvedLabel = "",
   resolvedType = "",
   annotationPredicate = "",
@@ -414,6 +424,7 @@ const treeRow = ({
   value,
   summary,
   raw,
+  entityIri,
   resolvedLabel,
   resolvedType,
   annotationPredicate,
@@ -448,6 +459,7 @@ const appendLeaf = (rows, parentId, depth, order, label, kind, value, extra = {}
       value: stringValue,
       summary: compact(stringValue),
       raw: extra.raw || stringValue,
+      entityIri: extra.entityIri || "",
       resolvedLabel: extra.resolvedLabel || "",
       resolvedType: extra.resolvedType || "",
       annotationPredicate: extra.annotationPredicate || "",
@@ -530,6 +542,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       value: transactionId,
       summary: compact(transactionId),
       raw: txId,
+      entityIri: transactionId,
       resolvedLabel: rootResolved.resolvedLabel,
       resolvedType: rootResolved.resolvedType,
     }),
@@ -564,6 +577,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         raw,
         {
           raw,
+          entityIri: annotationEntityIri(bindingValue(field.entity), "hash", bindingValue(field.raw)),
           resolvedLabel: resolved.resolvedLabel,
           resolvedType: resolved.resolvedType,
           annotationPredicate: bindingValue(field.kind) === "hash" ? "cardano:bytesHex" : "",
@@ -601,6 +615,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         value,
         {
           raw,
+          entityIri: annotationEntityIri(bindingValue(input.entity), "tx-out-ref", raw),
           resolvedLabel: resolved.resolvedLabel,
           resolvedType: resolved.resolvedType,
           annotationPredicate: raw === "" ? "" : "cardano:fromTxOutRef",
@@ -635,6 +650,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: outputValue,
           summary: compact(outputValue),
           raw: outputValue,
+          entityIri: outputValue,
           resolvedLabel: outputResolved.resolvedLabel,
           resolvedType: outputResolved.resolvedType,
           annotationPredicate: outputTxOutRef === "" ? "" : "cardano:fromTxOutRef",
@@ -658,6 +674,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           bindingValue(output.addressBech32),
           bindingValue(output.address),
         ).resolvedType,
+        entityIri: annotationEntityIri(bindingValue(output.address), "address", bindingValue(output.addressBech32)),
         annotationPredicate: "cardano:bech32",
         annotationValue: bindingValue(output.addressBech32),
       });
@@ -672,6 +689,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", datumHash, {
         resolvedLabel: datumHashResolved.resolvedLabel,
         resolvedType: datumHashResolved.resolvedType,
+        entityIri: annotationEntityIri(bindingValue(output.datumHash), "hash", bindingValue(output.datumHashHex)),
         annotationPredicate: "cardano:bytesHex",
         annotationValue: bindingValue(output.datumHashHex),
       });
@@ -679,6 +697,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw), {
         resolvedLabel: datumRawResolved.resolvedLabel,
         resolvedType: datumRawResolved.resolvedType,
+        entityIri: annotationEntityIri(bindingValue(output.datum), "raw-bytes", bindingValue(output.datumRaw)),
         annotationPredicate: "cardano:hasRawBytes",
         annotationValue: bindingValue(output.datumRaw),
       });
@@ -716,6 +735,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: witnessValue,
           summary: compact(witnessValue),
           raw: bindingValue(witness.witness),
+          entityIri: bindingValue(witness.witness),
           resolvedLabel: witnessResolved.resolvedLabel,
           resolvedType: witnessResolved.resolvedType,
         }),
@@ -725,6 +745,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", keyValue, {
         resolvedLabel: keyResolved.resolvedLabel,
         resolvedType: keyResolved.resolvedType,
+        entityIri: annotationEntityIri(bindingValue(witness.verificationKey), "key", bindingValue(witness.verificationKeyHex)),
         annotationPredicate: "cardano:bytesHex",
         annotationValue: bindingValue(witness.verificationKeyHex),
       });
@@ -761,6 +782,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: bindingValue(redeemer.redeemer),
           summary: compact(firstBindingValue(redeemer.dataHashHex, redeemer.dataHash, redeemer.redeemer)),
           raw: bindingValue(redeemer.redeemer),
+          entityIri: bindingValue(redeemer.redeemer),
           resolvedLabel: redeemerResolved.resolvedLabel,
           resolvedType: redeemerResolved.resolvedType,
         }),
@@ -778,6 +800,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", dataHashValue, {
         resolvedLabel: dataHashResolved.resolvedLabel,
         resolvedType: dataHashResolved.resolvedType,
+        entityIri: annotationEntityIri(bindingValue(redeemer.dataHash), "hash", bindingValue(redeemer.dataHashHex)),
         annotationPredicate: "cardano:bytesHex",
         annotationValue: bindingValue(redeemer.dataHashHex),
       });
@@ -785,6 +808,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw), {
         resolvedLabel: dataRawResolved.resolvedLabel,
         resolvedType: dataRawResolved.resolvedType,
+        entityIri: annotationEntityIri(bindingValue(redeemer.data), "raw-bytes", bindingValue(redeemer.dataRaw)),
         annotationPredicate: "cardano:hasRawBytes",
         annotationValue: bindingValue(redeemer.dataRaw),
       });
@@ -821,6 +845,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           value: bindingValue(meta.metadata),
           summary: compact(firstBindingValue(meta.text, meta.raw, meta.metadata)),
           raw: firstBindingValue(meta.raw, meta.metadata),
+          entityIri: bindingValue(meta.metadata),
           resolvedLabel: metaResolved.resolvedLabel,
           resolvedType: metaResolved.resolvedType,
         }),
@@ -828,6 +853,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       appendLeaf(rows, metaId, 3, 10, "Metadata label", "integer", bindingValue(meta.label));
       appendLeaf(rows, metaId, 3, 20, "Text", "text", bindingValue(meta.text));
       appendLeaf(rows, metaId, 3, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw), {
+        entityIri: annotationEntityIri(bindingValue(meta.metadata), "raw-bytes", bindingValue(meta.raw)),
         annotationPredicate: "cardano:hasRawBytes",
         annotationValue: bindingValue(meta.raw),
       });

--- a/docs/inspector/src/FFI/RdfShapes.purs
+++ b/docs/inspector/src/FFI/RdfShapes.purs
@@ -30,6 +30,7 @@ type DecodedTreeRow =
   , value :: String
   , summary :: String
   , raw :: String
+  , entityIri :: String
   , resolvedLabel :: String
   , resolvedType :: String
   , annotationPredicate :: String

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -116,6 +116,7 @@ type State =
   , txHash :: String
   , txHex :: String
   , result :: Maybe InspectorResult
+  , loadFormExpanded :: Boolean
   , resultTab :: ResultTab
   , txCbor :: Maybe String
   , operationArgs :: String
@@ -267,6 +268,7 @@ inspectorComponent initial =
         , txHash: ""
         , txHex: ""
         , result: Nothing
+        , loadFormExpanded: true
         , resultTab: StructureTab
         , txCbor: Nothing
         , operationArgs: "{}"
@@ -325,37 +327,42 @@ inspectorComponent initial =
       ]
 
   renderInspector state =
-    case state.result of
-      Just r | isDecodedResult r ->
-        HH.div
-          [ classNames [ "app-shell", "inspect-shell" ] ]
-          [ HH.div
-              [ classNames [ "workspace", "loaded-workspace" ] ]
-              [ renderLoadedInspectorHeader state
-              , HH.div
-                  [ classNames [ "workspace-right" ] ]
-                  [ renderResult state ]
-              ]
-          ]
-      _ ->
-        HH.div
-          [ classNames [ "app-shell", "inspect-shell" ] ]
-          [ HH.div
-              [ classNames [ "workspace" ] ]
-              [ HH.div
-                  [ classNames [ "workspace-left" ] ]
-                  [ renderSettingsSummary state
-                  , renderModeTabs state
-                  , renderBooksPanel state
-                  ]
-              , HH.div
-                  [ classNames [ "workspace-right" ] ]
-                  [ renderResult state ]
-              ]
-          ]
+    let
+      decodedLoaded = case state.result of
+        Just r -> isDecodedResult r
+        Nothing -> false
+      showLoadedHeader = decodedLoaded && not state.loadFormExpanded
+    in
+      HH.div
+        [ classNames [ "app-shell", "inspect-shell" ] ]
+        [ HH.div
+            [ classNames
+                ( if showLoadedHeader then
+                    [ "workspace", "loaded-workspace" ]
+                  else
+                    [ "workspace" ]
+                )
+            ]
+            [ if showLoadedHeader then
+                renderLoadedInspectorHeader state
+              else
+                renderLoadForm state
+            , renderBooksPanel state
+            , HH.div
+                [ classNames [ "workspace-main" ] ]
+                [ renderResult state ]
+            ]
+        ]
 
   isDecodedResult result =
     result.exitOk && (Json.inspect result.stdout).valid
+
+  renderLoadForm state =
+    HH.div
+      [ classNames [ "load-form-stack" ] ]
+      [ renderSettingsSummary state
+      , renderModeTabs state
+      ]
 
   renderSettings state =
     HH.div
@@ -2993,6 +3000,7 @@ inspectorComponent initial =
         _
           { running = true
           , result = Nothing
+          , loadFormExpanded = true
           , resultTab = StructureTab
           , txCbor = Nothing
           , operationArgs = "{}"
@@ -3042,7 +3050,7 @@ inspectorComponent initial =
                       in pure (Left diag)
                     Right cbor -> pure (Right cbor)
       case hexE of
-        Left err -> H.modify_ _ { running = false, fetchError = Just err, browserPath = "[]" }
+        Left err -> H.modify_ _ { running = false, loadFormExpanded = true, fetchError = Just err, browserPath = "[]" }
         Right h -> do
           operationResult <- H.liftAff (runLedgerOperation h "tx.inspect" "{}")
           let
@@ -3094,6 +3102,7 @@ inspectorComponent initial =
             _
               { running = false
               , result = Just inspectionResult
+              , loadFormExpanded = not (isDecodedResult inspectionResult)
               , txCbor = Just h
               , operationArgs = inputContextArgs
               , browser = if operationResult.exitOk && browser.valid then Just browser else Nothing
@@ -3177,7 +3186,7 @@ inspectorComponent initial =
     SelectResultTab tab ->
       H.modify_ _ { resultTab = tab }
     ChangeInput ->
-      H.modify_ _ { result = Nothing, copied = false, copiedPath = Nothing }
+      H.modify_ _ { loadFormExpanded = true, copied = false, copiedPath = Nothing }
 
   updateAnnotationDraft update =
     H.modify_ \st -> st { annotationDraft = map update st.annotationDraft }

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -3194,12 +3194,13 @@ inspectorComponent initial =
         BookStore.annotationTurtle
           { label
           , typeName
+          , entityIri: row.entityIri
           , predicate: row.annotationPredicate
           , value: row.annotationValue
           }
     if label == "" then
       annotationError "Label is required."
-    else if row.annotationPredicate == "" || row.annotationValue == "" || turtle == "" then
+    else if row.entityIri == "" || row.annotationPredicate == "" || row.annotationValue == "" || turtle == "" then
       annotationError "This decoded row does not expose a supported annotation identifier."
     else if draft.mode == "existing" then
       case Array.find (\book -> book.id == draft.bookId && book.selected && not book.seed) st.books of

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -927,8 +927,7 @@ inspectorComponent initial =
         if row.summary == "" then row.value else row.summary
       metaText =
         if row.resolvedLabel /= "" then row.resolvedLabel
-        else if row.resolvedType /= "" then row.resolvedType
-        else row.kind
+        else ""
     in
       [ HH.div
           [ classNames rowClasses ]
@@ -951,14 +950,14 @@ inspectorComponent initial =
                       HH.strong_ [ HH.text row.label ]
                   , HH.span
                       [ classNames [ "kind-badge" ] ]
-                      [ HH.text row.kind ]
+                      [ renderDecodedTreeKind row ]
                   ]
               , if summaryText == "" then
                   HH.text ""
                 else
                   HH.div
-                    [ classNames [ "decoded-tree-summary" ] ]
-                    [ HH.text summaryText ]
+                    (decodedTreeSummaryAttrs row summaryText)
+                    [ renderDecodedTreeSummary row summaryText ]
               , if metaText == "" then
                   HH.text ""
                 else
@@ -975,19 +974,114 @@ inspectorComponent initial =
         ]
       else []
 
+  renderDecodedTreeKind row =
+    if row.resolvedType == "" then
+      HH.text row.kind
+    else
+      renderDecodedTreeIri row.resolvedType
+
+  renderDecodedTreeSummary row summaryText =
+    let
+      fullSubject = decodedTreeFullSubject row summaryText
+    in
+      if fullSubject /= "" then
+        HH.button
+          [ classNames [ "decoded-tree-subject", "summary-copy-target" ]
+          , HP.title fullSubject
+          , HH.attr (HH.AttrName "aria-label") ("Copy " <> row.label)
+          , HE.onClick (\_ -> CopyValue row.id fullSubject)
+          ]
+          [ HH.text (middleTruncate 24 18 fullSubject) ]
+      else
+        renderDecodedTreeIri summaryText
+
+  decodedTreeSummaryAttrs row summaryText =
+    let
+      fullSubject = decodedTreeFullSubject row summaryText
+    in
+      if fullSubject == "" then
+        [ classNames [ "decoded-tree-summary" ] ]
+      else
+        [ classNames [ "decoded-tree-summary" ]
+        , HP.title fullSubject
+        ]
+
+  decodedTreeFullSubject row summaryText =
+    if isCardanoUrn row.value then row.value
+    else if isCardanoUrn summaryText then summaryText
+    else ""
+
+  renderDecodedTreeIri value =
+    case curieForIri value of
+      Just link ->
+        HH.a
+          [ classNames [ "decoded-tree-iri" ]
+          , HP.href link.href
+          , HP.target "_blank"
+          , HP.rel "noopener noreferrer"
+          , HP.title link.href
+          ]
+          [ HH.text link.label ]
+      Nothing ->
+        HH.text value
+
+  curieForIri value =
+    case Array.find (\prefix -> startsWith prefix.iri value) decodedTreeIriPrefixes of
+      Just prefix ->
+        Just
+          { href: value
+          , label:
+              prefix.name
+                <> StringCodeUnits.drop (StringCodeUnits.length prefix.iri) value
+          }
+      Nothing ->
+        if startsWith "https://" value || startsWith "http://" value then
+          Just { href: value, label: middleTruncate 32 24 value }
+        else
+          Nothing
+
+  decodedTreeIriPrefixes =
+    [ { name: "cardano:", iri: "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#" }
+    , { name: "rdf:", iri: "http://www.w3.org/1999/02/22-rdf-syntax-ns#" }
+    , { name: "rdfs:", iri: "http://www.w3.org/2000/01/rdf-schema#" }
+    , { name: "overlay:", iri: "https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#" }
+    , { name: "owl:", iri: "http://www.w3.org/2002/07/owl#" }
+    , { name: "xsd:", iri: "http://www.w3.org/2001/XMLSchema#" }
+    , { name: "sh:", iri: "http://www.w3.org/ns/shacl#" }
+    ]
+
+  isCardanoUrn value =
+    startsWith "urn:cardano:" value
+
+  startsWith prefix value =
+    StringCodeUnits.take (StringCodeUnits.length prefix) value == prefix
+
+  middleTruncate headCount tailCount value =
+    let
+      valueLength = StringCodeUnits.length value
+      limit = headCount + tailCount + 3
+    in
+      if valueLength <= limit then
+        value
+      else
+        StringCodeUnits.take headCount value
+          <> "..."
+          <> StringCodeUnits.drop (valueLength - tailCount) value
+
   renderDecodedTreeAnnotation state row =
     case state.annotationDraft of
       Just draft | draft.rowId == row.id ->
         renderDecodedTreeAnnotationDraft state row draft
       _ ->
         if row.resolvedLabel == "" && row.annotationPredicate /= "" && row.annotationValue /= "" then
-          HH.element (HH.ElemName "md-outlined-button")
+          HH.element (HH.ElemName "md-icon-button")
             [ classNames [ "inline-action", "decoded-tree-annotate" ]
             , HH.attr (HH.AttrName "role") "button"
-            , mdControl "inline"
+            , HH.attr (HH.AttrName "aria-label") "Label this node"
+            , mdControl "icon"
             , HE.onClick (\_ -> StartDecodedTreeAnnotation row)
             ]
-            [ HH.text "Label this as..." ]
+            [ HH.element (HH.ElemName "md-icon") [] [ HH.text "edit" ] ]
         else
           HH.text ""
 

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -246,6 +246,7 @@ data Action
   | BrowseJson String
   | ToggleDecodedTree String
   | SelectResultTab ResultTab
+  | ChangeInput
   | Navigate Route MouseEvent
   | ToggleTheme
 
@@ -324,21 +325,37 @@ inspectorComponent initial =
       ]
 
   renderInspector state =
-    HH.div
-      [ classNames [ "app-shell", "inspect-shell" ] ]
-      [ HH.div
-          [ classNames [ "workspace" ] ]
+    case state.result of
+      Just r | isDecodedResult r ->
+        HH.div
+          [ classNames [ "app-shell", "inspect-shell" ] ]
           [ HH.div
-              [ classNames [ "workspace-left" ] ]
-              [ renderSettingsSummary state
-              , renderModeTabs state
-              , renderBooksPanel state
+              [ classNames [ "workspace", "loaded-workspace" ] ]
+              [ renderLoadedInspectorHeader state
+              , HH.div
+                  [ classNames [ "workspace-right" ] ]
+                  [ renderResult state ]
               ]
-          , HH.div
-              [ classNames [ "workspace-right" ] ]
-              [ renderResult state ]
           ]
-      ]
+      _ ->
+        HH.div
+          [ classNames [ "app-shell", "inspect-shell" ] ]
+          [ HH.div
+              [ classNames [ "workspace" ] ]
+              [ HH.div
+                  [ classNames [ "workspace-left" ] ]
+                  [ renderSettingsSummary state
+                  , renderModeTabs state
+                  , renderBooksPanel state
+                  ]
+              , HH.div
+                  [ classNames [ "workspace-right" ] ]
+                  [ renderResult state ]
+              ]
+          ]
+
+  isDecodedResult result =
+    result.exitOk && (Json.inspect result.stdout).valid
 
   renderSettings state =
     HH.div
@@ -682,6 +699,98 @@ inspectorComponent initial =
           ]
           [ HH.text "Settings" ]
       ]
+
+  renderLoadedInspectorHeader state =
+    let
+      selected = selectedBooks state
+      parts = selectedBookParts state
+      overlayCount = Array.length (selectedOverlayParts state)
+      blueprintCount = Array.length (selectedBlueprintParts state)
+      shaclCount = Array.length (selectedShaclParts state)
+    in
+      HH.section
+        [ classNames [ "loaded-inspector-header" ]
+        , HH.attr (HH.AttrName "aria-label") "Loaded transaction controls"
+        ]
+        [ HH.div
+            [ classNames [ "loaded-inspector-context" ] ]
+            [ HH.div
+                [ classNames [ "loaded-context-item" ] ]
+                [ HH.span_ [ HH.text "Source" ]
+                , HH.strong_ [ HH.text (modeLabel state.mode) ]
+                ]
+            , HH.div
+                [ classNames [ "loaded-context-item" ] ]
+                [ HH.span_ [ HH.text "Provider" ]
+                , HH.strong_ [ HH.text (Provider.providerName state.provider) ]
+                ]
+            , HH.div
+                [ classNames [ "loaded-context-item" ] ]
+                [ HH.span_ [ HH.text "Network" ]
+                , HH.strong_ [ HH.text (networkName state.network) ]
+                ]
+            , HH.div
+                [ classNames [ "loaded-context-item", "loaded-context-hash" ] ]
+                [ HH.span_ [ HH.text "Tx id/hash" ]
+                , HH.code_ [ HH.text (loadedTxHash state) ]
+                ]
+            ]
+        , HH.div
+            [ classNames [ "loaded-book-context" ] ]
+            [ HH.span_ [ HH.text (show (Array.length selected) <> " selected") ]
+            , HH.span_ [ HH.text (show (Array.length parts) <> " parts") ]
+            , HH.span_ [ HH.text (show overlayCount <> " overlays") ]
+            , HH.span_ [ HH.text (show blueprintCount <> " blueprints") ]
+            , HH.span_ [ HH.text (show shaclCount <> " SHACL") ]
+            ]
+        , HH.div
+            [ classNames [ "loaded-inspector-actions" ] ]
+            [ HH.element (HH.ElemName "md-outlined-button")
+                [ classNames [ "secondary-action" ]
+                , HH.attr (HH.AttrName "role") "button"
+                , mdControl "secondary"
+                , HE.onClick (\_ -> ChangeInput)
+                ]
+                [ HH.text "Change input" ]
+            , HH.a
+                [ classNames [ "header-link" ]
+                , HP.href (state.routeBase <> Routing.routePath RouteLibrary)
+                , HE.onClick (Navigate RouteLibrary)
+                ]
+                [ HH.text "Library" ]
+            , HH.element (HH.ElemName "md-filled-button")
+                [ classNames [ "primary-action" ]
+                , HH.attr (HH.AttrName "role") "button"
+                , mdControl "primary"
+                , HP.disabled state.running
+                , HE.onClick (\_ -> ApplySelectedBooks)
+                ]
+                [ HH.text "Apply selected books" ]
+            ]
+        ]
+
+  modeLabel mode =
+    case mode of
+      ByHash -> "Tx hash"
+      ByHex  -> "CBOR hex"
+
+  loadedTxHash state =
+    case state.identification of
+      Just identification | identification.valid ->
+        case Array.find (\row -> row.path == "[\"identification\",\"tx_id\"]") identification.primary of
+          Just row -> row.value
+          Nothing ->
+            case Array.find (\row -> row.path == "[\"identification\",\"body_hash\"]") identification.primary of
+              Just row -> row.value
+              Nothing  -> fallbackInputHash state
+      _ -> fallbackInputHash state
+
+  fallbackInputHash state =
+    let
+      trimmedHash = String.trim state.txHash
+    in
+      if trimmedHash == "" then "decoded transaction"
+      else trimmedHash
 
   renderBooksPanel state =
     let
@@ -2973,6 +3082,8 @@ inspectorComponent initial =
             }
     SelectResultTab tab ->
       H.modify_ _ { resultTab = tab }
+    ChangeInput ->
+      H.modify_ _ { result = Nothing, copied = false, copiedPath = Nothing }
 
   updateAnnotationDraft update =
     H.modify_ \st -> st { annotationDraft = map update st.annotationDraft }

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -279,9 +279,9 @@ async function expectCQuisitorInspectSurface(page, route) {
   );
 
   const workspace = page.locator(".workspace");
-  const leftPane = page.locator(".workspace-left");
-  const rightPane = page.locator(".workspace-right");
   const loadedHeader = page.locator(".loaded-inspector-header");
+  const booksPanel = workspace.locator(".books-panel");
+  const resultPanel = workspace.locator(".result-panel");
   await expect(loadedHeader).toBeVisible();
   await expect(loadedHeader).toContainText("CBOR hex");
   await expect(loadedHeader).toContainText(/Blockfrost|Koios/);
@@ -293,17 +293,9 @@ async function expectCQuisitorInspectSurface(page, route) {
   await expect(loadedHeader.getByRole("button", { name: "Apply selected books" })).toBeVisible();
   await expect(loadedHeader).toContainText(/selected|parts/);
 
-  await expect(leftPane).toHaveCount(0);
-  const rightBox = await rightPane.boundingBox();
-  const workspaceBox = await workspace.boundingBox();
-  expect(rightBox).not.toBeNull();
-  expect(workspaceBox).not.toBeNull();
-
-  const rightRatio = rightBox.width / workspaceBox.width;
-  expect(rightRatio).toBeGreaterThan(0.92);
-  expect(rightBox.x - workspaceBox.x).toBeLessThanOrEqual(4);
-
-  const resultPanel = rightPane.locator(".result-panel");
+  await expect(page.locator(".workspace-left")).toHaveCount(0);
+  await expect(page.locator(".workspace-right")).toHaveCount(0);
+  await expect(booksPanel.getByRole("heading", { name: "Books" })).toBeVisible();
   const tabs = resultPanel.getByRole("tablist", { name: "Inspect result views" });
   await expect(tabs.getByRole("tab", { name: "Structure" })).toHaveAttribute(
     "aria-selected",
@@ -318,6 +310,36 @@ async function expectCQuisitorInspectSurface(page, route) {
   await expect(transactionRow).toBeVisible();
   await expect(resultPanel.getByRole("heading", { name: "Conway transaction identity" })).toHaveCount(0);
   await expect(resultPanel.locator(".summary-identity-grid")).toHaveCount(0);
+
+  const loadedStack = await workspace.evaluate((root) => {
+    const rectForElement = (element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+      };
+    };
+    const rectFor = (selector) => {
+      const element = root.querySelector(selector);
+      return element ? rectForElement(element) : null;
+    };
+    return {
+      workspace: rectForElement(root),
+      header: rectFor(".loaded-inspector-header"),
+      books: rectFor(".books-panel"),
+      result: rectFor(".result-panel"),
+    };
+  });
+  expect(loadedStack.workspace).not.toBeNull();
+  expect(loadedStack.header).not.toBeNull();
+  expect(loadedStack.books).not.toBeNull();
+  expect(loadedStack.result).not.toBeNull();
+  expect(loadedStack.header.bottom).toBeLessThanOrEqual(loadedStack.books.top + 1);
+  expect(loadedStack.books.bottom).toBeLessThanOrEqual(loadedStack.result.top + 1);
+  expect(loadedStack.result.width).toBeGreaterThan(loadedStack.workspace.width * 0.92);
+  expect(Math.abs(loadedStack.header.left - loadedStack.result.left)).toBeLessThanOrEqual(4);
 
   const positions = await resultPanel.evaluate((panel) => {
     const tree = panel.querySelector(".decoded-structure-panel .decoded-tree-row");
@@ -980,53 +1002,162 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   );
 });
 
-test("inspect keeps chain-data settings compact and gives input/results the workspace", async ({
+test("inspect stacks load form, books, and decoded result vertically", async ({
   page,
 }) => {
   await page.goto("/inspect");
 
   await expect(page.locator(".provider-panel")).toHaveCount(0);
-  const leftPane = page.locator(".workspace-left");
-  const rightPane = page.locator(".workspace-right");
-  const settingsSummary = leftPane.locator(".settings-summary");
-  const inputPanel = leftPane.locator(".input-panel");
-  const resultPanel = rightPane.locator(".result-panel");
+  const workspace = page.locator(".workspace");
+  const settingsSummary = workspace.locator(".settings-summary");
+  const inputPanel = workspace.locator(".input-panel");
+  const booksPanel = workspace.locator(".books-panel");
+  const resultPanel = workspace.locator(".result-panel");
 
-  await expect(leftPane).toBeVisible();
-  await expect(rightPane).toBeVisible();
+  await expect(page.locator(".workspace-left")).toHaveCount(0);
+  await expect(page.locator(".workspace-right")).toHaveCount(0);
   await expect(settingsSummary).toBeVisible();
   await expect(settingsSummary).toContainText("Blockfrost");
   await expect(settingsSummary).toContainText("mainnet");
   await expect(settingsSummary.getByRole("link", { name: "Settings" })).toBeVisible();
   await expect(inputPanel).toBeVisible();
-  await expect(leftPane.getByRole("heading", { name: "Books" })).toBeVisible();
+  await expect(booksPanel.getByRole("heading", { name: "Books" })).toBeVisible();
+  await expect(inputPanel.locator(".books-panel")).toHaveCount(0);
   await expect(resultPanel.getByRole("heading", { name: "Decoded structure" })).toBeVisible();
-  await expect(rightPane.locator(".decoded-structure-panel")).toHaveCount(0);
+  await expect(resultPanel.locator(".decoded-structure-panel")).toHaveCount(0);
 
-  const workspaceBox = await page.locator(".workspace").boundingBox();
-  const leftBox = await leftPane.boundingBox();
-  const rightBox = await rightPane.boundingBox();
-  expect(leftBox.width).toBeGreaterThan(workspaceBox.width * 0.46);
-  expect(leftBox.width).toBeLessThan(workspaceBox.width * 0.54);
-  expect(rightBox.width).toBeGreaterThan(workspaceBox.width * 0.46);
-  expect(rightBox.width).toBeLessThan(workspaceBox.width * 0.54);
-  expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(8);
+  const emptyStack = await workspace.evaluate((root) => {
+    const rectForElement = (element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+      };
+    };
+    const rectFor = (selector) => {
+      const element = root.querySelector(selector);
+      return element ? rectForElement(element) : null;
+    };
+    return {
+      workspace: rectForElement(root),
+      input: rectFor(".input-panel"),
+      books: rectFor(".books-panel"),
+      result: rectFor(".result-panel"),
+    };
+  });
+  expect(emptyStack.workspace).not.toBeNull();
+  expect(emptyStack.input).not.toBeNull();
+  expect(emptyStack.books).not.toBeNull();
+  expect(emptyStack.result).not.toBeNull();
+  expect(emptyStack.input.bottom).toBeLessThanOrEqual(emptyStack.books.top + 1);
+  expect(emptyStack.books.bottom).toBeLessThanOrEqual(emptyStack.result.top + 1);
+  expect(emptyStack.input.width).toBeGreaterThan(emptyStack.workspace.width * 0.92);
+  expect(emptyStack.result.width).toBeGreaterThan(emptyStack.workspace.width * 0.92);
+  expect(Math.abs(emptyStack.input.left - emptyStack.result.left)).toBeLessThanOrEqual(4);
+
+  const booksList = booksPanel.locator(".books-list");
+  const booksOverflow = await booksList.evaluate((element) => {
+    const styles = getComputedStyle(element);
+    return {
+      maxHeight: styles.maxHeight,
+      overflow: styles.overflow,
+      overflowY: styles.overflowY,
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+    };
+  });
+  expect(booksOverflow.maxHeight).not.toBe("150px");
+  expect(booksOverflow.overflow).not.toBe("hidden");
+  expect(booksOverflow.overflowY).not.toBe("hidden");
+  expect(booksOverflow.clientHeight).toBeGreaterThanOrEqual(booksOverflow.scrollHeight);
 
   await page.getByRole("radio", { name: "CBOR hex" }).check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill("not-a-conway-hex");
   await page.getByRole("button", { name: "Decode" }).click();
   await expect(resultPanel).toContainText(/malformed_hex|invalid/i);
   await expect(page.locator(".loaded-inspector-header")).toHaveCount(0);
-  await expect(leftPane).toBeVisible();
-  await expect(rightPane).toBeVisible();
+  await expect(inputPanel).toBeVisible();
+  await expect(booksPanel).toBeVisible();
+  await expect(resultPanel).toBeVisible();
 
-  const errorWorkspaceBox = await page.locator(".workspace").boundingBox();
-  const errorLeftBox = await leftPane.boundingBox();
-  const errorRightBox = await rightPane.boundingBox();
-  expect(errorLeftBox.width).toBeGreaterThan(errorWorkspaceBox.width * 0.46);
-  expect(errorLeftBox.width).toBeLessThan(errorWorkspaceBox.width * 0.54);
-  expect(errorRightBox.width).toBeGreaterThan(errorWorkspaceBox.width * 0.46);
-  expect(errorRightBox.width).toBeLessThan(errorWorkspaceBox.width * 0.54);
+  const errorStack = await workspace.evaluate((root) => {
+    const rectForElement = (element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        width: rect.width,
+      };
+    };
+    const rectFor = (selector) => {
+      const element = root.querySelector(selector);
+      return element ? rectForElement(element) : null;
+    };
+    return {
+      workspace: rectForElement(root),
+      input: rectFor(".input-panel"),
+      books: rectFor(".books-panel"),
+      result: rectFor(".result-panel"),
+    };
+  });
+  expect(errorStack.input.bottom).toBeLessThanOrEqual(errorStack.books.top + 1);
+  expect(errorStack.books.bottom).toBeLessThanOrEqual(errorStack.result.top + 1);
+  expect(errorStack.result.width).toBeGreaterThan(errorStack.workspace.width * 0.92);
+
+  const txCbor = (await readFile(fixturePath, "utf8")).trim();
+  await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
+  await page.getByRole("button", { name: "Decode" }).click();
+
+  const loadedHeader = page.locator(".loaded-inspector-header");
+  await expect(loadedHeader).toBeVisible();
+  await expect(inputPanel).toHaveCount(0);
+  await expect(booksPanel).toBeVisible();
+  await expect(resultPanel.getByRole("tab", { name: "Structure" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(resultPanel.locator(".decoded-structure-panel")).toBeVisible();
+
+  const loadedStack = await workspace.evaluate((root) => {
+    const rectForElement = (element) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        top: rect.top,
+        bottom: rect.bottom,
+        left: rect.left,
+        width: rect.width,
+      };
+    };
+    const rectFor = (selector) => {
+      const element = root.querySelector(selector);
+      return element ? rectForElement(element) : null;
+    };
+    return {
+      workspace: rectForElement(root),
+      header: rectFor(".loaded-inspector-header"),
+      books: rectFor(".books-panel"),
+      result: rectFor(".result-panel"),
+    };
+  });
+  expect(loadedStack.header).not.toBeNull();
+  expect(loadedStack.books).not.toBeNull();
+  expect(loadedStack.result).not.toBeNull();
+  expect(loadedStack.header.bottom).toBeLessThanOrEqual(loadedStack.books.top + 1);
+  expect(loadedStack.books.bottom).toBeLessThanOrEqual(loadedStack.result.top + 1);
+  expect(loadedStack.result.width).toBeGreaterThan(loadedStack.workspace.width * 0.92);
+  expect(Math.abs(loadedStack.header.left - loadedStack.result.left)).toBeLessThanOrEqual(4);
+
+  await loadedHeader.getByRole("button", { name: "Change input" }).click();
+  await expect(inputPanel).toBeVisible();
+  await expect(resultPanel.locator(".decoded-structure-panel")).toBeVisible();
+  await expect(page.getByPlaceholder("Conway tx CBOR hex...")).toHaveValue(txCbor);
+
+  await page.getByRole("button", { name: "Decode" }).click();
+  await expect(loadedHeader).toBeVisible();
+  await expect(inputPanel).toHaveCount(0);
+  await expect(resultPanel.locator(".decoded-structure-panel")).toBeVisible();
 });
 
 test("settings changes provider state used by inspect hash decode", async ({ page }) => {

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -281,30 +281,27 @@ async function expectCQuisitorInspectSurface(page, route) {
   const workspace = page.locator(".workspace");
   const leftPane = page.locator(".workspace-left");
   const rightPane = page.locator(".workspace-right");
-  const leftBox = await leftPane.boundingBox();
+  const loadedHeader = page.locator(".loaded-inspector-header");
+  await expect(loadedHeader).toBeVisible();
+  await expect(loadedHeader).toContainText("CBOR hex");
+  await expect(loadedHeader).toContainText(/Blockfrost|Koios/);
+  await expect(loadedHeader).toContainText("mainnet");
+  await expect(loadedHeader).toContainText(/Tx (id|hash)/i);
+  await expect(loadedHeader).toContainText(/[0-9a-f]{16}/i);
+  await expect(loadedHeader.getByRole("button", { name: "Change input" })).toBeVisible();
+  await expect(loadedHeader.getByRole("link", { name: "Library" })).toBeVisible();
+  await expect(loadedHeader.getByRole("button", { name: "Apply selected books" })).toBeVisible();
+  await expect(loadedHeader).toContainText(/selected|parts/);
+
+  await expect(leftPane).toHaveCount(0);
   const rightBox = await rightPane.boundingBox();
   const workspaceBox = await workspace.boundingBox();
-  expect(leftBox).not.toBeNull();
   expect(rightBox).not.toBeNull();
   expect(workspaceBox).not.toBeNull();
 
-  const leftRatio = leftBox.width / workspaceBox.width;
   const rightRatio = rightBox.width / workspaceBox.width;
-  expect(leftRatio).toBeGreaterThan(0.46);
-  expect(leftRatio).toBeLessThan(0.54);
-  expect(rightRatio).toBeGreaterThan(0.46);
-  expect(rightRatio).toBeLessThan(0.54);
-  expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(4);
-  expect(rightBox.x - (leftBox.x + leftBox.width)).toBeLessThanOrEqual(16);
-  await expect(rightPane).toHaveCSS("border-left-width", /[1-9]px/);
-
-  await expect(leftPane.locator(".settings-summary")).toContainText(/Blockfrost|Koios/);
-  await expect(leftPane.locator(".books-panel")).toContainText(/selected|parts/);
-  const pasteInput = leftPane.getByPlaceholder("Conway tx CBOR hex...");
-  await expect(pasteInput).toBeVisible();
-  const pasteBox = await pasteInput.boundingBox();
-  expect(pasteBox.height).toBeGreaterThan(170);
-  await expect(leftPane.getByRole("button", { name: "Decode" })).toBeVisible();
+  expect(rightRatio).toBeGreaterThan(0.92);
+  expect(rightBox.x - workspaceBox.x).toBeLessThanOrEqual(4);
 
   const resultPanel = rightPane.locator(".result-panel");
   const tabs = resultPanel.getByRole("tablist", { name: "Inspect result views" });
@@ -944,9 +941,16 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   await expect(providerPanel).not.toHaveCSS("background-color", lightBackground);
 
   await page.goto("/inspect");
+  const inputPanel = page.locator(".input-panel");
+  await expect(inputPanel).toHaveAttribute("data-md3-surface", "input");
+  await expect(page.locator("md-filled-button", { hasText: "Decode" })).toHaveAttribute(
+    "data-md3-control",
+    "primary",
+  );
+
   await decodeFixtureAt(page, "/inspect");
 
-  const inputPanel = page.locator(".input-panel");
+  const loadedHeader = page.locator(".loaded-inspector-header");
   const resultPanel = page.locator(".result-panel");
   const decodedPanel = page.locator(".decoded-structure-panel");
   await selectResultTab(page, "Validation");
@@ -956,7 +960,7 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   const lensPanel = page.locator(".sparql-lens-panel").first();
 
   await expect(page.locator(".provider-panel")).toHaveCount(0);
-  await expect(inputPanel).toHaveAttribute("data-md3-surface", "input");
+  await expect(loadedHeader).toBeVisible();
   await expect(resultPanel).toHaveAttribute("data-md3-surface", "result");
   await selectResultTab(page, "Structure");
   await expect(decodedPanel).toHaveAttribute("data-md3-surface", "decoded");
@@ -966,10 +970,6 @@ test("MD3 inspector surfaces expose tokenized panels and controls", async ({
   await expect(rdfPanel).toHaveAttribute("data-md3-surface", "decoded");
   await expect(lensPanel).toHaveAttribute("data-md3-surface", "decoded");
 
-  await expect(page.locator("md-filled-button", { hasText: "Decode" })).toHaveAttribute(
-    "data-md3-control",
-    "primary",
-  );
   await expect(page.locator("md-outlined-button", { hasText: "Copy JSON" })).toHaveAttribute(
     "data-md3-control",
     "secondary",
@@ -1011,6 +1011,22 @@ test("inspect keeps chain-data settings compact and gives input/results the work
   expect(rightBox.width).toBeGreaterThan(workspaceBox.width * 0.46);
   expect(rightBox.width).toBeLessThan(workspaceBox.width * 0.54);
   expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(8);
+
+  await page.getByRole("radio", { name: "CBOR hex" }).check();
+  await page.getByPlaceholder("Conway tx CBOR hex...").fill("not-a-conway-hex");
+  await page.getByRole("button", { name: "Decode" }).click();
+  await expect(resultPanel).toContainText(/malformed_hex|invalid/i);
+  await expect(page.locator(".loaded-inspector-header")).toHaveCount(0);
+  await expect(leftPane).toBeVisible();
+  await expect(rightPane).toBeVisible();
+
+  const errorWorkspaceBox = await page.locator(".workspace").boundingBox();
+  const errorLeftBox = await leftPane.boundingBox();
+  const errorRightBox = await rightPane.boundingBox();
+  expect(errorLeftBox.width).toBeGreaterThan(errorWorkspaceBox.width * 0.46);
+  expect(errorLeftBox.width).toBeLessThan(errorWorkspaceBox.width * 0.54);
+  expect(errorRightBox.width).toBeGreaterThan(errorWorkspaceBox.width * 0.46);
+  expect(errorRightBox.width).toBeLessThan(errorWorkspaceBox.width * 0.54);
 });
 
 test("settings changes provider state used by inspect hash decode", async ({ page }) => {
@@ -1536,24 +1552,14 @@ fixture:selectedLibraryAddress
   ).toBeChecked();
 
   await openInspectViaShell(page);
-  const txCbor = (await readFile(conwayMainnetFixturePath, "utf8")).trim();
-  await page.getByRole("radio", { name: "CBOR hex" }).check();
-  await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
-  await page.getByRole("button", { name: "Decode" }).click();
+  await selectResultTab(page, "Graph / RDF");
+  const overlayPanel = page.locator(".overlay-book-panel");
+  await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
+
+  await selectResultTab(page, "Structure");
   await expect(
     page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
-
-  await selectResultTab(page, "Graph / RDF");
-  const overlayPanel = page.locator(".overlay-book-panel");
-  const applySelectedBooks = overlayPanel.getByRole("button", {
-    name: "Apply selected books",
-  });
-  if (await applySelectedBooks.count()) {
-    await applySelectedBooks.click();
-  }
-
-  await selectResultTab(page, "Structure");
   const decodedPanel = page.locator(".decoded-structure-panel");
   await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
   const resolvedAddressRow = decodedPanel

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1328,6 +1328,50 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     ).toBeVisible();
   }
 
+  const body = decodedPanel.getByRole("button", { name: /^Body\b/ });
+  await body.click();
+  const fieldPredicateHref =
+    "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#";
+  const scalarBodyRow = (label) =>
+    decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-2", {
+      has: page.locator(".decoded-tree-keyline strong", {
+        hasText: new RegExp(`^${label}$`),
+      }),
+    });
+
+  const validityRow = scalarBodyRow("Validity");
+  await expect(validityRow).toBeVisible();
+  const validityTypeLink = validityRow.getByRole("link", { name: "cardano:isValid" });
+  await expect(validityTypeLink).toBeVisible();
+  await expect(validityTypeLink).toHaveAttribute(
+    "href",
+    `${fieldPredicateHref}isValid`,
+  );
+  await expect(validityRow).not.toContainText("cardano:Transaction");
+  await expect(validityRow).not.toContainText(`${fieldPredicateHref}isValid`);
+
+  const feeRow = scalarBodyRow("Fee");
+  await expect(feeRow).toBeVisible();
+  const feeTypeLink = feeRow.getByRole("link", { name: "cardano:hasFee" });
+  await expect(feeTypeLink).toBeVisible();
+  await expect(feeTypeLink).toHaveAttribute("href", `${fieldPredicateHref}hasFee`);
+  await expect(feeRow).not.toContainText("cardano:Transaction");
+  await expect(feeRow).not.toContainText(`${fieldPredicateHref}hasFee`);
+
+  const totalCollateralRow = scalarBodyRow("Total collateral");
+  if ((await totalCollateralRow.count()) > 0) {
+    const totalCollateralTypeLink = totalCollateralRow.getByRole("link", {
+      name: "cardano:totalCollateral",
+    });
+    await expect(totalCollateralTypeLink).toBeVisible();
+    await expect(totalCollateralTypeLink).toHaveAttribute(
+      "href",
+      `${fieldPredicateHref}totalCollateral`,
+    );
+    await expect(totalCollateralRow).not.toContainText("cardano:Transaction");
+    await expect(totalCollateralRow).not.toContainText(`${fieldPredicateHref}totalCollateral`);
+  }
+
   const outputs = decodedPanel.getByRole("button", { name: /^Outputs\b/ });
   await outputs.click();
   await expect(

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1164,7 +1164,24 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     hasText: "Transaction",
   });
   await expect(rootRow).toBeVisible();
-  await expect(rootRow).toContainText(/urn:cardano:tx:/);
+  const transactionTypeHref =
+    "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#Transaction";
+  const transactionTypeLink = rootRow.getByRole("link", {
+    name: "cardano:Transaction",
+  });
+  await expect(transactionTypeLink).toBeVisible();
+  await expect(transactionTypeLink).toHaveAttribute("href", transactionTypeHref);
+  await expect(transactionTypeLink).toHaveAttribute("target", "_blank");
+  await expect(transactionTypeLink).toHaveAttribute("rel", /noopener/);
+  await expect(rootRow).not.toContainText(transactionTypeHref);
+
+  const rootSummary = rootRow.locator(".decoded-tree-summary");
+  const visibleRootSummary = await rootSummary.innerText();
+  const fullRootSubject = await rootSummary.getAttribute("title");
+  expect(fullRootSubject).toMatch(/^urn:cardano:tx:/);
+  expect(visibleRootSummary).toContain("...");
+  expect(visibleRootSummary).not.toBe(fullRootSubject);
+  await expect(rootSummary.getByRole("link")).toHaveCount(0);
 
   for (const section of [
     "Body",
@@ -1593,10 +1610,14 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
   const inlineLabel = "Inline annotated fixture address";
   await expect(firstAddressRow).not.toContainText(inlineLabel);
+  await expect(firstAddressRow.getByLabel("Label", { exact: true })).toHaveCount(0);
+  await expect(firstAddressRow.getByLabel("Optional type")).toHaveCount(0);
   await firstAddressRow
-    .getByRole("button", { name: "Label this as..." })
+    .getByRole("button", { name: "Label this node" })
     .click();
-  await firstAddressRow.getByLabel("Label").fill(inlineLabel);
+  await expect(firstAddressRow.getByLabel("Label", { exact: true })).toBeVisible();
+  await expect(firstAddressRow.getByLabel("Optional type")).toBeVisible();
+  await firstAddressRow.getByLabel("Label", { exact: true }).fill(inlineLabel);
   await firstAddressRow.getByLabel("Optional type").fill("FixtureAddress");
   await firstAddressRow.getByRole("radio", { name: "Create new local book" }).check();
   await firstAddressRow.getByLabel("New book name").fill("Inline fixture annotations");
@@ -1609,10 +1630,12 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
     .filter({ hasText: "Datum hash" })
     .first();
   const appendedLabel = "Existing-book annotated fixture datum hash";
+  await expect(datumHashRow.getByLabel("Label", { exact: true })).toHaveCount(0);
   await datumHashRow
-    .getByRole("button", { name: "Label this as..." })
+    .getByRole("button", { name: "Label this node" })
     .click();
-  await datumHashRow.getByLabel("Label").fill(appendedLabel);
+  await expect(datumHashRow.getByLabel("Label", { exact: true })).toBeVisible();
+  await datumHashRow.getByLabel("Label", { exact: true }).fill(appendedLabel);
   await datumHashRow.getByRole("radio", { name: "Append to existing book" }).check();
   await datumHashRow.getByLabel("Target book").selectOption({
     label: "Inline fixture annotations",

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1598,6 +1598,33 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   const decodedPanel = page.locator(".decoded-structure-panel");
   await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
 
+  const output0Row = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Output 0" })
+    .first();
+  await expect(output0Row).toBeVisible();
+  const output0Subject = await output0Row
+    .locator(".decoded-tree-summary")
+    .getAttribute("title");
+  expect(output0Subject).toMatch(/^urn:cardano:utxo:/);
+
+  const outputLabel = "Inline annotated fixture output";
+  await expect(output0Row).not.toContainText(outputLabel);
+  await output0Row
+    .getByRole("button", { name: "Label this node" })
+    .click();
+  await expect(output0Row.getByLabel("Label", { exact: true })).toBeVisible();
+  await output0Row.getByLabel("Label", { exact: true }).fill(outputLabel);
+  await output0Row.getByLabel("Optional type").fill("cardano:TransactionOutput");
+  await output0Row.getByRole("radio", { name: "Create new local book" }).check();
+  await output0Row.getByLabel("New book name").fill("Inline fixture annotations");
+  await output0Row.getByRole("button", { name: "Save label" }).click();
+
+  await expect(output0Row).toContainText(outputLabel);
+  await expect(
+    output0Row.getByRole("link", { name: "cardano:TransactionOutput" }),
+  ).toBeVisible();
+
   const addressRows = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Address" });
@@ -1619,8 +1646,10 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   await expect(firstAddressRow.getByLabel("Optional type")).toBeVisible();
   await firstAddressRow.getByLabel("Label", { exact: true }).fill(inlineLabel);
   await firstAddressRow.getByLabel("Optional type").fill("FixtureAddress");
-  await firstAddressRow.getByRole("radio", { name: "Create new local book" }).check();
-  await firstAddressRow.getByLabel("New book name").fill("Inline fixture annotations");
+  await firstAddressRow.getByRole("radio", { name: "Append to existing book" }).check();
+  await firstAddressRow.getByLabel("Target book").selectOption({
+    label: "Inline fixture annotations",
+  });
   await firstAddressRow.getByRole("button", { name: "Save label" }).click();
 
   await expect(firstAddressRow).toContainText(inlineLabel);
@@ -1644,6 +1673,27 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
   await expect(datumHashRow).toContainText(appendedLabel);
 
+  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  const verificationKeyRow = decodedPanel
+    .locator(".decoded-tree-row")
+    .filter({ hasText: "Verification key" })
+    .first();
+  const verificationKeyLabel = "Existing-book annotated verification key";
+  await expect(verificationKeyRow).toBeVisible();
+  await expect(verificationKeyRow.getByLabel("Label", { exact: true })).toHaveCount(0);
+  await verificationKeyRow
+    .getByRole("button", { name: "Label this node" })
+    .click();
+  await expect(verificationKeyRow.getByLabel("Label", { exact: true })).toBeVisible();
+  await verificationKeyRow.getByLabel("Label", { exact: true }).fill(verificationKeyLabel);
+  await verificationKeyRow.getByRole("radio", { name: "Append to existing book" }).check();
+  await verificationKeyRow.getByLabel("Target book").selectOption({
+    label: "Inline fixture annotations",
+  });
+  await verificationKeyRow.getByRole("button", { name: "Save label" }).click();
+
+  await expect(verificationKeyRow).toContainText(verificationKeyLabel);
+
   const rawStore = await page.evaluate(
     (key) => window.localStorage.getItem(key),
     localBookStoreKey,
@@ -1658,9 +1708,13 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   expect(generatedBook.raw).toContain("@prefix cardano:");
   expect(generatedBook.raw).toContain("@prefix rdfs:");
   expect(generatedBook.raw).toContain("@prefix local:");
+  expect(generatedBook.raw).toContain(`<${output0Subject}>`);
+  expect(generatedBook.raw).not.toContain("local:annotation-");
   expect(generatedBook.raw).toContain("cardano:bech32");
+  expect(generatedBook.raw).toContain(outputLabel);
   expect(generatedBook.raw).toContain(inlineLabel);
   expect(generatedBook.raw).toContain(appendedLabel);
+  expect(generatedBook.raw).toContain(verificationKeyLabel);
 
   await page.getByRole("banner").getByRole("link", { name: "Library" }).click();
   await expect(page).toHaveURL(/\/library$/);

--- a/specs/121-collapse-inspector-rail/plan.md
+++ b/specs/121-collapse-inspector-rail/plan.md
@@ -12,7 +12,7 @@ Observed direction: CQuisitor keeps control surfaces compact and modal/header-li
 
 ## Slice
 
-One vertical presentation slice is appropriate because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior.
+The original rail-collapse work is one vertical presentation slice because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior. The A-001 preview follow-up adds a second presentation-only slice on the same branch/PR for decoded-structure row compactness.
 
 ### Slice 1: Loaded-state rail collapse
 
@@ -31,6 +31,30 @@ Work:
 - Keep input and books reachable from the loaded header without changing decode or book logic. A details/expand affordance, edit-input toggle, or compact controls are acceptable if the decoded structure remains dominant.
 - Update CSS `.workspace*` and responsive rules so loaded mode is full-width and narrow mode stacks cleanly.
 - Add/extend Playwright assertions for empty two-pane behavior and loaded full-width/collapsed behavior, including the existing prefixed subpath harness.
+
+Focused proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+- Browser smoke of the published preview with `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`.
+
+### Slice 2: Decoded-tree row compactness
+
+Owned files:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- In decoded-structure rows, render known vocab IRIs as linked CURIEs using a local prefix table that mirrors the `PREFIX` declarations in `docs/inspector/src/FFI/RdfShapes.js`; unknown HTTP(S) IRIs remain linked but middle-truncated.
+- Collapse `urn:cardano:*` subject values from `id` or `summary` into a short middle-ellipsized, copyable, tooltip-backed text form; do not link URN subjects.
+- Replace the always-visible inline annotation call-to-action with a compact `md-icon-button` edit affordance per row, while preserving `StartDecodedTreeAnnotation` and `SaveDecodedTreeAnnotation` behavior and every field in the existing annotation draft form.
+- Keep the change presentation-only: no decode/resolution changes, no annotation persistence changes, no new JavaScript dependencies.
+- Extend Playwright coverage for the CURIE href, absence of raw vocab URL text, collapsed/not-linked URN subjects, and editor hidden-until-click behavior.
 
 Focused proof:
 

--- a/specs/121-collapse-inspector-rail/plan.md
+++ b/specs/121-collapse-inspector-rail/plan.md
@@ -1,0 +1,47 @@
+# Plan
+
+## Current Gap
+
+Issue #119 made `/inspect` CQuisitor-like by giving input and decoded structure a compact two-pane workspace. Issue #121 narrows that behavior: the two-pane layout is still right for empty/error states, but after a successful decode the permanent left rail wastes space. The loaded transaction should read like a tool surface where the result is primary and input/config/book controls collapse into a slim, reachable header.
+
+Live CQuisitor reference captured outside git:
+
+- `/tmp/ux121/clins-121/cquisitor-ready.png`
+
+Observed direction: CQuisitor keeps control surfaces compact and modal/header-like so the working output dominates rather than sharing width with a persistent rail.
+
+## Slice
+
+One vertical presentation slice is appropriate because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior.
+
+### Slice 1: Loaded-state rail collapse
+
+Owned files:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- Gate `renderInspector` on `state.result`.
+- Preserve the existing two-pane render path when `state.result == Nothing`, including fetch-error display.
+- For `state.result == Just _`, render a loaded-state workspace variant: compact header strip for loaded context and controls, full-width result/decoded structure below.
+- Include loaded context in the header: source/input mode, provider, network, and transaction id/hash derived from existing result/state data.
+- Keep input and books reachable from the loaded header without changing decode or book logic. A details/expand affordance, edit-input toggle, or compact controls are acceptable if the decoded structure remains dominant.
+- Update CSS `.workspace*` and responsive rules so loaded mode is full-width and narrow mode stacks cleanly.
+- Add/extend Playwright assertions for empty two-pane behavior and loaded full-width/collapsed behavior, including the existing prefixed subpath harness.
+
+Focused proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+- Browser smoke of the published preview with `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`.
+
+## Risks
+
+- Existing CQuisitor layout tests currently assert the loaded pane stays 50/50; those must become the RED assertions for this ticket rather than being weakened.
+- The header must expose real context without inventing new data dependencies; prefer existing state/result helpers.
+- The CSS file is committed source in this app, so style changes must be reviewed like normal source rather than treated as generated output.

--- a/specs/121-collapse-inspector-rail/plan.md
+++ b/specs/121-collapse-inspector-rail/plan.md
@@ -12,7 +12,7 @@ Observed direction: CQuisitor keeps control surfaces compact and modal/header-li
 
 ## Slice
 
-The original rail-collapse work is one vertical presentation slice because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior. The A-001 preview follow-up adds a second presentation-only slice on the same branch/PR for decoded-structure row compactness. A-002 adds a logic slice for decoded-tree annotation resolution. A-004 is a user redirect that supersedes the horizontal two-pane layout from Slice 1/A-001 with a vertical stack: load form at the top, books as its own section, decoded structure full-width below.
+The original rail-collapse work is one vertical presentation slice because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior. The A-001 preview follow-up adds a second presentation-only slice on the same branch/PR for decoded-structure row compactness. A-002 adds a logic slice for decoded-tree annotation resolution. A-004 is a user redirect that supersedes the horizontal two-pane layout from Slice 1/A-001 with a vertical stack: load form at the top, books as its own section, decoded structure full-width below. A-005 adds a decoded-tree resolution fix so scalar body-field rows never inherit the parent transaction's class or label.
 
 ### Slice 1: Loaded-state rail collapse
 
@@ -116,9 +116,34 @@ Focused proof:
 - `just hlint`
 - Browser smoke of the published preview in empty and loaded states, including uncollapse/change-input visibility.
 
+### Slice 5: Field-level decoded-tree badges
+
+Owned files:
+
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- Add Playwright RED coverage proving the decoded Body/Fee row does not render `cardano:Transaction` as its resolved type badge and instead renders a field-level linked CURIE such as `cardano:hasFee`.
+- Fix `decodedBodyFieldsQuery` so scalar transaction-property rows (Validity, Fee, Total collateral) surface a row-level predicate/value-kind type rather than resolving `rdfs:label` and `a ?resolvedType` from the parent transaction entity.
+- Preserve genuine sub-entity resolution for rows whose entity is meaningful in its own right, including hashes, mint values, collateral returns, inputs, outputs, witnesses, redeemers, metadata, and A-002 annotation targets.
+- Audit the decoded-tree lenses in `docs/inspector/src/FFI/RdfShapes.js` for the same parent-inheritance pattern and document the settled row-to-type mapping in the implementation notes or test names.
+- Keep all prior A-001/A-002/A-004 behavior intact: linked CURIEs, collapsed copyable `urn:cardano:*` subjects, edit-icon annotation gating, annotation labels resolving live, and the vertical layout.
+
+Focused proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+- Browser smoke of the published preview: decode, expand Body, and confirm Fee shows a field-level badge, not `cardano:Transaction`.
+
 ## Risks
 
 - Existing CQuisitor layout tests currently assert the loaded pane stays 50/50; those must become the RED assertions for this ticket rather than being weakened.
 - The header must expose real context without inventing new data dependencies; prefer existing state/result helpers.
 - The CSS file is committed source in this app, so style changes must be reviewed like normal source rather than treated as generated output.
 - Slice 4 intentionally changes earlier loaded-state layout assertions. Tests that still encode "decoded structure is on the right" should become RED assertions for the new vertical order rather than being weakened or deleted without replacement.
+- Slice 5 must not solve the visible symptom by hiding badges globally. The fix belongs in the tree row data: scalar rows get their own predicate/type, while real entities continue to resolve labels and classes.

--- a/specs/121-collapse-inspector-rail/plan.md
+++ b/specs/121-collapse-inspector-rail/plan.md
@@ -12,7 +12,7 @@ Observed direction: CQuisitor keeps control surfaces compact and modal/header-li
 
 ## Slice
 
-The original rail-collapse work is one vertical presentation slice because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior. The A-001 preview follow-up adds a second presentation-only slice on the same branch/PR for decoded-structure row compactness.
+The original rail-collapse work is one vertical presentation slice because the state gate, CSS layout, and Playwright coverage are one coherent UX behavior. The A-001 preview follow-up adds a second presentation-only slice on the same branch/PR for decoded-structure row compactness. A-002 adds a logic slice for decoded-tree annotation resolution. A-004 is a user redirect that supersedes the horizontal two-pane layout from Slice 1/A-001 with a vertical stack: load form at the top, books as its own section, decoded structure full-width below.
 
 ### Slice 1: Loaded-state rail collapse
 
@@ -90,8 +90,35 @@ Focused proof:
 - `just hlint`
 - Browser smoke of the published preview: label a decoded node and observe the row resolve live without re-decode.
 
+### Slice 4: Vertical inspect stack
+
+Owned files:
+
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/dist/styles.css`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- Replace the horizontal `.workspace` two-column layout with a vertical stack ordered top-to-bottom: collapsible load form, independent books section, full-width decoded result/structure area.
+- Keep the load form expanded for empty/error states. Once a transaction result is present, default the load form to a compact header with source/network/tx context and a "Change input" style control that re-expands it at any time.
+- Ensure the expanded loaded form is fully re-operable: users can change the tx hash or CBOR input and decode again; after successful re-decode the form returns to the compact loaded header.
+- Move `renderBooksPanel` out of the load/input form. Fix the books-panel max-height/overflow truncation so the section is not clipped; it may size to content or scroll deliberately with visible affordance.
+- Move `renderResult` below the load/books sections and make it full-width in both empty and loaded states. Remove the right-column decoded structure assumption.
+- Preserve all prior decoded-tree behavior: linked CURIEs, collapsed/copyable `urn:cardano:*` subjects, edit-icon-gated annotation editor, and entity-bound annotation save/resolution.
+- Extend Playwright coverage for vertical order, full-width decoded structure/no right column, books outside load form and not clipped, and collapse/uncollapse/re-decode round trip.
+
+Focused proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+- Browser smoke of the published preview in empty and loaded states, including uncollapse/change-input visibility.
+
 ## Risks
 
 - Existing CQuisitor layout tests currently assert the loaded pane stays 50/50; those must become the RED assertions for this ticket rather than being weakened.
 - The header must expose real context without inventing new data dependencies; prefer existing state/result helpers.
 - The CSS file is committed source in this app, so style changes must be reviewed like normal source rather than treated as generated output.
+- Slice 4 intentionally changes earlier loaded-state layout assertions. Tests that still encode "decoded structure is on the right" should become RED assertions for the new vertical order rather than being weakened or deleted without replacement.

--- a/specs/121-collapse-inspector-rail/plan.md
+++ b/specs/121-collapse-inspector-rail/plan.md
@@ -64,6 +64,32 @@ Focused proof:
 - `just hlint`
 - Browser smoke of the published preview with `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`.
 
+### Slice 3: Annotation labels bind to decoded entities
+
+Owned files:
+
+- `docs/inspector/src/FFI/BookStore.js`
+- `docs/inspector/src/FFI/BookStore.purs`
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Work:
+
+- Add/extend Playwright coverage so saving an inline decoded-tree annotation proves resolver binding, not just local book persistence or transient DOM text. The test must fail on the current synthetic-proxy Turtle.
+- Expose the canonical decoded-tree entity IRI on `DecodedTreeRow` (or otherwise pass the same canonical subject into the save path) for rows that support annotations.
+- Generate annotation Turtle that writes `rdfs:label` and optional `a <type>` on the target entity IRI itself, matching the decoded-tree/overlay resolution subject convention instead of `local:annotation-*` proxy subjects.
+- Recompute decoded-tree lenses after save as today, preserving selected-book persistence, export/import round-trip, and A-001 CURIE/collapsed-URN/edit-icon presentation.
+
+Focused proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+- Browser smoke of the published preview: label a decoded node and observe the row resolve live without re-decode.
+
 ## Risks
 
 - Existing CQuisitor layout tests currently assert the loaded pane stays 50/50; those must become the RED assertions for this ticket rather than being weakened.

--- a/specs/121-collapse-inspector-rail/spec.md
+++ b/specs/121-collapse-inspector-rail/spec.md
@@ -1,0 +1,30 @@
+# Issue #121: Collapse Inspector Rail After Decode
+
+## User Story
+
+As a transaction analyst using `/inspect`, I want the decoded structure to take over the page after a transaction is loaded, while keeping input, provider, and book controls reachable from a compact header, so I can inspect the transaction without a permanent half-width control rail crowding the tree.
+
+## Functional Requirements
+
+- FR1: When `state.result` is `Nothing`, `/inspect` MUST keep the current two-pane layout: settings summary, mode tabs, and books on the left; result placeholder on the right.
+- FR2: When an error is present without a decoded result, `/inspect` MUST keep the current two-pane input layout so the user can correct the input in place.
+- FR3: When `state.result` is `Just _`, `/inspect` MUST render a compact loaded-state header above the result and let the decoded structure/results span the full workspace width.
+- FR4: The loaded-state header MUST show loaded transaction context: source/provider/network and a transaction id/hash when available.
+- FR5: The loaded-state header MUST provide reachable controls to change input and to access/apply selected books without making the old rail permanently consume half the workspace.
+- FR6: The change MUST be presentation-only: no ledger operation, provider resolution, transaction decode, book store, RDF, or validation logic changes.
+- FR7: Narrow viewports MUST stack sensibly, with no overlapping text or inaccessible controls.
+
+## Acceptance Criteria
+
+- AC1: Empty `/inspect` still has visible `.workspace-left` and `.workspace-right` panes with approximately even desktop widths.
+- AC2: After decoding `specs/001-ledger-functional-layer/fixtures/conway-mainnet-tx.hex`, the workspace switches to loaded mode, the old left rail is collapsed into a slim header, and the decoded result spans nearly the full workspace width.
+- AC3: The loaded header exposes provider/network/source context, a transaction id/hash, an input-change affordance, and book context/access.
+- AC4: Playwright asserts both the unchanged empty layout and the loaded full-width/collapsed layout, including subpath behavior.
+- AC5: `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint` pass.
+- AC6: The draft PR preview is browser-smoked at `/lambdasistemi/cardano-ledger-inspector/pr-<N>/inspector/` with the Conway fixture and a screenshot of the loaded full-width state.
+
+## Non-Goals
+
+- No decode, provider, validation, RDF, witness, book-resolution, or WASM behavior changes.
+- No dependency, lockfile, generated hash, or deployment workflow changes.
+- Do not rename the product wordmark; it remains "Ledger Inspector".

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -2,7 +2,7 @@
 
 ## Slice 1: Loaded-state rail collapse
 
-- [ ] T121-S1 Add Playwright RED assertions that empty/error states keep the two-pane layout and loaded state collapses the left rail into a slim header with full-width decoded results.
-- [ ] T121-S1 Update `Main.purs` presentation to gate on `state.result`, preserving the empty/error two-pane path and rendering a loaded-state header plus full-width result path for `Just _`.
-- [ ] T121-S1 Update `styles.css` workspace/header/responsive rules so loaded desktop is full-width and narrow layouts stack without overlap.
-- [ ] T121-S1 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S1` trailer.
+- [X] T121-S1 Add Playwright RED assertions that empty/error states keep the two-pane layout and loaded state collapses the left rail into a slim header with full-width decoded results.
+- [X] T121-S1 Update `Main.purs` presentation to gate on `state.result`, preserving the empty/error two-pane path and rendering a loaded-state header plus full-width result path for `Just _`.
+- [X] T121-S1 Update `styles.css` workspace/header/responsive rules so loaded desktop is full-width and narrow layouts stack without overlap.
+- [X] T121-S1 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S1` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -9,7 +9,7 @@
 
 ## Slice 2: Decoded-tree row compactness
 
-- [ ] T121-S2 Add Playwright RED assertions for decoded-structure rows: vocab IRIs render as linked CURIEs with the full href, raw vocab URLs are not shown as row text, `urn:cardano:*` subjects are collapsed and not linked, and annotation fields stay hidden until the edit icon is clicked.
-- [ ] T121-S2 Update `Main.purs` presentation so decoded tree rows use the `FFI/RdfShapes.js` prefix table for linked CURIE labels, collapse/copy non-dereferenceable `urn:cardano:*` subjects, and gate the existing annotation draft form behind an `md-icon-button` edit affordance without changing the save flow.
-- [ ] T121-S2 Update `styles.css` for the compact CURIE/subject/edit-icon row presentation and responsive annotation expander behavior.
-- [ ] T121-S2 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S2` trailer.
+- [X] T121-S2 Add Playwright RED assertions for decoded-structure rows: vocab IRIs render as linked CURIEs with the full href, raw vocab URLs are not shown as row text, `urn:cardano:*` subjects are collapsed and not linked, and annotation fields stay hidden until the edit icon is clicked.
+- [X] T121-S2 Update `Main.purs` presentation so decoded tree rows use the `FFI/RdfShapes.js` prefix table for linked CURIE labels, collapse/copy non-dereferenceable `urn:cardano:*` subjects, and gate the existing annotation draft form behind an `md-icon-button` edit affordance without changing the save flow.
+- [X] T121-S2 Update `styles.css` for the compact CURIE/subject/edit-icon row presentation and responsive annotation expander behavior.
+- [X] T121-S2 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S2` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -6,3 +6,10 @@
 - [X] T121-S1 Update `Main.purs` presentation to gate on `state.result`, preserving the empty/error two-pane path and rendering a loaded-state header plus full-width result path for `Just _`.
 - [X] T121-S1 Update `styles.css` workspace/header/responsive rules so loaded desktop is full-width and narrow layouts stack without overlap.
 - [X] T121-S1 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S1` trailer.
+
+## Slice 2: Decoded-tree row compactness
+
+- [ ] T121-S2 Add Playwright RED assertions for decoded-structure rows: vocab IRIs render as linked CURIEs with the full href, raw vocab URLs are not shown as row text, `urn:cardano:*` subjects are collapsed and not linked, and annotation fields stay hidden until the edit icon is clicked.
+- [ ] T121-S2 Update `Main.purs` presentation so decoded tree rows use the `FFI/RdfShapes.js` prefix table for linked CURIE labels, collapse/copy non-dereferenceable `urn:cardano:*` subjects, and gate the existing annotation draft form behind an `md-icon-button` edit affordance without changing the save flow.
+- [ ] T121-S2 Update `styles.css` for the compact CURIE/subject/edit-icon row presentation and responsive annotation expander behavior.
+- [ ] T121-S2 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S2` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -13,3 +13,10 @@
 - [X] T121-S2 Update `Main.purs` presentation so decoded tree rows use the `FFI/RdfShapes.js` prefix table for linked CURIE labels, collapse/copy non-dereferenceable `urn:cardano:*` subjects, and gate the existing annotation draft form behind an `md-icon-button` edit affordance without changing the save flow.
 - [X] T121-S2 Update `styles.css` for the compact CURIE/subject/edit-icon row presentation and responsive annotation expander behavior.
 - [X] T121-S2 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S2` trailer.
+
+## Slice 3: Annotation labels bind to decoded entities
+
+- [ ] T121-S3 Add Playwright RED coverage that labeling decoded-tree nodes resolves the row through the decoded-tree resolver immediately after Save, including Output 0, an address, a script/hash-like row, and another identifier row where present.
+- [ ] T121-S3 Surface the decoded row's canonical entity IRI to the annotation save path and update generated annotation Turtle so `rdfs:label` and optional `a <type>` attach to that entity rather than a synthetic local proxy.
+- [ ] T121-S3 Preserve the A-001 presentation contract and existing annotation book persistence/export/import behavior while making the saved label/type re-query into `resolvedLabel`/`resolvedType` without a re-decode.
+- [ ] T121-S3 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S3` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -16,7 +16,7 @@
 
 ## Slice 3: Annotation labels bind to decoded entities
 
-- [ ] T121-S3 Add Playwright RED coverage that labeling decoded-tree nodes resolves the row through the decoded-tree resolver immediately after Save, including Output 0, an address, a script/hash-like row, and another identifier row where present.
-- [ ] T121-S3 Surface the decoded row's canonical entity IRI to the annotation save path and update generated annotation Turtle so `rdfs:label` and optional `a <type>` attach to that entity rather than a synthetic local proxy.
-- [ ] T121-S3 Preserve the A-001 presentation contract and existing annotation book persistence/export/import behavior while making the saved label/type re-query into `resolvedLabel`/`resolvedType` without a re-decode.
-- [ ] T121-S3 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S3` trailer.
+- [X] T121-S3 Add Playwright RED coverage that labeling decoded-tree nodes resolves the row through the decoded-tree resolver immediately after Save, including Output 0, an address, a script/hash-like row, and another identifier row where present.
+- [X] T121-S3 Surface the decoded row's canonical entity IRI to the annotation save path and update generated annotation Turtle so `rdfs:label` and optional `a <type>` attach to that entity rather than a synthetic local proxy.
+- [X] T121-S3 Preserve the A-001 presentation contract and existing annotation book persistence/export/import behavior while making the saved label/type re-query into `resolvedLabel`/`resolvedType` without a re-decode.
+- [X] T121-S3 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S3` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -23,7 +23,7 @@
 
 ## Slice 4: Vertical inspect stack
 
-- [ ] T121-S4 Add Playwright RED coverage for the revised vertical inspect layout: load form above books above decoded structure, no right-column decoded pane, decoded structure full-width, books outside the load form and not clipped, and loaded-state collapse/uncollapse/re-decode behavior.
-- [ ] T121-S4 Update `Main.purs` presentation so `.workspace` renders as a vertical stack with a top collapsible load form, a separate books section, and full-width decoded results below while preserving CURIE links, collapsed URNs, edit-icon annotation gating, and entity-bound annotation resolution.
-- [ ] T121-S4 Update `styles.css` to remove the horizontal two-column workspace assumptions, fix the books panel height truncation/overflow bug, and keep empty, loaded, and narrow layouts visually coherent.
-- [ ] T121-S4 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S4` trailer.
+- [X] T121-S4 Add Playwright RED coverage for the revised vertical inspect layout: load form above books above decoded structure, no right-column decoded pane, decoded structure full-width, books outside the load form and not clipped, and loaded-state collapse/uncollapse/re-decode behavior.
+- [X] T121-S4 Update `Main.purs` presentation so `.workspace` renders as a vertical stack with a top collapsible load form, a separate books section, and full-width decoded results below while preserving CURIE links, collapsed URNs, edit-icon annotation gating, and entity-bound annotation resolution.
+- [X] T121-S4 Update `styles.css` to remove the horizontal two-column workspace assumptions, fix the books panel height truncation/overflow bug, and keep empty, loaded, and narrow layouts visually coherent.
+- [X] T121-S4 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S4` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -30,7 +30,7 @@
 
 ## Slice 5: Field-level decoded-tree badges
 
-- [ ] T121-S5 Add Playwright RED coverage that the decoded Body/Fee row renders a field-level linked CURIE badge and never `cardano:Transaction`, with scalar body fields not inheriting the transaction label/type.
-- [ ] T121-S5 Update `RdfShapes.js` decoded-tree lenses so scalar transaction-property rows use their own field predicate or value type, while genuine sub-entities still resolve their own `rdfs:label` and `a` class.
-- [ ] T121-S5 Audit body fields, inputs, outputs, witnesses, redeemers, metadata, and the root query for parent-inheritance bugs and preserve A-001/A-002/A-004 row presentation, annotation resolution, and vertical layout behavior.
-- [ ] T121-S5 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S5` trailer.
+- [X] T121-S5 Add Playwright RED coverage that the decoded Body/Fee row renders a field-level linked CURIE badge and never `cardano:Transaction`, with scalar body fields not inheriting the transaction label/type.
+- [X] T121-S5 Update `RdfShapes.js` decoded-tree lenses so scalar transaction-property rows use their own field predicate or value type, while genuine sub-entities still resolve their own `rdfs:label` and `a` class.
+- [X] T121-S5 Audit body fields, inputs, outputs, witnesses, redeemers, metadata, and the root query for parent-inheritance bugs and preserve A-001/A-002/A-004 row presentation, annotation resolution, and vertical layout behavior.
+- [X] T121-S5 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S5` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -20,3 +20,10 @@
 - [X] T121-S3 Surface the decoded row's canonical entity IRI to the annotation save path and update generated annotation Turtle so `rdfs:label` and optional `a <type>` attach to that entity rather than a synthetic local proxy.
 - [X] T121-S3 Preserve the A-001 presentation contract and existing annotation book persistence/export/import behavior while making the saved label/type re-query into `resolvedLabel`/`resolvedType` without a re-decode.
 - [X] T121-S3 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S3` trailer.
+
+## Slice 4: Vertical inspect stack
+
+- [ ] T121-S4 Add Playwright RED coverage for the revised vertical inspect layout: load form above books above decoded structure, no right-column decoded pane, decoded structure full-width, books outside the load form and not clipped, and loaded-state collapse/uncollapse/re-decode behavior.
+- [ ] T121-S4 Update `Main.purs` presentation so `.workspace` renders as a vertical stack with a top collapsible load form, a separate books section, and full-width decoded results below while preserving CURIE links, collapsed URNs, edit-icon annotation gating, and entity-bound annotation resolution.
+- [ ] T121-S4 Update `styles.css` to remove the horizontal two-column workspace assumptions, fix the books panel height truncation/overflow bug, and keep empty, loaded, and narrow layouts visually coherent.
+- [ ] T121-S4 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S4` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+## Slice 1: Loaded-state rail collapse
+
+- [ ] T121-S1 Add Playwright RED assertions that empty/error states keep the two-pane layout and loaded state collapses the left rail into a slim header with full-width decoded results.
+- [ ] T121-S1 Update `Main.purs` presentation to gate on `state.result`, preserving the empty/error two-pane path and rendering a loaded-state header plus full-width result path for `Just _`.
+- [ ] T121-S1 Update `styles.css` workspace/header/responsive rules so loaded desktop is full-width and narrow layouts stack without overlap.
+- [ ] T121-S1 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S1` trailer.

--- a/specs/121-collapse-inspector-rail/tasks.md
+++ b/specs/121-collapse-inspector-rail/tasks.md
@@ -27,3 +27,10 @@
 - [X] T121-S4 Update `Main.purs` presentation so `.workspace` renders as a vertical stack with a top collapsible load form, a separate books section, and full-width decoded results below while preserving CURIE links, collapsed URNs, edit-icon annotation gating, and entity-bound annotation resolution.
 - [X] T121-S4 Update `styles.css` to remove the horizontal two-column workspace assumptions, fix the books panel height truncation/overflow bug, and keep empty, loaded, and narrow layouts visually coherent.
 - [X] T121-S4 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S4` trailer.
+
+## Slice 5: Field-level decoded-tree badges
+
+- [ ] T121-S5 Add Playwright RED coverage that the decoded Body/Fee row renders a field-level linked CURIE badge and never `cardano:Transaction`, with scalar body fields not inheriting the transaction label/type.
+- [ ] T121-S5 Update `RdfShapes.js` decoded-tree lenses so scalar transaction-property rows use their own field predicate or value type, while genuine sub-entities still resolve their own `rdfs:label` and `a` class.
+- [ ] T121-S5 Audit body fields, inputs, outputs, witnesses, redeemers, metadata, and the root query for parent-inheritance bugs and preserve A-001/A-002/A-004 row presentation, annotation resolution, and vertical layout behavior.
+- [ ] T121-S5 Run `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint`; commit one bisect-safe slice with the required `Tasks: T121-S5` trailer.


### PR DESCRIPTION
Closes #121

## Summary
- restructure `/inspect` into a vertical stack: top load form/header, separate Books section, full-width decoded/result area below
- keep the load form expanded for empty/error states; after successful decode it collapses to a compact header and can be uncollapsed with `Change input` without clearing the current result
- move Books out of the load form and fix the clipped books-list height/overflow behavior
- compact decoded-structure rows: vocab IRIs render as linked CURIEs, `urn:cardano:*` subjects are collapsed/copyable and not linked, and annotation editing is gated behind the per-row edit icon
- fix inline decoded-tree annotations so saved labels/types attach to the decoded entity IRI instead of a synthetic `local:annotation-*` proxy, resolving live after Save without re-decode
- fix decoded-tree scalar body fields so Fee/Validity/Total collateral use field-level CURIE badges (`cardano:hasFee`, `cardano:isValid`, `cardano:totalCollateral`) instead of inheriting `cardano:Transaction` from the parent transaction
- add Playwright coverage for vertical order, full-width decoded structure, no right column, unclipped external Books section, collapse/uncollapse/re-decode, CURIE hrefs, collapsed URNs, hidden-until-click annotation editing, annotation labels binding to decoded rows, and scalar field badge attribution

## Verification
- `./gate.sh` at `522a2a8` (format-check, hlint, tx-inspector-ui build, 38 Playwright tests)
- worker gate at `601d35b` before task-amend: `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, `just hlint`, `./gate.sh`
- Claude Code navigator cross-check: `NAVIGATOR-VERIFIED-FINAL 522a2a8`
- GitHub checks green for `522a2a8`
- Preview smoke passed for `522a2a8`: decoded the fixture, expanded Body, confirmed Fee renders linked `cardano:hasFee` with href `https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#hasFee`, and confirmed the row does not show `cardano:Transaction` or the raw vocab URL
- previous preview smoke passed for `78a7b2a`: verified empty vertical stack, unclipped external Books section, loaded compact header + full-width decoded structure, `Change input` uncollapse, and re-decode collapse round trip
- previous preview smoke passed for `7d9dce8`: labeled `Output 0`, saw the row resolve live, and verified the generated book targets `<urn:cardano:utxo:2e614d780fc09097e4c90bbf1d366b289cb93086d62733e7f74ecb28f49da6f3:0>` with no `local:annotation-*`

Preview smoke screenshots:
- `/tmp/ux121/clins-121/preview-fee-field-badge.png`
- `/tmp/ux121/clins-121/preview-vertical-empty.png`
- `/tmp/ux121/clins-121/preview-vertical-loaded.png`
- `/tmp/ux121/clins-121/preview-annotation-resolution.png`

Preview URL: https://preview.dev.plutimus.com/lambdasistemi/cardano-ledger-inspector/pr-122/inspector/

Draft only; not ready for merge.