### PR TITLE
feat(inspector): resolve opaque entities via flat cardano:txOutRef

### DIFF
--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -392,7 +392,7 @@ fieldset {
 
 .loaded-inspector-context {
   display: grid;
-  grid-template-columns: repeat(3, minmax(96px, auto)) minmax(180px, 1fr);
+  grid-template-columns: repeat(3, minmax(96px, auto)) repeat(2, minmax(180px, 1fr));
   align-items: center;
   gap: 8px;
   min-width: 0;
@@ -418,11 +418,23 @@ fieldset {
   font-size: 0.88rem;
 }
 
-.loaded-context-hash code {
+.loaded-context-value {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.loaded-context-value code {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.loaded-context-copy {
+  min-height: 30px;
 }
 
 .loaded-book-context,

--- a/docs/inspector/dist/styles.css
+++ b/docs/inspector/dist/styles.css
@@ -1392,18 +1392,6 @@ md-icon-button:focus-visible,
   background: color-mix(in srgb, var(--md-sys-color-primary-container) 44%, var(--surface));
 }
 
-.decoded-tree-depth-1 {
-  margin-left: 12px;
-}
-
-.decoded-tree-depth-2 {
-  margin-left: 24px;
-}
-
-.decoded-tree-depth-3 {
-  margin-left: 36px;
-}
-
 .decoded-tree-main {
   display: grid;
   gap: 0.25rem;
@@ -1417,12 +1405,31 @@ md-icon-button:focus-visible,
   min-width: 0;
 }
 
+.decoded-tree-keyline > strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.decoded-tree-keyline .kind-badge {
+  flex: 0 0 auto;
+}
+
 .decoded-tree-toggle {
-  min-width: 104px;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.decoded-tree-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
 }
 
 .decoded-tree-annotate {
-  justify-self: start;
+  flex: 0 0 auto;
   width: 32px;
   height: 32px;
   max-width: 100%;
@@ -1592,8 +1599,7 @@ md-icon-button:focus-visible,
   min-width: 0;
 }
 
-.browser-keyline,
-.browser-actions {
+.browser-keyline {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -1601,10 +1607,29 @@ md-icon-button:focus-visible,
 }
 
 .browser-keyline code {
+  flex: 0 1 auto;
+  min-width: 0;
   max-width: min(42vw, 28rem);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.browser-keyline .kind-badge {
+  flex: 0 0 auto;
+}
+
+.browser-row-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+}
+
+.browser-row-action {
+  min-width: 68px;
+  min-height: 30px;
 }
 
 .browser-summary {
@@ -1839,10 +1864,6 @@ pre {
   .browser-heading,
   .identity-heading {
     display: grid;
-  }
-
-  .browser-actions {
-    justify-content: start;
   }
 
   .browser-children {

--- a/docs/inspector/protocols/amaru-treasury/journal-2026.json
+++ b/docs/inspector/protocols/amaru-treasury/journal-2026.json
@@ -1,5 +1,5 @@
 {
-  "scope_owners": "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#00",
+  "scope_owners": "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#0",
   "treasuries": {
     "core_development": {
       "owner": "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
@@ -7,15 +7,15 @@
       "address": "addr1x90mk0jjjhppr36ethwj8kewpgyrxyc7q6qucl4gqru96dzlhvl999wzz8r4jhway0djuzsgxvf3up5pe3l2sq8ct56qtjz6ah",
       "treasury_script": {
         "hash": "5fbb3e5295c211c7595ddd23db2e0a0833131e0681cc7ea800f85d34",
-        "deployed_at": "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#00"
+        "deployed_at": "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#0"
       },
       "permissions_script": {
         "hash": "03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39",
-        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#00"
+        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#0"
       },
       "registry_script": {
         "hash": "1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b",
-        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#00"
+        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#0"
       }
     },
     "ops_and_use_cases": {
@@ -24,15 +24,15 @@
       "address": "addr1x9r8gmryz5wrwvlxm6g4s4u9ssdz656z95hwjnk9rgamedzxw3kxg9guxue7dh53tptctpq694f5ytfwa98v2x3mhj6qe3kxep",
       "treasury_script": {
         "hash": "46746c64151c3733e6de91585785841a2d53422d2ee94ec51a3bbcb4",
-        "deployed_at": "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#00"
+        "deployed_at": "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#0"
       },
       "permissions_script": {
         "hash": "cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb",
-        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#01"
+        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#1"
       },
       "registry_script": {
         "hash": "bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c",
-        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#01"
+        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#1"
       }
     },
     "network_compliance": {
@@ -41,15 +41,15 @@
       "address": "addr1xyezq8wpaqnssdjvd3p220uf7e6nzjae44w6yu625y965rfjyqwur6p8pqmycmzz55lcnan4x99mnt2a5fe54ggt4gxs8thzgk",
       "treasury_script": {
         "hash": "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
-        "deployed_at": "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#00"
+        "deployed_at": "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#0"
       },
       "permissions_script": {
 	"hash": "a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094",
-        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#02"
+        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#2"
       },
       "registry_script": {
         "hash": "38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d",
-        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#02"
+        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#2"
       }
     },
     "middleware": {
@@ -58,15 +58,15 @@
       "address": "addr1x8a5gxtm0ynzw80f80rsps3a5dwem43swsekpnctd0wuwxhmgsvhk7fxyuw7jw78qrprmg6anhtrqapnvr8sk67acudqhnwrjp",
       "treasury_script": {
         "hash": "fb44197b7926271de93bc700c23da35d9dd630743360cf0b6bddc71a",
-        "deployed_at": "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#00"
+        "deployed_at": "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#0"
       },
       "permissions_script": {
         "hash": "212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c",
-        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#03"
+        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#3"
       },
       "registry_script": {
         "hash": "def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638",
-        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#03"
+        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#3"
       }
     },
     "contingency": {
@@ -75,15 +75,15 @@
       "address": "addr1x8ndhlcfy30t38z0tql64fpg8ply93r37xrgvdagfpsz5nhxm0lsjfz7hzwy7kpl42jzswr7gtz8ruvxscm6sjrq9f8qruq0ae",
       "treasury_script": {
         "hash": "e6dbff09245eb89c4f583faaa428387e42c471f1868637a848602a4e",
-        "deployed_at": "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#00"
+        "deployed_at": "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#0"
       },
       "permissions_script": {
         "hash": "2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a",
-        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04"
+        "deployed_at": "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#4"
       },
       "registry_script": {
         "hash": "7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988",
-        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04"
+        "deployed_at": "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#4"
       }
     }
   }

--- a/docs/inspector/protocols/amaru-treasury/overlay.ttl
+++ b/docs/inspector/protocols/amaru-treasury/overlay.ttl
@@ -40,7 +40,7 @@ overlay:scriptRole a rdf:Property ; rdfs:label "Script role" .
 overlay:amaruScopeOwners
   a overlay:ScopeOwners ;
   rdfs:label "Amaru treasury scope owners" ;
-  cardano:fromTxOutRef "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#00" .
+  cardano:txOutRef "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#0" .
 
 overlay:amaruAddress-contingency
   a overlay:Address ;
@@ -62,21 +62,21 @@ overlay:amaruTreasury-contingency
   a overlay:CardanoScript ;
   rdfs:label "Amaru Contingency treasury script" ;
   overlay:scriptRole "treasury_script" ;
-  cardano:fromTxOutRef "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#00" ;
+  cardano:txOutRef "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#0" ;
   overlay:slug "contingency-treasury_script" .
 
 <urn:cardano:id:script:2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Contingency permissions script" ;
   overlay:scriptRole "permissions_script" ;
-  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04" ;
+  cardano:txOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#4" ;
   overlay:slug "contingency-permissions_script" .
 
 <urn:cardano:id:script:7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Contingency registry script" ;
   overlay:scriptRole "registry_script" ;
-  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04" ;
+  cardano:txOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#4" ;
   overlay:slug "contingency-registry_script" .
 
 overlay:amaruAddress-core_development
@@ -104,21 +104,21 @@ overlay:amaruTreasury-core_development
   a overlay:CardanoScript ;
   rdfs:label "Amaru Core Development treasury script" ;
   overlay:scriptRole "treasury_script" ;
-  cardano:fromTxOutRef "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#00" ;
+  cardano:txOutRef "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#0" ;
   overlay:slug "core_development-treasury_script" .
 
 <urn:cardano:id:script:03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Core Development permissions script" ;
   overlay:scriptRole "permissions_script" ;
-  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#00" ;
+  cardano:txOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#0" ;
   overlay:slug "core_development-permissions_script" .
 
 <urn:cardano:id:script:1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Core Development registry script" ;
   overlay:scriptRole "registry_script" ;
-  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#00" ;
+  cardano:txOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#0" ;
   overlay:slug "core_development-registry_script" .
 
 overlay:amaruAddress-middleware
@@ -146,21 +146,21 @@ overlay:amaruTreasury-middleware
   a overlay:CardanoScript ;
   rdfs:label "Amaru Middleware treasury script" ;
   overlay:scriptRole "treasury_script" ;
-  cardano:fromTxOutRef "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#00" ;
+  cardano:txOutRef "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#0" ;
   overlay:slug "middleware-treasury_script" .
 
 <urn:cardano:id:script:212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Middleware permissions script" ;
   overlay:scriptRole "permissions_script" ;
-  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#03" ;
+  cardano:txOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#3" ;
   overlay:slug "middleware-permissions_script" .
 
 <urn:cardano:id:script:def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Middleware registry script" ;
   overlay:scriptRole "registry_script" ;
-  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#03" ;
+  cardano:txOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#3" ;
   overlay:slug "middleware-registry_script" .
 
 overlay:amaruAddress-network_compliance
@@ -188,21 +188,21 @@ overlay:amaruTreasury-network_compliance
   a overlay:CardanoScript ;
   rdfs:label "Amaru Network Compliance treasury script" ;
   overlay:scriptRole "treasury_script" ;
-  cardano:fromTxOutRef "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#00" ;
+  cardano:txOutRef "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#0" ;
   overlay:slug "network_compliance-treasury_script" .
 
 <urn:cardano:id:script:a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Network Compliance permissions script" ;
   overlay:scriptRole "permissions_script" ;
-  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#02" ;
+  cardano:txOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#2" ;
   overlay:slug "network_compliance-permissions_script" .
 
 <urn:cardano:id:script:38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Network Compliance registry script" ;
   overlay:scriptRole "registry_script" ;
-  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#02" ;
+  cardano:txOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#2" ;
   overlay:slug "network_compliance-registry_script" .
 
 overlay:amaruAddress-ops_and_use_cases
@@ -230,19 +230,19 @@ overlay:amaruTreasury-ops_and_use_cases
   a overlay:CardanoScript ;
   rdfs:label "Amaru Ops And Use Cases treasury script" ;
   overlay:scriptRole "treasury_script" ;
-  cardano:fromTxOutRef "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#00" ;
+  cardano:txOutRef "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#0" ;
   overlay:slug "ops_and_use_cases-treasury_script" .
 
 <urn:cardano:id:script:cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Ops And Use Cases permissions script" ;
   overlay:scriptRole "permissions_script" ;
-  cardano:fromTxOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#01" ;
+  cardano:txOutRef "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#1" ;
   overlay:slug "ops_and_use_cases-permissions_script" .
 
 <urn:cardano:id:script:bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c>
   a overlay:CardanoScript ;
   rdfs:label "Amaru Ops And Use Cases registry script" ;
   overlay:scriptRole "registry_script" ;
-  cardano:fromTxOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#01" ;
+  cardano:txOutRef "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#1" ;
   overlay:slug "ops_and_use_cases-registry_script" .

--- a/docs/inspector/src/FFI/OverlayBook.js
+++ b/docs/inspector/src/FFI/OverlayBook.js
@@ -55,7 +55,7 @@ cardano:TransactionShape
 `;
 
 const AMARU_JOURNAL = {
-  scope_owners: "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#00",
+  scope_owners: "11ace24a7b0caad4a68a38ef2fff18185dc9ea604e84425dab487cae94e4cf54#0",
   treasuries: {
     core_development: {
       owner: "7095faf3d48d582fbae8b3f2e726670d7a35e2400c783d992bbdeffb",
@@ -63,15 +63,15 @@ const AMARU_JOURNAL = {
       address: "addr1x90mk0jjjhppr36ethwj8kewpgyrxyc7q6qucl4gqru96dzlhvl999wzz8r4jhway0djuzsgxvf3up5pe3l2sq8ct56qtjz6ah",
       treasury_script: {
         hash: "5fbb3e5295c211c7595ddd23db2e0a0833131e0681cc7ea800f85d34",
-        deployed_at: "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#00",
+        deployed_at: "87ee53271fb41021efa13c2dbe2998c18ead07d32a6ab6dda184853ed7e39aae#0",
       },
       permissions_script: {
         hash: "03ee9cf951e89fb82c47edbff562ee90be17de85b2c24b451c7e8e39",
-        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#00",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#0",
       },
       registry_script: {
         hash: "1e1ee91b8e2bddc9d583d92fd1ba5ea47b8a3e62c1eacb0ec799b99b",
-        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#00",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#0",
       },
     },
     ops_and_use_cases: {
@@ -80,15 +80,15 @@ const AMARU_JOURNAL = {
       address: "addr1x9r8gmryz5wrwvlxm6g4s4u9ssdz656z95hwjnk9rgamedzxw3kxg9guxue7dh53tptctpq694f5ytfwa98v2x3mhj6qe3kxep",
       treasury_script: {
         hash: "46746c64151c3733e6de91585785841a2d53422d2ee94ec51a3bbcb4",
-        deployed_at: "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#00",
+        deployed_at: "660c0729b68bce67f62d4f1f3ae38082217e55915bb3e0d9222a67b2f9fd821c#0",
       },
       permissions_script: {
         hash: "cf9a4136d781e65d6885ee574480d29f1d1a342fe15f215ee6bf0cbb",
-        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#01",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#1",
       },
       registry_script: {
         hash: "bd7d70eff456af39f86e708fb634b7b69edf5c2aafae7a422f905f5c",
-        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#01",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#1",
       },
     },
     network_compliance: {
@@ -97,15 +97,15 @@ const AMARU_JOURNAL = {
       address: "addr1xyezq8wpaqnssdjvd3p220uf7e6nzjae44w6yu625y965rfjyqwur6p8pqmycmzz55lcnan4x99mnt2a5fe54ggt4gxs8thzgk",
       treasury_script: {
         hash: "32201dc1e82708364c6c42a53f89f675314bb9ad5da2734aa10baa0d",
-        deployed_at: "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#00",
+        deployed_at: "810bfcbde85ae72f27d7e8cd154c03c802de15d3fa0dd83a32a4b0fdba330b3c#0",
       },
       permissions_script: {
         hash: "a64d1b9e1aeffe54056034d84977061b45a92691efc282fbee3fc094",
-        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#02",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#2",
       },
       registry_script: {
         hash: "38c627d45835744a2d6c727124f2b5852e5564aeab3f608e0e84ea6d",
-        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#02",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#2",
       },
     },
     middleware: {
@@ -114,15 +114,15 @@ const AMARU_JOURNAL = {
       address: "addr1x8a5gxtm0ynzw80f80rsps3a5dwem43swsekpnctd0wuwxhmgsvhk7fxyuw7jw78qrprmg6anhtrqapnvr8sk67acudqhnwrjp",
       treasury_script: {
         hash: "fb44197b7926271de93bc700c23da35d9dd630743360cf0b6bddc71a",
-        deployed_at: "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#00",
+        deployed_at: "ec31219173fd4eb3cc3c2123e53425654c1122354ceafc247e7c32d278dad223#0",
       },
       permissions_script: {
         hash: "212e6b9a723138a5b3fe0e55aa4badd9bbae54e3f6309000e30fae3c",
-        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#03",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#3",
       },
       registry_script: {
         hash: "def2913d56acc4c81de20b7b5039e10ceb261c79ed968dc526596638",
-        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#03",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#3",
       },
     },
     contingency: {
@@ -131,15 +131,15 @@ const AMARU_JOURNAL = {
       address: "addr1x8ndhlcfy30t38z0tql64fpg8ply93r37xrgvdagfpsz5nhxm0lsjfz7hzwy7kpl42jzswr7gtz8ruvxscm6sjrq9f8qruq0ae",
       treasury_script: {
         hash: "e6dbff09245eb89c4f583faaa428387e42c471f1868637a848602a4e",
-        deployed_at: "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#00",
+        deployed_at: "b25328336bbba240d5906952534e84bb8edf1a690f86a4160c38703396853c90#0",
       },
       permissions_script: {
         hash: "2810b46b73cb27292cd8511274b6930188eee61b7d8635af6b1b626a",
-        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#04",
+        deployed_at: "25ba96f5deb14bb5c56e7542d6a9ba8450f52cc698ebd74574e1a0525d861095#4",
       },
       registry_script: {
         hash: "7d275cf8c09fd91e73879993ef13cb73915196478d5e3777992f988",
-        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#04",
+        deployed_at: "e7b395a93d49a17994d66df0e4778a01dee05e7711e6612f28d97b63e4e6311c#4",
       },
     },
   },
@@ -151,6 +151,9 @@ export const bundledSundaeSwapBlueprint = globalThis.sundaeSwapV3BlueprintJson |
 
 const text = (value) =>
   value === null || value === undefined ? "" : String(value);
+
+const txOutRef = (value) =>
+  text(value).replace(/#0+([0-9]+)$/, "#$1");
 
 const literal = (value) => JSON.stringify(text(value));
 
@@ -193,7 +196,7 @@ const scriptBlock = (treasurySlug, role, script) => {
     ["a", "overlay:CardanoScript"],
     ["rdfs:label", literal(`Amaru ${title} ${roleLabel}`)],
     ["overlay:scriptRole", literal(role)],
-    ["cardano:fromTxOutRef", literal(script.deployed_at)],
+    ["cardano:txOutRef", literal(txOutRef(script.deployed_at))],
     ["overlay:slug", literal(`${slug}-${role}`)],
   ]);
 };
@@ -233,7 +236,7 @@ ${VOCAB}
 ${block(scopeOwnersSubject, [
     ["a", "overlay:ScopeOwners"],
     ["rdfs:label", literal("Amaru treasury scope owners")],
-    ["cardano:fromTxOutRef", literal(scopeOwners)],
+    ["cardano:txOutRef", literal(txOutRef(scopeOwners))],
   ])}
 ${block(address, [
     ["a", "overlay:Address"],

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -568,41 +568,132 @@ const normalizeDecodedTreeRows = (graphTtl) => {
   const redeemers = queryBindings(graphTtl, decodedRedeemersQuery);
   const metadata = queryBindings(graphTtl, decodedMetadataQuery);
 
-  if (bodyFields.length > 0) {
-    addSection(rows, "decoded-body", "Body", 10, countText(bodyFields.length, "field"));
-    bodyFields.forEach((field, index) => {
-      const raw = firstBindingValue(field.raw, field.value, field.entity);
-      const resolved = resolvedFrom(
-        labelMatches,
-        bindingValue(field.resolvedLabel),
-        bindingValue(field.resolvedType),
-        raw,
-        bindingValue(field.value),
-        bindingValue(field.entity),
-      );
-      appendLeaf(
-        rows,
-        "decoded-body",
-        2,
-        index,
-        bindingValue(field.label),
-        bindingValue(field.kind),
-        raw,
-        {
-          raw,
-          entityIri: annotationEntityIri(bindingValue(field.entity), "hash", bindingValue(field.raw)),
-          resolvedLabel: resolved.resolvedLabel,
-          resolvedType: resolved.resolvedType,
-          annotationPredicate: bindingValue(field.kind) === "hash" ? "cardano:bytesHex" : "",
-          annotationValue: bindingValue(field.kind) === "hash" ? bindingValue(field.raw) : "",
-        },
-      );
-    });
+  const bodyFieldByLabel = new Map();
+  for (const field of bodyFields) {
+    const label = bindingValue(field.label);
+    if (label !== "" && !bodyFieldByLabel.has(label)) bodyFieldByLabel.set(label, field);
   }
 
-  if (inputs.length > 0) {
-    addSection(rows, "decoded-inputs", "Inputs", 20, countText(inputs.length, "input"));
-    inputs.forEach((input, index) => {
+  const metadataById = new Map();
+  for (const row of metadata) {
+    const id = bindingValue(row.metadata);
+    if (id !== "" && !metadataById.has(id)) metadataById.set(id, row);
+  }
+  const metadataRows = Array.from(metadataById.values());
+
+  const addNode = ({
+    id,
+    parentId,
+    depth,
+    order,
+    label,
+    kind,
+    value = "",
+    summary = "",
+    raw = "",
+    entityIri = "",
+    resolvedLabel = "",
+    resolvedType = "",
+    annotationPredicate = "",
+    annotationValue = "",
+  }) => {
+    rows.push(
+      treeRow({
+        id,
+        parentId,
+        depth,
+        order,
+        label,
+        kind,
+        value,
+        summary,
+        raw,
+        entityIri,
+        resolvedLabel,
+        resolvedType,
+        annotationPredicate,
+        annotationValue,
+      }),
+    );
+  };
+  const addNullField = (parentId, depth, order, label) => {
+    addNode({
+      id: `${parentId}-${slug(label)}`,
+      parentId,
+      depth,
+      order,
+      label,
+      kind: "null",
+      value: "NULL",
+      summary: "NULL",
+      raw: "NULL",
+    });
+  };
+  const addContainerField = (parentId, depth, order, label, summary, extra = {}) => {
+    addNode({
+      id: extra.id || `${parentId}-${slug(label)}`,
+      parentId,
+      depth,
+      order,
+      label,
+      kind: extra.kind || "section",
+      value: extra.value || "",
+      summary,
+      raw: extra.raw || "",
+      entityIri: extra.entityIri || "",
+      resolvedLabel: extra.resolvedLabel || "",
+      resolvedType: extra.resolvedType || "",
+    });
+  };
+  const addBodyScalar = (parentId, depth, order, label, sourceLabel) => {
+    const field = bodyFieldByLabel.get(sourceLabel);
+    if (!field) {
+      addNullField(parentId, depth, order, label);
+      return;
+    }
+    const raw = firstBindingValue(field.raw, field.value, field.entity);
+    if (raw === "") {
+      addNullField(parentId, depth, order, label);
+      return;
+    }
+    const resolved = resolvedFrom(
+      labelMatches,
+      bindingValue(field.resolvedLabel),
+      bindingValue(field.resolvedType),
+      raw,
+      bindingValue(field.value),
+      bindingValue(field.entity),
+    );
+    addNode({
+      id: `${parentId}-${slug(label)}`,
+      parentId,
+      depth,
+      order,
+      label,
+      kind: bindingValue(field.kind),
+      value: raw,
+      summary: compact(raw),
+      raw,
+      entityIri: annotationEntityIri(bindingValue(field.entity), "hash", bindingValue(field.raw)),
+      resolvedLabel: resolved.resolvedLabel,
+      resolvedType: resolved.resolvedType,
+      annotationPredicate: bindingValue(field.kind) === "hash" ? "cardano:bytesHex" : "",
+      annotationValue: bindingValue(field.kind) === "hash" ? bindingValue(field.raw) : "",
+    });
+  };
+  const groupedInputs = {
+    inputs: inputs.filter((input) => bindingValue(input.section) === "Inputs"),
+    collateral: inputs.filter((input) => bindingValue(input.section) === "Collateral inputs"),
+    reference_inputs: inputs.filter((input) => bindingValue(input.section) === "Reference inputs"),
+  };
+  const addInputGroup = (label, order, rowsForSection, childLabel) => {
+    const parentId = `decoded-body-${slug(label)}`;
+    if (rowsForSection.length === 0) {
+      addNullField("decoded-body", 3, order, label);
+      return;
+    }
+    addContainerField("decoded-body", 3, order, label, countText(rowsForSection.length, "input"));
+    rowsForSection.forEach((input, index) => {
       const section = bindingValue(input.section);
       const tx = bindingValue(input.txIdHex);
       const inputIndex = bindingValue(input.index);
@@ -620,10 +711,10 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       );
       appendLeaf(
         rows,
-        "decoded-inputs",
-        2,
+        parentId,
+        4,
         index,
-        section === "Inputs" ? `Input ${index}` : `${section} ${index}`,
+        `${childLabel} ${index}`,
         "tx-out-ref",
         value,
         {
@@ -636,10 +727,64 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         },
       );
     });
-  }
+  };
 
-  if (outputs.length > 0) {
-    addSection(rows, "decoded-outputs", "Outputs", 30, countText(outputs.length, "output"));
+  addNode({
+    id: "decoded-transaction-hash",
+    parentId: "decoded-root",
+    depth: 1,
+    order: 10,
+    label: "transaction_hash",
+    kind: "hash",
+    value: txId,
+    summary: compact(txId),
+    raw: txId,
+    entityIri: annotationEntityIri(transactionId, "tx", txId),
+    resolvedLabel: rootResolved.resolvedLabel,
+    resolvedType: rootResolved.resolvedType,
+    annotationPredicate: txId === "" ? "" : "cardano:bytesHex",
+    annotationValue: txId,
+  });
+  addNode({
+    id: "decoded-transaction",
+    parentId: "decoded-root",
+    depth: 1,
+    order: 20,
+    label: "transaction",
+    kind: humanToken(firstBindingValue(root.resolvedType) || "Transaction"),
+    value: transactionId,
+    summary: compact(transactionId),
+    raw: txId,
+    entityIri: transactionId,
+    resolvedLabel: rootResolved.resolvedLabel,
+    resolvedType: rootResolved.resolvedType,
+  });
+  addContainerField(
+    "decoded-transaction",
+    2,
+    10,
+    "body",
+    countText(21, "field"),
+    { id: "decoded-body" },
+  );
+  addContainerField(
+    "decoded-transaction",
+    2,
+    20,
+    "witness_set",
+    countText(6, "field"),
+    { id: "decoded-witness_set" },
+  );
+
+  const bodyFieldOrder = [
+    ["inputs", 10, () => addInputGroup("inputs", 10, groupedInputs.inputs, "Input")],
+    ["outputs", 20, () => {
+      const outputParentId = "decoded-body-outputs";
+      if (outputs.length === 0) {
+        addNullField("decoded-body", 3, 20, "outputs");
+        return;
+      }
+      addContainerField("decoded-body", 3, 20, "outputs", countText(outputs.length, "output"));
     outputs.forEach((output, index) => {
       const outputIndex = firstBindingValue(output.index, { value: String(index) });
       const outputId = `decoded-output-${slug(outputIndex)}-${index}`;
@@ -655,8 +800,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       rows.push(
         treeRow({
           id: outputId,
-          parentId: "decoded-outputs",
-          depth: 2,
+          parentId: outputParentId,
+          depth: 4,
           order: index,
           label: `Output ${outputIndex}`,
           kind: "output",
@@ -670,9 +815,9 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           annotationValue: outputTxOutRef,
         }),
       );
-      appendLeaf(rows, outputId, 3, 10, "Index", "integer", outputIndex);
-      appendLeaf(rows, outputId, 3, 20, "Lovelace", "lovelace", bindingValue(output.lovelace));
-      appendLeaf(rows, outputId, 3, 30, "Address", "address", bindingValue(output.address), {
+      appendLeaf(rows, outputId, 5, 10, "Index", "integer", outputIndex);
+      appendLeaf(rows, outputId, 5, 20, "Lovelace", "lovelace", bindingValue(output.lovelace));
+      appendLeaf(rows, outputId, 5, 30, "Address", "address", bindingValue(output.address), {
         resolvedLabel: resolvedFrom(
           labelMatches,
           "",
@@ -699,7 +844,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         bindingValue(output.datumHashHex),
         bindingValue(output.datumHash),
       );
-      appendLeaf(rows, outputId, 3, 40, "Datum hash", "hash", datumHash, {
+      appendLeaf(rows, outputId, 5, 40, "Datum hash", "hash", datumHash, {
         resolvedLabel: datumHashResolved.resolvedLabel,
         resolvedType: datumHashResolved.resolvedType,
         entityIri: annotationEntityIri(bindingValue(output.datumHash), "hash", bindingValue(output.datumHashHex)),
@@ -707,7 +852,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         annotationValue: bindingValue(output.datumHashHex),
       });
       const datumRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(output.datumRaw));
-      appendLeaf(rows, outputId, 3, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw), {
+      appendLeaf(rows, outputId, 5, 50, "Datum raw bytes", "raw-bytes", bindingValue(output.datumRaw), {
         resolvedLabel: datumRawResolved.resolvedLabel,
         resolvedType: datumRawResolved.resolvedType,
         entityIri: annotationEntityIri(bindingValue(output.datum), "raw-bytes", bindingValue(output.datumRaw)),
@@ -715,18 +860,33 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         annotationValue: bindingValue(output.datumRaw),
       });
     });
-  }
+    }],
+    ["fee", 30, () => addBodyScalar("decoded-body", 3, 30, "fee", "Fee")],
+    ["ttl", 40, () => addNullField("decoded-body", 3, 40, "ttl")],
+    ["certs", 50, () => addNullField("decoded-body", 3, 50, "certs")],
+    ["withdrawals", 60, () => addNullField("decoded-body", 3, 60, "withdrawals")],
+    ["update", 70, () => addNullField("decoded-body", 3, 70, "update")],
+    ["auxiliary_data_hash", 80, () => addBodyScalar("decoded-body", 3, 80, "auxiliary_data_hash", "Auxiliary data hash")],
+    ["validity_start_interval", 90, () => addNullField("decoded-body", 3, 90, "validity_start_interval")],
+    ["mint", 100, () => addBodyScalar("decoded-body", 3, 100, "mint", "Mint")],
+    ["script_data_hash", 110, () => addBodyScalar("decoded-body", 3, 110, "script_data_hash", "Script data hash")],
+    ["collateral", 120, () => addInputGroup("collateral", 120, groupedInputs.collateral, "Collateral")],
+    ["required_signers", 130, () => addNullField("decoded-body", 3, 130, "required_signers")],
+    ["network_id", 140, () => addNullField("decoded-body", 3, 140, "network_id")],
+    ["collateral_return", 150, () => addBodyScalar("decoded-body", 3, 150, "collateral_return", "Collateral return")],
+    ["total_collateral", 160, () => addBodyScalar("decoded-body", 3, 160, "total_collateral", "Total collateral")],
+    ["reference_inputs", 170, () => addInputGroup("reference_inputs", 170, groupedInputs.reference_inputs, "Reference input")],
+    ["voting_procedures", 180, () => addNullField("decoded-body", 3, 180, "voting_procedures")],
+    ["voting_proposals", 190, () => addNullField("decoded-body", 3, 190, "voting_proposals")],
+    ["donation", 200, () => addNullField("decoded-body", 3, 200, "donation")],
+    ["current_treasury_value", 210, () => addNullField("decoded-body", 3, 210, "current_treasury_value")],
+  ];
+  bodyFieldOrder.forEach(([, , add]) => add());
 
-  const feeFields = bodyFields.filter((field) => bindingValue(field.label) === "Fee");
-  if (feeFields.length > 0) {
-    addSection(rows, "decoded-fee", "Fee", 40, compact(bindingValue(feeFields[0].value)));
-    feeFields.forEach((field, index) => {
-      appendLeaf(rows, "decoded-fee", 2, index, "Lovelace", "lovelace", bindingValue(field.value));
-    });
-  }
-
-  if (witnesses.length > 0) {
-    addSection(rows, "decoded-witnesses", "Witnesses", 50, countText(witnesses.length, "key witness"));
+  if (witnesses.length === 0) {
+    addNullField("decoded-witness_set", 3, 10, "vkeys");
+  } else {
+    addContainerField("decoded-witness_set", 3, 10, "vkeys", "");
     witnesses.forEach((witness, index) => {
       const witnessId = `decoded-key-witness-${index}`;
       const witnessValue = firstBindingValue(witness.verificationKeyHex, witness.verificationKey, witness.witness);
@@ -740,8 +900,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       rows.push(
         treeRow({
           id: witnessId,
-          parentId: "decoded-witnesses",
-          depth: 2,
+          parentId: "decoded-witness_set-vkeys",
+          depth: 4,
           order: index,
           label: `Key witness ${index}`,
           kind: "key-witness",
@@ -755,7 +915,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       );
       const keyValue = firstBindingValue(witness.verificationKeyHex, witness.verificationKey);
       const keyResolved = resolvedFrom(labelMatches, "", "", keyValue);
-      appendLeaf(rows, witnessId, 3, 10, "Verification key", "key", keyValue, {
+      appendLeaf(rows, witnessId, 5, 10, "Verification key", "key", keyValue, {
         resolvedLabel: keyResolved.resolvedLabel,
         resolvedType: keyResolved.resolvedType,
         entityIri: annotationEntityIri(bindingValue(witness.verificationKey), "key", bindingValue(witness.verificationKeyHex)),
@@ -763,15 +923,21 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         annotationValue: bindingValue(witness.verificationKeyHex),
       });
       const signatureResolved = resolvedFrom(labelMatches, "", "", bindingValue(witness.signature));
-      appendLeaf(rows, witnessId, 3, 20, "Signature", "signature", bindingValue(witness.signature), {
+      appendLeaf(rows, witnessId, 5, 20, "Signature", "signature", bindingValue(witness.signature), {
         resolvedLabel: signatureResolved.resolvedLabel,
         resolvedType: signatureResolved.resolvedType,
       });
     });
   }
 
-  if (redeemers.length > 0) {
-    addSection(rows, "decoded-redeemers", "Redeemers", 60, countText(redeemers.length, "redeemer"));
+  addNullField("decoded-witness_set", 3, 20, "native_scripts");
+  addNullField("decoded-witness_set", 3, 30, "bootstraps");
+  addNullField("decoded-witness_set", 3, 40, "plutus_scripts");
+  addNullField("decoded-witness_set", 3, 50, "plutus_data");
+  if (redeemers.length === 0) {
+    addNullField("decoded-witness_set", 3, 60, "redeemers");
+  } else {
+    addContainerField("decoded-witness_set", 3, 60, "redeemers", countText(redeemers.length, "redeemer"));
     redeemers.forEach((redeemer, index) => {
       const redeemerId = `decoded-redeemer-${index}`;
       const purpose = bindingValue(redeemer.purpose);
@@ -787,8 +953,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       rows.push(
         treeRow({
           id: redeemerId,
-          parentId: "decoded-redeemers",
-          depth: 2,
+          parentId: "decoded-witness_set-redeemers",
+          depth: 4,
           order: index,
           label: purpose === "" ? `Redeemer ${index}` : `${purpose} redeemer ${redeemerIndex}`,
           kind: "redeemer",
@@ -800,8 +966,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           resolvedType: redeemerResolved.resolvedType,
         }),
       );
-      appendLeaf(rows, redeemerId, 3, 10, "Purpose", "purpose", purpose);
-      appendLeaf(rows, redeemerId, 3, 20, "Index", "integer", redeemerIndex);
+      appendLeaf(rows, redeemerId, 5, 10, "Purpose", "purpose", purpose);
+      appendLeaf(rows, redeemerId, 5, 20, "Index", "integer", redeemerIndex);
       const dataHashValue = firstBindingValue(redeemer.dataHashHex, redeemer.dataHash);
       const dataHashResolved = resolvedFrom(
         labelMatches,
@@ -810,7 +976,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         bindingValue(redeemer.dataHashHex),
         bindingValue(redeemer.dataHash),
       );
-      appendLeaf(rows, redeemerId, 3, 30, "Data hash", "hash", dataHashValue, {
+      appendLeaf(rows, redeemerId, 5, 30, "Data hash", "hash", dataHashValue, {
         resolvedLabel: dataHashResolved.resolvedLabel,
         resolvedType: dataHashResolved.resolvedType,
         entityIri: annotationEntityIri(bindingValue(redeemer.dataHash), "hash", bindingValue(redeemer.dataHashHex)),
@@ -818,26 +984,42 @@ const normalizeDecodedTreeRows = (graphTtl) => {
         annotationValue: bindingValue(redeemer.dataHashHex),
       });
       const dataRawResolved = resolvedFrom(labelMatches, "", "", bindingValue(redeemer.dataRaw));
-      appendLeaf(rows, redeemerId, 3, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw), {
+      appendLeaf(rows, redeemerId, 5, 40, "Data raw bytes", "raw-bytes", bindingValue(redeemer.dataRaw), {
         resolvedLabel: dataRawResolved.resolvedLabel,
         resolvedType: dataRawResolved.resolvedType,
         entityIri: annotationEntityIri(bindingValue(redeemer.data), "raw-bytes", bindingValue(redeemer.dataRaw)),
         annotationPredicate: "cardano:hasRawBytes",
         annotationValue: bindingValue(redeemer.dataRaw),
       });
-      appendLeaf(rows, redeemerId, 3, 50, "Memory units", "ex-units", bindingValue(redeemer.memory));
-      appendLeaf(rows, redeemerId, 3, 60, "CPU units", "ex-units", bindingValue(redeemer.cpu));
+      appendLeaf(rows, redeemerId, 5, 50, "Memory units", "ex-units", bindingValue(redeemer.memory));
+      appendLeaf(rows, redeemerId, 5, 60, "CPU units", "ex-units", bindingValue(redeemer.cpu));
     });
   }
 
-  const metadataById = new Map();
-  for (const row of metadata) {
-    const id = bindingValue(row.metadata);
-    if (id !== "" && !metadataById.has(id)) metadataById.set(id, row);
-  }
-  const metadataRows = Array.from(metadataById.values());
+  const validityField = bodyFieldByLabel.get("Validity");
+  const isValidValue = firstBindingValue(root.valid, validityField?.value);
+  addNode({
+    id: "decoded-is-valid",
+    parentId: "decoded-transaction",
+    depth: 2,
+    order: 30,
+    label: "is_valid",
+    kind: "boolean",
+    value: isValidValue === "" ? "NULL" : isValidValue,
+    summary: isValidValue === "" ? "NULL" : isValidValue,
+    raw: isValidValue,
+    resolvedType: "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#isValid",
+  });
+  addContainerField(
+    "decoded-transaction",
+    2,
+    40,
+    "auxiliary_data",
+    metadataRows.length === 0 ? "NULL" : countText(metadataRows.length, "label"),
+    { id: "decoded-auxiliary_data" },
+  );
   if (metadataRows.length > 0) {
-    addSection(rows, "decoded-metadata", "Metadata", 70, countText(metadataRows.length, "label"));
+    addContainerField("decoded-auxiliary_data", 3, 10, "metadata", countText(metadataRows.length, "label"));
     metadataRows.forEach((meta, index) => {
       const metaId = `decoded-metadata-${slug(bindingValue(meta.label))}-${index}`;
       const metaResolved = resolvedFrom(
@@ -850,8 +1032,8 @@ const normalizeDecodedTreeRows = (graphTtl) => {
       rows.push(
         treeRow({
           id: metaId,
-          parentId: "decoded-metadata",
-          depth: 2,
+          parentId: "decoded-auxiliary_data-metadata",
+          depth: 4,
           order: index,
           label: `Metadata label ${bindingValue(meta.label)}`,
           kind: "metadata",
@@ -863,15 +1045,20 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           resolvedType: metaResolved.resolvedType,
         }),
       );
-      appendLeaf(rows, metaId, 3, 10, "Metadata label", "integer", bindingValue(meta.label));
-      appendLeaf(rows, metaId, 3, 20, "Text", "text", bindingValue(meta.text));
-      appendLeaf(rows, metaId, 3, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw), {
+      appendLeaf(rows, metaId, 5, 10, "Metadata label", "integer", bindingValue(meta.label));
+      appendLeaf(rows, metaId, 5, 20, "Text", "text", bindingValue(meta.text));
+      appendLeaf(rows, metaId, 5, 30, "Raw bytes", "raw-bytes", bindingValue(meta.raw), {
         entityIri: annotationEntityIri(bindingValue(meta.metadata), "raw-bytes", bindingValue(meta.raw)),
         annotationPredicate: "cardano:hasRawBytes",
         annotationValue: bindingValue(meta.raw),
       });
     });
+  } else {
+    addNullField("decoded-auxiliary_data", 3, 10, "metadata");
   }
+  addNullField("decoded-auxiliary_data", 3, 20, "native_scripts");
+  addNullField("decoded-auxiliary_data", 3, 30, "plutus_scripts");
+  addNullField("decoded-auxiliary_data", 3, 40, "prefer_alonzo_format");
 
   return rows.sort((a, b) => {
     if (a.parentId !== b.parentId) return a.parentId.localeCompare(b.parentId);

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -22,7 +22,7 @@ PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardan
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX overlay: <https://lambdasistemi.github.io/cardano-ledger-inspector/overlay/amaru-treasury#>
-SELECT ?label ?entity ?type ?scriptRole ?fromTxOutRef ?bech32 ?slug
+SELECT ?label ?entity ?type ?scriptRole ?txOutRef ?fromTxOutRef ?bech32 ?slug
 WHERE {
   ?entity rdfs:label ?label .
   FILTER(
@@ -31,6 +31,7 @@ WHERE {
   )
   OPTIONAL { ?entity a ?type . }
   OPTIONAL { ?entity overlay:scriptRole ?scriptRole . }
+  OPTIONAL { ?entity cardano:txOutRef ?txOutRef . }
   OPTIONAL { ?entity cardano:fromTxOutRef ?fromTxOutRef . }
   OPTIONAL { ?entity cardano:bech32 ?bech32 . }
   OPTIONAL { ?entity overlay:slug ?slug . }
@@ -139,7 +140,7 @@ ORDER BY ?sort ?label ?value ?entity
 const decodedInputsQuery = `
 PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT ?section ?entity ?txIdHex ?index ?sort ?resolvedLabel ?resolvedType
+SELECT ?section ?entity ?txOutRef ?txIdHex ?index ?sort ?resolvedLabel ?resolvedType
 WHERE {
   ?transaction a cardano:Transaction .
   {
@@ -155,6 +156,7 @@ WHERE {
     BIND("Collateral inputs" AS ?section)
     BIND("30" AS ?sort)
   }
+  OPTIONAL { ?entity cardano:txOutRef ?txOutRef . }
   OPTIONAL {
     ?entity cardano:fromTxOutRef ?ref .
     OPTIONAL { ?ref cardano:hasIndex ?index . }
@@ -163,8 +165,16 @@ WHERE {
       OPTIONAL { ?txId cardano:bytesHex ?txIdHex . }
     }
   }
-  OPTIONAL { ?entity rdfs:label ?resolvedLabel . }
-  OPTIONAL { ?entity a ?resolvedType . }
+  OPTIONAL { ?entity rdfs:label ?directResolvedLabel . }
+  OPTIONAL { ?entity a ?directResolvedType . }
+  OPTIONAL {
+    FILTER(BOUND(?txOutRef))
+    ?txOutRefEntity cardano:txOutRef ?txOutRef ;
+      rdfs:label ?txOutRefResolvedLabel .
+    OPTIONAL { ?txOutRefEntity a ?txOutRefResolvedType . }
+  }
+  BIND(COALESCE(?directResolvedLabel, ?txOutRefResolvedLabel) AS ?resolvedLabel)
+  BIND(COALESCE(?directResolvedType, ?txOutRefResolvedType) AS ?resolvedType)
 }
 ORDER BY ?sort ?txIdHex ?index ?entity
 `;
@@ -265,12 +275,13 @@ ORDER BY ?label ?metadata ?text
 const decodedLabelMatchesQuery = `
 PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT ?entity ?label ?type ?bech32 ?bytesHex ?fromTxOutRef ?rawBytes ?datumHashHex
+SELECT ?entity ?label ?type ?bech32 ?bytesHex ?txOutRef ?fromTxOutRef ?rawBytes ?datumHashHex
 WHERE {
   ?entity rdfs:label ?label .
   OPTIONAL { ?entity a ?type . }
   OPTIONAL { ?entity cardano:bech32 ?bech32 . }
   OPTIONAL { ?entity cardano:bytesHex ?bytesHex . }
+  OPTIONAL { ?entity cardano:txOutRef ?txOutRef . }
   OPTIONAL { ?entity cardano:fromTxOutRef ?fromTxOutRef . }
   OPTIONAL { ?entity cardano:hasRawBytes ?rawBytes . }
   OPTIONAL {
@@ -349,6 +360,7 @@ const normalizeResolvedLabelRows = (result) => {
     role: humanToken(firstBindingValue(binding.scriptRole, binding.type)),
     entity: bindingValue(binding.entity),
     matched: firstBindingValue(
+      binding.txOutRef,
       binding.fromTxOutRef,
       binding.bech32,
       binding.slug,
@@ -395,6 +407,11 @@ const compact = (value, max = 72) => {
 const txOutRefFromUtxoUri = (value) => {
   const match = String(value || "").match(/^urn:cardano:utxo:([0-9a-f]{64}):([0-9]+)$/i);
   return match ? `${match[1]}#${match[2]}` : "";
+};
+
+const txOutRefParts = (value) => {
+  const match = String(value || "").match(/^([0-9a-f]{64})#([0-9]+)$/i);
+  return match ? { tx: match[1], index: match[2] } : { tx: "", index: "" };
 };
 
 const isIri = (value) => /^https?:\/\//.test(String(value || "")) || String(value || "").startsWith("urn:");
@@ -503,6 +520,7 @@ const decodedLabelMatches = (graphTtl) => {
     addMatchValue(matches, bindingValue(row.entity), match);
     addMatchValue(matches, bindingValue(row.bech32), match);
     addMatchValue(matches, bindingValue(row.bytesHex), match);
+    addMatchValue(matches, bindingValue(row.txOutRef), match);
     addMatchValue(matches, bindingValue(row.fromTxOutRef), match);
     addMatchValue(matches, bindingValue(row.rawBytes), match);
     addMatchValue(matches, bindingValue(row.datumHashHex), match);
@@ -695,13 +713,17 @@ const normalizeDecodedTreeRows = (graphTtl) => {
     addContainerField("decoded-body", 3, order, label, countText(rowsForSection.length, "input"));
     rowsForSection.forEach((input, index) => {
       const section = bindingValue(input.section);
-      const tx = bindingValue(input.txIdHex);
-      const inputIndex = bindingValue(input.index);
+      const flatTxOutRef = bindingValue(input.txOutRef);
+      const flatParts = txOutRefParts(flatTxOutRef);
+      const tx = bindingValue(input.txIdHex) || flatParts.tx;
+      const inputIndex = bindingValue(input.index) || flatParts.index;
       const value =
         tx === "" && inputIndex === ""
           ? bindingValue(input.entity)
           : `${compact(tx, 28)}#${inputIndex}`;
-      const raw = tx === "" ? bindingValue(input.entity) : `${tx}#${inputIndex}`;
+      const raw =
+        flatTxOutRef ||
+        (tx === "" ? bindingValue(input.entity) : `${tx}#${inputIndex}`);
       const resolved = resolvedFrom(
         labelMatches,
         bindingValue(input.resolvedLabel),
@@ -722,7 +744,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           entityIri: annotationEntityIri(bindingValue(input.entity), "tx-out-ref", raw),
           resolvedLabel: resolved.resolvedLabel,
           resolvedType: resolved.resolvedType,
-          annotationPredicate: raw === "" ? "" : "cardano:fromTxOutRef",
+          annotationPredicate: raw === "" ? "" : "cardano:txOutRef",
           annotationValue: raw,
         },
       );
@@ -811,7 +833,7 @@ const normalizeDecodedTreeRows = (graphTtl) => {
           entityIri: outputValue,
           resolvedLabel: outputResolved.resolvedLabel,
           resolvedType: outputResolved.resolvedType,
-          annotationPredicate: outputTxOutRef === "" ? "" : "cardano:fromTxOutRef",
+          annotationPredicate: outputTxOutRef === "" ? "" : "cardano:txOutRef",
           annotationValue: outputTxOutRef,
         }),
       );

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -958,6 +958,9 @@ inspectorComponent initial =
                   , HH.span
                       [ classNames [ "kind-badge" ] ]
                       [ renderDecodedTreeKind row ]
+                  , HH.span
+                      [ classNames [ "decoded-tree-actions" ] ]
+                      [ renderDecodedTreeAnnotationAction state row ]
                   ]
               , if summaryText == "" then
                   HH.text ""
@@ -1079,6 +1082,13 @@ inspectorComponent initial =
     case state.annotationDraft of
       Just draft | draft.rowId == row.id ->
         renderDecodedTreeAnnotationDraft state row draft
+      _ ->
+        HH.text ""
+
+  renderDecodedTreeAnnotationAction state row =
+    case state.annotationDraft of
+      Just draft | draft.rowId == row.id ->
+        HH.text ""
       _ ->
         if row.resolvedLabel == "" && row.annotationPredicate /= "" && row.annotationValue /= "" then
           HH.element (HH.ElemName "md-icon-button")
@@ -2443,6 +2453,19 @@ inspectorComponent initial =
                   , HH.span
                       [ classNames [ "kind-badge" ] ]
                       [ HH.text row.kind ]
+                  , if row.canDive then
+                      HH.span
+                        [ classNames [ "browser-row-actions" ] ]
+                        [
+                          HH.element (HH.ElemName "md-outlined-button")
+                            [ HE.onClick (\_ -> BrowseJson row.path)
+                            , classNames [ "inline-action", "browser-row-action" ]
+                            , HH.attr (HH.AttrName "role") "button"
+                            , mdControl "inline"
+                            ]
+                            [ HH.text (if expanded then "Close" else "Open") ]
+                        ]
+                    else HH.text ""
                   ]
               , HH.div
                   [ classNames [ "browser-summary", "summary-copy-target" ]
@@ -2451,19 +2474,6 @@ inspectorComponent initial =
                   ]
                   [ HH.text row.summary ]
               ]
-          , if row.canDive then
-              HH.div
-                [ classNames [ "browser-actions" ] ]
-                [
-                  HH.element (HH.ElemName "md-outlined-button")
-                    [ HE.onClick (\_ -> BrowseJson row.path)
-                    , classNames [ "inline-action" ]
-                    , HH.attr (HH.AttrName "role") "button"
-                    , mdControl "inline"
-                    ]
-                    [ HH.text (if expanded then "Close" else "Open") ]
-                ]
-            else HH.text ""
           ]
       ] <> if expanded then
         [ HH.div

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -924,7 +924,7 @@ inspectorComponent initial =
   renderDecodedTreeRow state rows row =
     let
       hasChildren = Array.any (\candidate -> candidate.parentId == row.id) rows
-      expanded = row.parentId == "" || row.depth >= 1 || Array.elem row.id state.decodedTreeExpanded
+      expanded = row.parentId == "" || Array.elem row.id state.decodedTreeExpanded
       rowClasses =
         if hasChildren && expanded then
           [ "decoded-tree-row", "is-expanded", "decoded-tree-depth-" <> show row.depth ]
@@ -2516,6 +2516,14 @@ inspectorComponent initial =
   closePath path paths =
     Array.filter (_ /= path) paths
 
+  defaultDecodedTreeExpanded lens =
+    case lens of
+      Nothing -> []
+      Just decoded ->
+        decoded.rows
+          # Array.filter (\row -> row.parentId == "" || row.depth <= 2)
+          # map _.id
+
   rootBrowserNodes browser =
     [ { path: browser.currentPath, browser } ]
 
@@ -3140,7 +3148,7 @@ inspectorComponent initial =
                   if operationResult.exitOk && browser.valid then rootBrowserNodes browser
                   else []
               , expandedPaths = []
-              , decodedTreeExpanded = []
+              , decodedTreeExpanded = defaultDecodedTreeExpanded lenses.decodedTreeLens
               , browserPath = browser.currentPath
               }
     Copy -> do

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -714,6 +714,37 @@ inspectorComponent initial =
       overlayCount = Array.length (selectedOverlayParts state)
       blueprintCount = Array.length (selectedBlueprintParts state)
       shaclCount = Array.length (selectedShaclParts state)
+      txHash = loadedTxHash state
+      txIdPath = "loaded-header:tx-id"
+      cborPath = "loaded-header:cbor"
+      renderContextItem label extraClasses content =
+        HH.div
+          [ classNames ([ "loaded-context-item" ] <> extraClasses) ]
+          ([ HH.span_ [ HH.text label ] ] <> content)
+      renderCopyContextValue label path fullValue displayValue =
+        HH.div
+          [ classNames [ "loaded-context-value" ] ]
+          [ HH.code
+              [ classNames [ "summary-copy-target" ]
+              , HP.title fullValue
+              , HE.onClick (\_ -> CopyValue path fullValue)
+              ]
+              [ HH.text displayValue ]
+          , HH.element (HH.ElemName "md-outlined-button")
+              [ HE.onClick (\_ -> CopyValue path fullValue)
+              , classNames [ "inline-action", "loaded-context-copy" ]
+              , HH.attr (HH.AttrName "role") "button"
+              , HH.attr (HH.AttrName "aria-label") ("Copy " <> label)
+              , mdControl "inline"
+              ]
+              [ HH.text
+                  ( if state.copiedPath == Just path then
+                      "Copied"
+                    else
+                      "Copy"
+                  )
+              ]
+          ]
     in
       HH.section
         [ classNames [ "loaded-inspector-header" ]
@@ -721,27 +752,23 @@ inspectorComponent initial =
         ]
         [ HH.div
             [ classNames [ "loaded-inspector-context" ] ]
-            [ HH.div
-                [ classNames [ "loaded-context-item" ] ]
-                [ HH.span_ [ HH.text "Source" ]
-                , HH.strong_ [ HH.text (modeLabel state.mode) ]
-                ]
-            , HH.div
-                [ classNames [ "loaded-context-item" ] ]
-                [ HH.span_ [ HH.text "Provider" ]
-                , HH.strong_ [ HH.text (Provider.providerName state.provider) ]
-                ]
-            , HH.div
-                [ classNames [ "loaded-context-item" ] ]
-                [ HH.span_ [ HH.text "Network" ]
-                , HH.strong_ [ HH.text (networkName state.network) ]
-                ]
-            , HH.div
-                [ classNames [ "loaded-context-item", "loaded-context-hash" ] ]
-                [ HH.span_ [ HH.text "Tx id/hash" ]
-                , HH.code_ [ HH.text (loadedTxHash state) ]
-                ]
-            ]
+            ( [ renderContextItem "Source" [] [ HH.strong_ [ HH.text (modeLabel state.mode) ] ]
+              , renderContextItem "Provider" [] [ HH.strong_ [ HH.text (Provider.providerName state.provider) ] ]
+              , renderContextItem "Network" [] [ HH.strong_ [ HH.text (networkName state.network) ] ]
+              , renderContextItem "Tx id/hash"
+                  [ "loaded-context-hash" ]
+                  [ renderCopyContextValue "Tx id/hash" txIdPath txHash txHash ]
+              ]
+                <> (case state.txCbor of
+                  Just cbor ->
+                    [ renderContextItem "CBOR"
+                        [ "loaded-context-cbor" ]
+                        [ renderCopyContextValue "CBOR" cborPath cbor (middleTruncate 16 8 cbor) ]
+                    ]
+                  Nothing ->
+                    []
+                )
+            )
         , HH.div
             [ classNames [ "loaded-book-context" ] ]
             [ HH.span_ [ HH.text (show (Array.length selected) <> " selected") ]

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -924,7 +924,7 @@ inspectorComponent initial =
   renderDecodedTreeRow state rows row =
     let
       hasChildren = Array.any (\candidate -> candidate.parentId == row.id) rows
-      expanded = row.parentId == "" || row.depth >= 2 || Array.elem row.id state.decodedTreeExpanded
+      expanded = row.parentId == "" || row.depth >= 1 || Array.elem row.id state.decodedTreeExpanded
       rowClasses =
         if hasChildren && expanded then
           [ "decoded-tree-row", "is-expanded", "decoded-tree-depth-" <> show row.depth ]

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { createServer } from "node:http";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -25,6 +25,14 @@ const packagedSiteDir = path.resolve(
   process.cwd(),
   process.env.TX_INSPECTOR_SITE_DIR || "result",
 );
+const amaruTreasuryTxRoot =
+  process.env.TX_AMARU_TREASURY_TX_ROOT || "/code/amaru-treasury-tx";
+const amaruTreasuryTx2026Root = path.join(
+  amaruTreasuryTxRoot,
+  "transactions/2026",
+);
+const contingencyTxId =
+  "18d57a4f104df4cc776104ce626958e2110122392e4c4c7671edc8861b48452e";
 const previewPrefix = "/lambdasistemi/cardano-ledger-inspector/pr-99/";
 const localBookStoreKey = "cardano-ledger-inspector.books.v1";
 const pastedTurtleBook = `
@@ -51,6 +59,525 @@ cardano:RequiresSentinelShape
   sh:minCount 1 ;
   sh:message "Transactions must include sentinel off-spec marker." .
 `;
+
+const conwayBodyFields = [
+  { key: 0, label: "inputs" },
+  { key: 1, label: "outputs" },
+  { key: 2, label: "fee" },
+  { key: 3, label: "ttl" },
+  { key: 4, label: "certs" },
+  { key: 5, label: "withdrawals" },
+  { key: 6, label: "update" },
+  { key: 7, label: "auxiliary_data_hash" },
+  { key: 8, label: "validity_start_interval" },
+  { key: 9, label: "mint" },
+  { key: 11, label: "script_data_hash" },
+  { key: 13, label: "collateral" },
+  { key: 14, label: "required_signers" },
+  { key: 15, label: "network_id" },
+  { key: 16, label: "collateral_return" },
+  { key: 17, label: "total_collateral" },
+  { key: 18, label: "reference_inputs" },
+  { key: 19, label: "voting_procedures" },
+  { key: 20, label: "voting_proposals" },
+  { key: 22, label: "donation" },
+  { key: 21, label: "current_treasury_value" },
+];
+const conwayWitnessFields = [
+  { keys: [0], label: "vkeys" },
+  { keys: [1], label: "native_scripts" },
+  { keys: [2], label: "bootstraps" },
+  { keys: [3, 6, 7], label: "plutus_scripts" },
+  { keys: [4], label: "plutus_data" },
+  { keys: [5], label: "redeemers" },
+];
+const conwayAuxiliaryDataFields = [
+  "metadata",
+  "native_scripts",
+  "plutus_scripts",
+  "prefer_alonzo_format",
+];
+const conwayBodyFieldByKey = new Map(
+  conwayBodyFields.map((field) => [field.key, field.label]),
+);
+const conwayWitnessFieldByKey = new Map(
+  conwayWitnessFields.flatMap((field) =>
+    field.keys.map((key) => [key, field.label]),
+  ),
+);
+class CborReader {
+  constructor(hex) {
+    this.bytes = Buffer.from(hex.replace(/\s+/g, ""), "hex");
+    this.offset = 0;
+  }
+
+  peekByte() {
+    if (this.offset >= this.bytes.length) {
+      throw new Error("unexpected end of CBOR");
+    }
+    return this.bytes[this.offset];
+  }
+
+  readByte() {
+    const byte = this.peekByte();
+    this.offset += 1;
+    return byte;
+  }
+
+  isBreak() {
+    return this.offset < this.bytes.length && this.bytes[this.offset] === 0xff;
+  }
+
+  readLength(additional) {
+    if (additional < 24) return additional;
+    if (additional === 24) return this.readByte();
+    if (additional === 25) {
+      const value = this.bytes.readUInt16BE(this.offset);
+      this.offset += 2;
+      return value;
+    }
+    if (additional === 26) {
+      const value = this.bytes.readUInt32BE(this.offset);
+      this.offset += 4;
+      return value;
+    }
+    if (additional === 27) {
+      const value = this.bytes.readBigUInt64BE(this.offset);
+      this.offset += 8;
+      if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new Error(`CBOR length exceeds safe integer: ${value}`);
+      }
+      return Number(value);
+    }
+    if (additional === 31) return null;
+    throw new Error(`unsupported CBOR additional info ${additional}`);
+  }
+
+  readHeader() {
+    const initial = this.readByte();
+    const major = initial >> 5;
+    const additional = initial & 0x1f;
+    const length = this.readLength(additional);
+    return { major, additional, length, indefinite: additional === 31 };
+  }
+
+  readInteger() {
+    const header = this.readHeader();
+    if (header.major === 0) return header.length;
+    if (header.major === 1) return -1 - header.length;
+    throw new Error(`expected integer key, got CBOR major ${header.major}`);
+  }
+
+  readArrayLength() {
+    const header = this.readHeader();
+    if (header.major !== 4 || header.indefinite) {
+      throw new Error("expected definite CBOR array");
+    }
+    return header.length;
+  }
+
+  readBool() {
+    const header = this.readHeader();
+    if (header.major !== 7) {
+      throw new Error(`expected CBOR bool, got major ${header.major}`);
+    }
+    if (header.additional === 20) return false;
+    if (header.additional === 21) return true;
+    throw new Error(`expected CBOR bool, got simple ${header.additional}`);
+  }
+
+  readIntegerKeyMap() {
+    const header = this.readHeader();
+    if (header.major !== 5) {
+      throw new Error(`expected CBOR map, got major ${header.major}`);
+    }
+    const keys = [];
+    const readEntry = () => {
+      keys.push(this.readInteger());
+      this.skipValue();
+    };
+
+    if (header.indefinite) {
+      while (!this.isBreak()) readEntry();
+      this.readByte();
+    } else {
+      for (let i = 0; i < header.length; i += 1) readEntry();
+    }
+    return new Set(keys);
+  }
+
+  readAuxiliaryData() {
+    if (this.peekByte() === 0xf6) {
+      this.skipValue();
+      return { present: false, metadataLabels: [] };
+    }
+
+    while ((this.peekByte() >> 5) === 6) {
+      this.readHeader();
+    }
+
+    const header = this.readHeader();
+    if (header.major !== 5) {
+      this.skipValueAfterHeader(header);
+      return { present: true, metadataLabels: [] };
+    }
+
+    const metadataLabels = [];
+    let sawAuxiliaryEnvelope = false;
+    const readEntry = () => {
+      const key = this.readInteger();
+      if (key >= 0 && key <= 3) sawAuxiliaryEnvelope = true;
+      if (key === 0) {
+        metadataLabels.push(...this.readMetadataLabels());
+      } else {
+        if (!sawAuxiliaryEnvelope) metadataLabels.push(key);
+        this.skipValue();
+      }
+    };
+
+    if (header.indefinite) {
+      while (!this.isBreak()) readEntry();
+      this.readByte();
+    } else {
+      for (let i = 0; i < header.length; i += 1) readEntry();
+    }
+
+    return { present: true, metadataLabels };
+  }
+
+  readMetadataLabels() {
+    const header = this.readHeader();
+    if (header.major !== 5) {
+      this.skipValueAfterHeader(header);
+      return [];
+    }
+
+    const labels = [];
+    const readEntry = () => {
+      labels.push(this.readInteger());
+      this.skipValue();
+    };
+    if (header.indefinite) {
+      while (!this.isBreak()) readEntry();
+      this.readByte();
+    } else {
+      for (let i = 0; i < header.length; i += 1) readEntry();
+    }
+    return labels;
+  }
+
+  skipValue() {
+    this.skipValueAfterHeader(this.readHeader());
+  }
+
+  skipValueAfterHeader(header) {
+    switch (header.major) {
+      case 0:
+      case 1:
+        return;
+      case 2:
+      case 3:
+        if (header.indefinite) {
+          while (!this.isBreak()) this.skipValue();
+          this.readByte();
+        } else {
+          this.offset += header.length;
+        }
+        return;
+      case 4:
+        if (header.indefinite) {
+          while (!this.isBreak()) this.skipValue();
+          this.readByte();
+        } else {
+          for (let i = 0; i < header.length; i += 1) this.skipValue();
+        }
+        return;
+      case 5:
+        if (header.indefinite) {
+          while (!this.isBreak()) {
+            this.skipValue();
+            this.skipValue();
+          }
+          this.readByte();
+        } else {
+          for (let i = 0; i < header.length; i += 1) {
+            this.skipValue();
+            this.skipValue();
+          }
+        }
+        return;
+      case 6:
+        this.skipValue();
+        return;
+      case 7:
+        if (header.additional === 24) this.offset += 1;
+        else if (header.additional === 25) this.offset += 2;
+        else if (header.additional === 26) this.offset += 4;
+        else if (header.additional === 27) this.offset += 8;
+        return;
+      default:
+        throw new Error(`unsupported CBOR major type ${header.major}`);
+    }
+  }
+}
+
+function walkConwayTransactionCbor(hex) {
+  const reader = new CborReader(hex);
+  const txLength = reader.readArrayLength();
+  expect(txLength, "Conway transaction CBOR must be a 4-item array").toBe(4);
+  const bodyKeys = reader.readIntegerKeyMap();
+  const witnessKeys = reader.readIntegerKeyMap();
+  const isValid = reader.readBool();
+  const auxiliaryData = reader.readAuxiliaryData();
+
+  return { bodyKeys, witnessKeys, isValid, auxiliaryData };
+}
+
+async function signedTxFixtures(root = amaruTreasuryTx2026Root) {
+  const fixtures = [];
+  async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (entry.isFile() && entry.name === "signed-tx.hex") {
+        fixtures.push(entryPath);
+      }
+    }
+  }
+  await walk(root);
+  return fixtures.sort();
+}
+
+function normalizeStructureLabel(label) {
+  return String(label || "")
+    .replace(/\s+\d+\s+(fields?|inputs?|outputs?|key witnesses?|redeemers?|labels?)$/i, "")
+    .replace(/\s+NULL$/i, "")
+    .replace(/\s+(true|false)$/i, "")
+    .replace(/\s+urn:cardano:.*$/i, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function normalizeSummary(summary) {
+  return String(summary || "").trim();
+}
+
+async function expandDecodedStructure(panel) {
+  for (let pass = 0; pass < 8; pass += 1) {
+    const expanded = await panel.evaluate(async (root) => {
+      const toggles = Array.from(
+        root.querySelectorAll(".decoded-tree-row:not(.is-expanded) .decoded-tree-toggle"),
+      );
+      for (const toggle of toggles) toggle.click();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      return toggles.length;
+    });
+    if (expanded === 0) return;
+  }
+}
+
+async function decodedStructureRows(page) {
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await expandDecodedStructure(decodedPanel);
+  return decodedPanel.locator(".decoded-tree-row").evaluateAll((nodes) =>
+    nodes.map((node, index) => {
+      const depthClass = Array.from(node.classList).find((className) =>
+        className.startsWith("decoded-tree-depth-"),
+      );
+      const labelNode =
+        node.querySelector(".decoded-tree-keyline > md-outlined-button") ||
+        node.querySelector(".decoded-tree-keyline > strong");
+      const summaryNode = node.querySelector(".decoded-tree-summary");
+      const depth = depthClass
+        ? Number(depthClass.replace("decoded-tree-depth-", ""))
+        : 0;
+      return {
+        index,
+        depth,
+        label: labelNode?.textContent?.trim() || "",
+        summary: summaryNode?.textContent?.trim() || "",
+      };
+    }),
+  );
+}
+
+function rowLabel(row) {
+  return normalizeStructureLabel(row.label);
+}
+
+function rowSummary(row) {
+  return normalizeSummary(row.summary);
+}
+
+function rootRowIndex(rows) {
+  const index = rows.findIndex((row) => row.depth === 0 && rowLabel(row) === "transaction");
+  expect(index, "Structure tree should expose a transaction root").toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function descendantRange(rows, parentIndex) {
+  const parentDepth = rows[parentIndex].depth;
+  let end = parentIndex + 1;
+  while (end < rows.length && rows[end].depth > parentDepth) end += 1;
+  return rows.slice(parentIndex + 1, end);
+}
+
+function childRows(rows, parentIndex) {
+  const parentDepth = rows[parentIndex].depth;
+  return descendantRange(rows, parentIndex).filter(
+    (row) => row.depth === parentDepth + 1,
+  );
+}
+
+function childLabels(rows, parentIndex) {
+  return childRows(rows, parentIndex).map(rowLabel);
+}
+
+function childRow(rows, parentIndex, label) {
+  return childRows(rows, parentIndex).find((row) => rowLabel(row) === label);
+}
+
+function rowIndex(rows, target) {
+  const index = rows.findIndex((row) => row.index === target.index);
+  expect(index, `row ${target.label} should be present`).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function expectAbsentRowsAreNull(rows, parentIndex, fields, presentLabels, context) {
+  for (const child of childRows(rows, parentIndex)) {
+    const label = rowLabel(child);
+    if (!fields.includes(label) || presentLabels.has(label)) continue;
+    expect(
+      rowSummary(child),
+      `${context}.${label} should render explicit NULL when absent`,
+    ).toBe("NULL");
+  }
+}
+
+function renderedConwayFieldTree(rows) {
+  const rootIndex = rootRowIndex(rows);
+  const transactionRow = childRow(rows, rootIndex, "transaction");
+  expect(transactionRow, "transaction wrapper").toBeTruthy();
+  const transactionIndex = rowIndex(rows, transactionRow);
+  const bodyRow = childRow(rows, transactionIndex, "body");
+  expect(bodyRow, "transaction body").toBeTruthy();
+  const witnessRow = childRow(rows, transactionIndex, "witness_set");
+  expect(witnessRow, "transaction witness_set").toBeTruthy();
+  const auxiliaryRow = childRow(rows, transactionIndex, "auxiliary_data");
+  expect(auxiliaryRow, "transaction auxiliary_data").toBeTruthy();
+
+  return {
+    top_level: childLabels(rows, rootIndex),
+    transaction: childLabels(rows, transactionIndex),
+    body: childLabels(rows, rowIndex(rows, bodyRow)),
+    witness_set: childLabels(rows, rowIndex(rows, witnessRow)),
+    auxiliary_data: childLabels(rows, rowIndex(rows, auxiliaryRow)),
+  };
+}
+
+function expectRenderedConwayShape(rows, shape, fixtureName) {
+  const rootIndex = rootRowIndex(rows);
+  expect(childLabels(rows, rootIndex), `${fixtureName} top-level structure`).toEqual([
+    "transaction_hash",
+    "transaction",
+  ]);
+
+  const transactionRow = childRow(rows, rootIndex, "transaction");
+  expect(transactionRow, `${fixtureName} transaction wrapper`).toBeTruthy();
+  const transactionIndex = rowIndex(rows, transactionRow);
+  expect(childLabels(rows, transactionIndex), `${fixtureName} transaction fields`).toEqual([
+    "body",
+    "witness_set",
+    "is_valid",
+    "auxiliary_data",
+  ]);
+
+  const bodyRow = childRow(rows, transactionIndex, "body");
+  expect(bodyRow, `${fixtureName} body`).toBeTruthy();
+  const bodyIndex = rowIndex(rows, bodyRow);
+  const bodyLabels = childLabels(rows, bodyIndex);
+  const expectedBodyLabels = conwayBodyFields.map((field) => field.label);
+  expect(bodyLabels, `${fixtureName} body CDDL order`).toEqual(expectedBodyLabels);
+  for (const key of shape.bodyKeys) {
+    const field = conwayBodyFieldByKey.get(key);
+    expect(field, `${fixtureName} unsupported body key ${key}`).toBeTruthy();
+    expect(bodyLabels, `${fixtureName} present body key ${key}`).toContain(field);
+  }
+  expectAbsentRowsAreNull(
+    rows,
+    bodyIndex,
+    expectedBodyLabels,
+    new Set(
+      Array.from(shape.bodyKeys)
+        .map((key) => conwayBodyFieldByKey.get(key))
+        .filter(Boolean),
+    ),
+    `${fixtureName}.body`,
+  );
+
+  const witnessRow = childRow(rows, transactionIndex, "witness_set");
+  expect(witnessRow, `${fixtureName} witness_set`).toBeTruthy();
+  const witnessIndex = rowIndex(rows, witnessRow);
+  const witnessLabels = childLabels(rows, witnessIndex);
+  const expectedWitnessLabels = conwayWitnessFields.map((field) => field.label);
+  expect(witnessLabels, `${fixtureName} witness_set CDDL order`).toEqual(
+    expectedWitnessLabels,
+  );
+  for (const key of shape.witnessKeys) {
+    const field = conwayWitnessFieldByKey.get(key);
+    expect(field, `${fixtureName} unsupported witness_set key ${key}`).toBeTruthy();
+    expect(witnessLabels, `${fixtureName} present witness_set key ${key}`).toContain(field);
+  }
+  expectAbsentRowsAreNull(
+    rows,
+    witnessIndex,
+    expectedWitnessLabels,
+    new Set(
+      Array.from(shape.witnessKeys)
+        .map((key) => conwayWitnessFieldByKey.get(key))
+        .filter(Boolean),
+    ),
+    `${fixtureName}.witness_set`,
+  );
+
+  const isValidRow = childRow(rows, transactionIndex, "is_valid");
+  expect(isValidRow, `${fixtureName} is_valid`).toBeTruthy();
+  expect(rowSummary(isValidRow), `${fixtureName} is_valid value`).toBe(
+    String(shape.isValid),
+  );
+
+  const auxiliaryRow = childRow(rows, transactionIndex, "auxiliary_data");
+  expect(auxiliaryRow, `${fixtureName} auxiliary_data`).toBeTruthy();
+  if (!shape.auxiliaryData.present) {
+    expect(rowSummary(auxiliaryRow), `${fixtureName} auxiliary_data absent`).toBe("NULL");
+  } else {
+    const auxiliaryIndex = rowIndex(rows, auxiliaryRow);
+    expect(
+      childLabels(rows, auxiliaryIndex),
+      `${fixtureName} auxiliary_data fields`,
+    ).toEqual(conwayAuxiliaryDataFields);
+    if (shape.auxiliaryData.metadataLabels.length > 0) {
+      const metadataRow = childRow(rows, auxiliaryIndex, "metadata");
+      expect(metadataRow, `${fixtureName} auxiliary_data.metadata`).toBeTruthy();
+      const metadataLabels = descendantRange(rows, rowIndex(rows, metadataRow)).map(rowLabel);
+      expect(
+        metadataLabels,
+        `${fixtureName} auxiliary_data.metadata expansion`,
+      ).toContain("metadata_label");
+      expect(
+        metadataLabels.some((label) => ["text", "raw_bytes"].includes(label)),
+        `${fixtureName} auxiliary_data.metadata value expansion`,
+      ).toBeTruthy();
+    }
+  }
+
+  const feeRows = rows.filter((row) => rowLabel(row) === "fee");
+  expect(feeRows, `${fixtureName} duplicate fee rows`).toHaveLength(1);
+}
 
 function contentTypeFor(filePath) {
   if (filePath.endsWith(".html")) return "text/html";
@@ -192,8 +719,20 @@ async function decodeFixtureAt(page, route, txFixturePath = fixturePath) {
   await installClipboardMock(page);
   await mockKoiosValidationContext(page, validationContext);
 
+  await decodeTxCbor(page, route, txCbor);
+}
+
+async function decodeTxCbor(page, route, txCbor) {
   await page.goto(route);
-  await page.getByRole("radio", { name: "CBOR hex" }).check();
+  await submitTxCbor(page, txCbor);
+}
+
+async function submitTxCbor(page, txCbor) {
+  const cborMode = page.getByRole("radio", { name: "CBOR hex" });
+  if ((await cborMode.count()) === 0) {
+    await page.getByRole("button", { name: "Change input" }).click();
+  }
+  await cborMode.check();
   await page.getByPlaceholder("Conway tx CBOR hex...").fill(txCbor);
   await page.getByRole("button", { name: "Decode" }).click();
 
@@ -204,7 +743,8 @@ async function decodeFixtureAt(page, route, txFixturePath = fixturePath) {
   await expect(
     resultPanel
       .getByRole("tabpanel", { name: "Structure" })
-      .locator(".decoded-tree-row", { hasText: "Transaction" }),
+      .locator(".decoded-tree-row.decoded-tree-depth-0", { hasText: "Transaction" })
+      .first(),
   ).toBeVisible();
 }
 
@@ -228,12 +768,10 @@ async function expectTabbedInspectResult(page) {
     structurePanel.getByRole("heading", { name: "Decoded structure" }),
   ).toBeVisible();
   await expect(
-    structurePanel.locator(".decoded-tree-row", { hasText: "Transaction" }),
+    structurePanel
+      .locator(".decoded-tree-row.decoded-tree-depth-0", { hasText: "Transaction" })
+      .first(),
   ).toBeVisible();
-
-  const documentHeight = await page.evaluate(() => document.documentElement.scrollHeight);
-  const viewportHeight = await page.evaluate(() => window.innerHeight);
-  expect(documentHeight).toBeLessThan(viewportHeight * 4);
 
   await tabs.getByRole("tab", { name: "Witness" }).click();
   const witnessPanel = resultPanel.getByRole("tabpanel", { name: "Witness" });
@@ -1291,9 +1829,9 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
   ).toBeVisible();
   await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
 
-  const rootRow = decodedPanel.locator(".decoded-tree-row", {
+  const rootRow = decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-0", {
     hasText: "Transaction",
-  });
+  }).first();
   await expect(rootRow).toBeVisible();
   const transactionTypeHref =
     "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#Transaction";
@@ -1315,31 +1853,36 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
   await expect(rootSummary.getByRole("link")).toHaveCount(0);
 
   for (const section of [
-    "Body",
-    "Inputs",
-    "Outputs",
-    "Fee",
-    "Witnesses",
-    "Redeemers",
-    "Metadata",
+    "transaction",
+    "body",
+    "inputs",
+    "outputs",
+    "witness_set",
+    "vkeys",
+    "redeemers",
+    "metadata",
   ]) {
     await expect(
       decodedPanel.getByRole("button", { name: new RegExp(`^${section}\\b`) }),
     ).toBeVisible();
   }
 
-  const body = decodedPanel.getByRole("button", { name: /^Body\b/ });
+  const body = decodedPanel.getByRole("button", { name: /^body\b/ });
   await body.click();
   const fieldPredicateHref =
     "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#";
   const scalarBodyRow = (label) =>
-    decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-2", {
+    decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-3", {
       has: page.locator(".decoded-tree-keyline strong", {
         hasText: new RegExp(`^${label}$`),
       }),
     });
 
-  const validityRow = scalarBodyRow("Validity");
+  const validityRow = decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-2", {
+    has: page.locator(".decoded-tree-keyline strong", {
+      hasText: /^is_valid$/,
+    }),
+  });
   await expect(validityRow).toBeVisible();
   const validityTypeLink = validityRow.getByRole("link", { name: "cardano:isValid" });
   await expect(validityTypeLink).toBeVisible();
@@ -1350,7 +1893,7 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
   await expect(validityRow).not.toContainText("cardano:Transaction");
   await expect(validityRow).not.toContainText(`${fieldPredicateHref}isValid`);
 
-  const feeRow = scalarBodyRow("Fee");
+  const feeRow = scalarBodyRow("fee");
   await expect(feeRow).toBeVisible();
   const feeTypeLink = feeRow.getByRole("link", { name: "cardano:hasFee" });
   await expect(feeTypeLink).toBeVisible();
@@ -1358,7 +1901,7 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
   await expect(feeRow).not.toContainText("cardano:Transaction");
   await expect(feeRow).not.toContainText(`${fieldPredicateHref}hasFee`);
 
-  const totalCollateralRow = scalarBodyRow("Total collateral");
+  const totalCollateralRow = scalarBodyRow("total_collateral");
   if ((await totalCollateralRow.count()) > 0) {
     const totalCollateralTypeLink = totalCollateralRow.getByRole("link", {
       name: "cardano:totalCollateral",
@@ -1372,7 +1915,7 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     await expect(totalCollateralRow).not.toContainText(`${fieldPredicateHref}totalCollateral`);
   }
 
-  const outputs = decodedPanel.getByRole("button", { name: /^Outputs\b/ });
+  const outputs = decodedPanel.getByRole("button", { name: /^outputs\b/ });
   await outputs.click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
@@ -1384,17 +1927,12 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     decodedPanel.locator(".decoded-tree-row", { hasText: "Lovelace" }).first(),
   ).toBeVisible();
 
-  await outputs.click();
-  await expect(
-    decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
-  ).toHaveCount(0);
-
-  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^vkeys\b/ }).click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Key witness" }).first(),
   ).toBeVisible();
 
-  const metadata = decodedPanel.getByRole("button", { name: /^Metadata\b/ });
+  const metadata = decodedPanel.getByRole("button", { name: /^metadata\b/ });
   await metadata.click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Metadata label" }).first(),
@@ -1414,6 +1952,53 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     }),
   ).toBeVisible();
   await expect(lensPanel.locator(".sparql-lens-row").first()).toBeVisible();
+});
+
+test("faithful CQuisitor parity renders Conway structure for the Amaru treasury corpus", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+
+  const fixtures = await signedTxFixtures();
+  expect(
+    fixtures.length,
+    `${amaruTreasuryTx2026Root} signed-tx.hex corpus should be non-empty`,
+  ).toBeGreaterThan(0);
+
+  const validationContext = await loadValidationContext();
+  await installClipboardMock(page);
+  await mockKoiosValidationContext(page, validationContext);
+  await page.goto("/");
+
+  let checkedContingencyGolden = false;
+  for (const txFixturePath of fixtures) {
+    const txCbor = (await readFile(txFixturePath, "utf8")).trim();
+    const shape = walkConwayTransactionCbor(txCbor);
+    await submitTxCbor(page, txCbor);
+
+    const rows = await decodedStructureRows(page);
+    const fixtureName = path.relative(amaruTreasuryTx2026Root, txFixturePath);
+    expectRenderedConwayShape(rows, shape, fixtureName);
+
+    if (txFixturePath.includes(contingencyTxId)) {
+      checkedContingencyGolden = true;
+      expect(
+        renderedConwayFieldTree(rows),
+        "18d57a4f contingency CQuisitor field tree",
+      ).toEqual({
+        top_level: ["transaction_hash", "transaction"],
+        transaction: ["body", "witness_set", "is_valid", "auxiliary_data"],
+        body: conwayBodyFields.map((field) => field.label),
+        witness_set: conwayWitnessFields.map((field) => field.label),
+        auxiliary_data: conwayAuxiliaryDataFields,
+      });
+    }
+  }
+
+  expect(
+    checkedContingencyGolden,
+    `expected to cover contingency transaction ${contingencyTxId}`,
+  ).toBe(true);
 });
 
 test("decodes genuine Conway fixture into RDF tree", async ({
@@ -1443,24 +2028,24 @@ test("decodes genuine Conway fixture into RDF tree", async ({
   await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
   await expect(decodedPanel.getByText("Tree renderer pending.", { exact: true })).toHaveCount(0);
 
-  const rootRow = decodedPanel.locator(".decoded-tree-row", {
+  const rootRow = decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-0", {
     hasText: "Transaction",
-  });
+  }).first();
   await expect(rootRow).toBeVisible();
   await expect(rootRow).toContainText(/urn:cardano:tx:/);
 
-  for (const section of ["Outputs", "Witnesses"]) {
+  for (const section of ["outputs", "vkeys"]) {
     await expect(
       decodedPanel.getByRole("button", { name: new RegExp(`^${section}\\b`) }),
     ).toBeVisible();
   }
 
-  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
   ).toBeVisible();
 
-  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^vkeys\b/ }).click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: /Key witness|Script witness|Redeemer/ }).first(),
   ).toBeVisible();
@@ -1479,10 +2064,12 @@ test("preview subpath decodes genuine Conway fixture into RDF tree", async ({
     await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
     await expect(decodedPanel.getByText("Tree renderer pending.", { exact: true })).toHaveCount(0);
     await expect(
-      decodedPanel.locator(".decoded-tree-row", { hasText: "Transaction" }),
+      decodedPanel
+        .locator(".decoded-tree-row.decoded-tree-depth-0", { hasText: "Transaction" })
+        .first(),
     ).toBeVisible();
-    await expect(decodedPanel.getByRole("button", { name: /^Outputs\b/ })).toBeVisible();
-    await expect(decodedPanel.getByRole("button", { name: /^Witnesses\b/ })).toBeVisible();
+    await expect(decodedPanel.getByRole("button", { name: /^outputs\b/ })).toBeVisible();
+    await expect(decodedPanel.getByRole("button", { name: /^vkeys\b/ })).toBeVisible();
   });
 });
 
@@ -1617,7 +2204,7 @@ test("resolves decoded-tree address rows from selected Turtle overlay books", as
   await decodeFixture(page, conwayMainnetFixturePath);
 
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
 
   const addressRow = decodedPanel
     .locator(".decoded-tree-row")
@@ -1753,7 +2340,7 @@ fixture:selectedLibraryAddress
     page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
   const resolvedAddressRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Address" })
@@ -1771,7 +2358,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   await decodeFixtureAt(page, "/inspect", conwayMainnetFixturePath);
 
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
 
   const output0Row = decodedPanel
     .locator(".decoded-tree-row")
@@ -1848,7 +2435,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
   await expect(datumHashRow).toContainText(appendedLabel);
 
-  await decodedPanel.getByRole("button", { name: /^Witnesses\b/ }).click();
+  await decodedPanel.getByRole("button", { name: /^vkeys\b/ }).click();
   const verificationKeyRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Verification key" })
@@ -1920,7 +2507,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
     await decodeFixtureAt(cleanPage, "/inspect", conwayMainnetFixturePath);
     const cleanDecodedPanel = cleanPage.locator(".decoded-structure-panel");
-    await cleanDecodedPanel.getByRole("button", { name: /^Outputs\b/ }).click();
+    await cleanDecodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
     await expect(
       cleanDecodedPanel
         .locator(".decoded-tree-row")

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -350,6 +350,16 @@ async function signedTxFixtures(root = amaruTreasuryTx2026Root) {
   return fixtures.sort();
 }
 
+async function contingencySignedTxFixture() {
+  const fixtures = await signedTxFixtures();
+  const fixture = fixtures.find((fixturePath) => fixturePath.includes(contingencyTxId));
+  expect(
+    fixture,
+    `expected to find contingency signed-tx.hex fixture ${contingencyTxId}`,
+  ).toBeTruthy();
+  return fixture;
+}
+
 function normalizeStructureLabel(label) {
   return String(label || "")
     .replace(/\s+\d+\s+(fields?|inputs?|outputs?|key witnesses?|redeemers?|labels?)$/i, "")
@@ -367,16 +377,19 @@ function normalizeSummary(summary) {
 }
 
 async function expandDecodedStructure(panel) {
-  for (let pass = 0; pass < 8; pass += 1) {
+  for (let pass = 0; pass < 256; pass += 1) {
     const expanded = await panel.evaluate(async (root) => {
-      const toggles = Array.from(
-        root.querySelectorAll(".decoded-tree-row:not(.is-expanded) .decoded-tree-toggle"),
-      );
-      for (const toggle of toggles) toggle.click();
+      const toggle = Array.from(root.querySelectorAll(".decoded-tree-row:not(.is-expanded)"))
+        .map((row) =>
+          row.querySelector(":scope > .decoded-tree-main > .decoded-tree-keyline .decoded-tree-toggle"),
+        )
+        .find(Boolean);
+      if (!toggle) return false;
+      toggle.click();
       await new Promise((resolve) => requestAnimationFrame(resolve));
-      return toggles.length;
+      return true;
     });
-    if (expanded === 0) return;
+    if (!expanded) return;
   }
 }
 
@@ -465,6 +478,21 @@ async function browserRowActionLayout(row) {
     ).map((button) => button.textContent.trim()),
     standaloneActionCount: node.querySelectorAll(":scope > .browser-actions").length,
   }));
+}
+
+async function directDecodedTreeChildLabels(row) {
+  return row.evaluate((node) => {
+    const children = node.nextElementSibling;
+    if (!children?.classList.contains("decoded-tree-children")) return [];
+    return Array.from(children.children)
+      .filter((child) => child.classList.contains("decoded-tree-row"))
+      .map((child) => {
+        const label =
+          child.querySelector(":scope > .decoded-tree-main > .decoded-tree-keyline > md-outlined-button") ||
+          child.querySelector(":scope > .decoded-tree-main > .decoded-tree-keyline > strong");
+        return label?.textContent?.trim() || "";
+      });
+  });
 }
 
 function rowLabel(row) {
@@ -1890,6 +1918,7 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     decodedPanel.getByRole("heading", { name: "Decoded structure" }),
   ).toBeVisible();
   await expect(decodedPanel.locator(".decoded-structure-placeholder")).toHaveCount(0);
+  await expandDecodedStructure(decodedPanel);
 
   const rootRow = decodedPanel.locator(".decoded-tree-row.decoded-tree-depth-0", {
     hasText: "Transaction",
@@ -1929,8 +1958,6 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     ).toBeVisible();
   }
 
-  const body = decodedPanel.getByRole("button", { name: /^body\b/ });
-  await body.click();
   const fieldPredicateHref =
     "https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#";
   const scalarBodyRow = (label) =>
@@ -1977,8 +2004,6 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     await expect(totalCollateralRow).not.toContainText(`${fieldPredicateHref}totalCollateral`);
   }
 
-  const outputs = decodedPanel.getByRole("button", { name: /^outputs\b/ });
-  await outputs.click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Output 0" }),
   ).toBeVisible();
@@ -1989,13 +2014,10 @@ test("renders decoded-structure tree from RDF rows", async ({ page }) => {
     decodedPanel.locator(".decoded-tree-row", { hasText: "Lovelace" }).first(),
   ).toBeVisible();
 
-  await decodedPanel.getByRole("button", { name: /^vkeys\b/ }).click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Key witness" }).first(),
   ).toBeVisible();
 
-  const metadata = decodedPanel.getByRole("button", { name: /^metadata\b/ });
-  await metadata.click();
   await expect(
     decodedPanel.locator(".decoded-tree-row", { hasText: "Metadata label" }).first(),
   ).toBeVisible();
@@ -2061,6 +2083,44 @@ test("faithful CQuisitor parity renders Conway structure for the Amaru treasury 
     checkedContingencyGolden,
     `expected to cover contingency transaction ${contingencyTxId}`,
   ).toBe(true);
+});
+
+test("decoded structure toggles collapse and expand direct children", async ({
+  page,
+}) => {
+  const txFixturePath = await contingencySignedTxFixture();
+  const txCbor = (await readFile(txFixturePath, "utf8")).trim();
+  await decodeTxCbor(page, "/", txCbor);
+
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  const bodyRow = decodedPanel
+    .locator(".decoded-tree-row", {
+      has: page.locator(".decoded-tree-keyline > md-outlined-button", {
+        hasText: /^body\b/,
+      }),
+    })
+    .first();
+  await expect(bodyRow).toBeVisible();
+
+  const initiallyVisibleChildren =
+    (await directDecodedTreeChildLabels(bodyRow)).map(normalizeStructureLabel);
+  expect(initiallyVisibleChildren).toEqual(
+    expect.arrayContaining(["inputs", "outputs", "fee"]),
+  );
+
+  await bodyRow
+    .locator(":scope > .decoded-tree-main > .decoded-tree-keyline .decoded-tree-toggle")
+    .click();
+  await expect(directDecodedTreeChildLabels(bodyRow)).resolves.toEqual([]);
+
+  await bodyRow
+    .locator(":scope > .decoded-tree-main > .decoded-tree-keyline .decoded-tree-toggle")
+    .click();
+  const restoredChildren =
+    (await directDecodedTreeChildLabels(bodyRow)).map(normalizeStructureLabel);
+  expect(restoredChildren).toEqual(
+    expect.arrayContaining(["inputs", "outputs", "fee"]),
+  );
 });
 
 test("decodes genuine Conway fixture into RDF tree", async ({
@@ -2266,7 +2326,7 @@ test("resolves decoded-tree address rows from selected Turtle overlay books", as
   await decodeFixture(page, conwayMainnetFixturePath);
 
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
+  await expandDecodedStructure(decodedPanel);
 
   const addressRow = decodedPanel
     .locator(".decoded-tree-row")
@@ -2329,6 +2389,7 @@ fixture:decodedTreasuryAddress
   await overlayPanel.getByRole("button", { name: "Apply selected books" }).click();
 
   await selectResultTab(page, "Structure");
+  await expandDecodedStructure(decodedPanel);
   const resolvedAddressRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Address" })
@@ -2402,7 +2463,7 @@ fixture:selectedLibraryAddress
     page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
+  await expandDecodedStructure(decodedPanel);
   const resolvedAddressRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Address" })
@@ -2420,7 +2481,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   await decodeFixtureAt(page, "/inspect", conwayMainnetFixturePath);
 
   const decodedPanel = page.locator(".decoded-structure-panel");
-  await decodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
+  await expandDecodedStructure(decodedPanel);
 
   const output0Row = decodedPanel
     .locator(".decoded-tree-row")
@@ -2455,6 +2516,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   await expect(
     output0Row.getByRole("link", { name: "cardano:TransactionOutput" }),
   ).toBeVisible();
+  await expandDecodedStructure(decodedPanel);
 
   const addressRows = decodedPanel
     .locator(".decoded-tree-row")
@@ -2484,6 +2546,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
   await firstAddressRow.getByRole("button", { name: "Save label" }).click();
 
   await expect(firstAddressRow).toContainText(inlineLabel);
+  await expandDecodedStructure(decodedPanel);
 
   const datumHashRow = decodedPanel
     .locator(".decoded-tree-row")
@@ -2504,7 +2567,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
   await expect(datumHashRow).toContainText(appendedLabel);
 
-  await decodedPanel.getByRole("button", { name: /^vkeys\b/ }).click();
+  await expandDecodedStructure(decodedPanel);
   const verificationKeyRow = decodedPanel
     .locator(".decoded-tree-row")
     .filter({ hasText: "Verification key" })
@@ -2576,7 +2639,7 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
     await decodeFixtureAt(cleanPage, "/inspect", conwayMainnetFixturePath);
     const cleanDecodedPanel = cleanPage.locator(".decoded-structure-panel");
-    await cleanDecodedPanel.getByRole("button", { name: /^outputs\b/ }).click();
+    await expandDecodedStructure(cleanDecodedPanel);
     await expect(
       cleanDecodedPanel
         .locator(".decoded-tree-row")

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -1885,6 +1885,42 @@ test("decodes a Conway transaction and exposes compact identity values", async (
     .toBe(bodyHash);
 });
 
+test("loaded header surfaces tx id and CBOR", async ({ page }) => {
+  const txFixturePath = await contingencySignedTxFixture();
+  const txCbor = (await readFile(txFixturePath, "utf8")).trim();
+
+  await decodeFixtureAt(page, "/", txFixturePath);
+
+  const loadedHeader = page.locator(".loaded-inspector-header");
+  await expect(loadedHeader).toBeVisible();
+
+  const txIdRow = loadedHeader.locator(".loaded-context-item").filter({
+    has: page.getByText("Tx id/hash", { exact: true }),
+  });
+  await expect(txIdRow).toBeVisible();
+  await expect(txIdRow.locator("code")).toHaveText(contingencyTxId);
+
+  const cborRow = loadedHeader.locator(".loaded-context-item").filter({
+    has: page.getByText("CBOR", { exact: true }),
+  });
+  await expect(cborRow).toBeVisible();
+  const cborValue = cborRow.locator("code");
+  await expect(cborValue).toContainText(txCbor.slice(0, 16));
+  await expect(cborValue).toContainText(txCbor.slice(-8));
+  const visibleCbor = await cborValue.innerText();
+  expect(visibleCbor.length).toBeLessThan(txCbor.length);
+
+  await cborRow.getByRole("button", { name: "Copy CBOR" }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(txCbor);
+
+  await txIdRow.getByRole("button", { name: "Copy Tx id/hash" }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toBe(contingencyTxId);
+});
+
 test("renders the transaction RDF graph after decode", async ({ page }) => {
   await decodeFixture(page);
 

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -405,6 +405,68 @@ async function decodedStructureRows(page) {
   );
 }
 
+async function decodedStructureIndentationViolations(page) {
+  const decodedPanel = page.locator(".decoded-structure-panel");
+  await expandDecodedStructure(decodedPanel);
+  return decodedPanel.locator(".decoded-tree-row-list").evaluate((root) => {
+    const depthOf = (row) => {
+      const depthClass = Array.from(row.classList).find((className) =>
+        className.startsWith("decoded-tree-depth-"),
+      );
+      return depthClass ? Number(depthClass.replace("decoded-tree-depth-", "")) : 0;
+    };
+    const labelOf = (row) =>
+      (
+        row.querySelector(".decoded-tree-keyline > md-outlined-button") ||
+        row.querySelector(".decoded-tree-keyline > strong")
+      )?.textContent?.trim() || "(unlabelled)";
+    const directRows = (container) =>
+      Array.from(container.children).filter((child) =>
+        child.classList.contains("decoded-tree-row"),
+      );
+
+    const violations = [];
+    for (const parent of root.querySelectorAll(".decoded-tree-row")) {
+      const parentDepth = depthOf(parent);
+      if (parentDepth < 3) continue;
+      const childContainer = parent.nextElementSibling;
+      if (!childContainer?.classList.contains("decoded-tree-children")) continue;
+      const parentLeft = parent.getBoundingClientRect().left;
+      for (const child of directRows(childContainer)) {
+        const childDepth = depthOf(child);
+        if (childDepth !== parentDepth + 1) continue;
+        const childLeft = child.getBoundingClientRect().left;
+        if (!(childLeft > parentLeft)) {
+          violations.push(
+            `${labelOf(parent)} depth ${parentDepth} left ${parentLeft.toFixed(2)} -> ${labelOf(child)} depth ${childDepth} left ${childLeft.toFixed(2)}`,
+          );
+        }
+      }
+    }
+    return violations;
+  });
+}
+
+async function decodedTreeAnnotationActionLayout(row) {
+  return row.evaluate((node) => ({
+    headerButtonCount: node.querySelectorAll(
+      ':scope > .decoded-tree-main > .decoded-tree-keyline .decoded-tree-annotate[data-aria-label="Label this node"]',
+    ).length,
+    standaloneButtonCount: node.querySelectorAll(
+      ":scope > .decoded-tree-main > .decoded-tree-annotate",
+    ).length,
+  }));
+}
+
+async function browserRowActionLayout(row) {
+  return row.evaluate((node) => ({
+    headerActions: Array.from(
+      node.querySelectorAll(":scope > .browser-row-main > .browser-keyline md-outlined-button"),
+    ).map((button) => button.textContent.trim()),
+    standaloneActionCount: node.querySelectorAll(":scope > .browser-actions").length,
+  }));
+}
+
 function rowLabel(row) {
   return normalizeStructureLabel(row.label);
 }
@@ -2372,9 +2434,16 @@ test("labels decoded-tree nodes into local books and resolves immediately", asyn
 
   const outputLabel = "Inline annotated fixture output";
   await expect(output0Row).not.toContainText(outputLabel);
+  await expect(decodedTreeAnnotationActionLayout(output0Row)).resolves.toEqual({
+    headerButtonCount: 1,
+    standaloneButtonCount: 0,
+  });
   await output0Row
     .getByRole("button", { name: "Label this node" })
     .click();
+  await expect(
+    output0Row.locator(":scope > .decoded-tree-main > .decoded-tree-annotation-form"),
+  ).toBeVisible();
   await expect(output0Row.getByLabel("Label", { exact: true })).toBeVisible();
   await output0Row.getByLabel("Label", { exact: true }).fill(outputLabel);
   await output0Row.getByLabel("Optional type").fill("cardano:TransactionOutput");
@@ -3126,12 +3195,23 @@ test("opens browser rows in place without losing identity context", async ({
     .first();
 
   await expect(inputsRow.getByRole("button", { name: "Copy" })).toHaveCount(0);
+  await expect(browserRowActionLayout(inputsRow)).resolves.toEqual({
+    headerActions: ["Open"],
+    standaloneActionCount: 0,
+  });
   await inputsRow.locator(".browser-summary").click();
   await expect(inputsRow).toHaveClass(/is-copied/);
 
-  await inputsRow.getByRole("button", { name: "Open" }).click();
+  await inputsRow
+    .locator(":scope > .browser-row-main > .browser-keyline")
+    .getByRole("button", { name: "Open" })
+    .click();
 
   await expect(page.locator(".browser-children").first()).toBeVisible();
+  await expect(browserRowActionLayout(inputsRow)).resolves.toEqual({
+    headerActions: ["Close"],
+    standaloneActionCount: 0,
+  });
   await expect(
     page.getByRole("heading", { name: "Identity metadata" }),
   ).toBeVisible();
@@ -3152,4 +3232,6 @@ test("keeps decoded transaction layout within the viewport", async ({ page }) =>
   });
 
   expect(overflowPx).toBeLessThanOrEqual(1);
+
+  await expect(decodedStructureIndentationViolations(page)).resolves.toEqual([]);
 });

--- a/flake.nix
+++ b/flake.nix
@@ -186,8 +186,8 @@
 
           expectedTxRdfCore = {
             location = "https://github.com/lambdasistemi/cardano-ledger-rdf";
-            rev = "6769e28535aafee20743710ebdff53e652e8a22b";
-            sha256 = "0m1yj9cdzdh1bcrz1wn5d34fw8y6rh7gl624qh5h3idyni8jdqnw";
+            rev = "1ef103a923dc64fae7ef94cafd6e18665fefbb91";
+            sha256 = "03mdkmk90pcxcbkq7wcbki4dr5lnsl1vcrkal3mqyjxhhhfc9vf5";
           };
 
           expectedPlutusPin = {

--- a/gate.sh
+++ b/gate.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+git diff --check
+nix build .#packages.x86_64-linux.tx-inspector-ui
+nix develop --quiet -c sh -c 'cd docs/inspector && TX_AMARU_TREASURY_TX_ROOT=/code/amaru-treasury-tx TX_INSPECTOR_SITE_DIR=../../result playwright test tests/tx-identify.spec.mjs --grep "faithful CQuisitor parity" --reporter=list'
+just test-playwright
 just format-check
 just hlint
-nix build .#packages.x86_64-linux.tx-inspector-ui
-just test-playwright

--- a/libs/cardano-ledger-inspector/cabal-wasm.project
+++ b/libs/cardano-ledger-inspector/cabal-wasm.project
@@ -32,9 +32,9 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/lambdasistemi/cardano-ledger-rdf
-  tag: 6769e28535aafee20743710ebdff53e652e8a22b
+  tag: 1ef103a923dc64fae7ef94cafd6e18665fefbb91
   subdir: tx-rdf-core
-  --sha256: 0m1yj9cdzdh1bcrz1wn5d34fw8y6rh7gl624qh5h3idyni8jdqnw
+  --sha256: 03mdkmk90pcxcbkq7wcbki4dr5lnsl1vcrkal3mqyjxhhhfc9vf5
 
 package cardano-crypto-praos
   flags: -external-libsodium-vrf

--- a/nix/wasm-targets.nix
+++ b/nix/wasm-targets.nix
@@ -73,7 +73,7 @@ in
     # dependenciesHash distinct from wasm-ledger-smoke because the inspector
     # pulls additional Hackage tarballs (aeson, base16-bytestring, text,
     # microlens, ...) that expand the cabal cache.
-    dependenciesHash = "sha256-KmY5jyyPc2NFXZSP133Tq6rQWp3d7STwT4O51h7Ukys=";
+    dependenciesHash = "sha256-Fn+8MGGv3zAMXvGwDaqlCFDm+v47kytXut6TY2cNuF8=";
   };
 
   # Spike depends on cardano-ledger-wasm via an external path package injected

--- a/specs/124-faithful-structure-decode/plan.md
+++ b/specs/124-faithful-structure-decode/plan.md
@@ -1,0 +1,42 @@
+# Plan
+
+## Context
+
+The current Structure tree is generated from `tx.rdf` through `docs/inspector/src/FFI/RdfShapes.js` and rendered by `docs/inspector/src/Main.purs`. It currently presents a curated tree: body scalar fields, all input-like rows in one "Inputs" section, outputs, a duplicate Fee section, witnesses, redeemers, and a collapsed metadata section. Issue #124 requires this to become a faithful structural view of the Conway transaction in CDDL order.
+
+The acceptance oracle is hermetic. It does not call `cardano-cli`, CSL, or CML. The parity test key-walks only the top-level CBOR shape needed to know which CDDL keys are present, then compares that structural field set and order with the rendered Structure rows.
+
+## Slice 1: Faithful Structure Parity
+
+One vertical slice covers the whole milestone because the RED test and the Structure implementation must agree on the same CDDL contract.
+
+Owned files:
+
+- `docs/inspector/src/FFI/RdfShapes.js`
+- `docs/inspector/src/FFI/RdfShapes.purs`
+- `docs/inspector/src/Main.purs`
+- `docs/inspector/tests/tx-identify.spec.mjs`
+
+Expected implementation shape:
+
+- Add a dependency-free CBOR key walker in the Playwright spec or a local helper in that same file. It only needs to walk the outer transaction array, body map integer keys, witness-set map integer keys, `is_valid`, and auxiliary-data presence enough for the parity assertions.
+- Add RED assertions over every current Amaru `signed-tx.hex` fixture under `/code/amaru-treasury-tx/transactions/2026/**`, with a non-empty corpus assertion.
+- Add a focused golden assertion for the `18d57a4f...` contingency transaction matching the CQuisitor field tree from `/tmp/ux121/faithful-decode-spec.md`.
+- Update the decoded Structure normalization so it emits a stable row tree in the CDDL order from the spec, explicitly includes NULL rows for absent fields, keeps input categories distinct, removes the duplicate Fee section, expands auxiliary metadata, and shows `is_valid`.
+- Preserve existing decoded-tree row shape and annotation metadata so book resolution and CURIE tests keep working.
+
+## Verification
+
+Focused proof inside the slice:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `nix develop --quiet -c sh -c 'cd docs/inspector && TX_AMARU_TREASURY_TX_ROOT=/code/amaru-treasury-tx TX_INSPECTOR_SITE_DIR=../../result playwright test tests/tx-identify.spec.mjs --grep "faithful CQuisitor parity" --reporter=list'`
+
+Final proof:
+
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`
+- `just test-playwright`
+- `just format-check`
+- `just hlint`
+
+The PR remains draft after verification.

--- a/specs/124-faithful-structure-decode/spec.md
+++ b/specs/124-faithful-structure-decode/spec.md
@@ -1,0 +1,30 @@
+# Issue 124: Faithful Structural Decode
+
+## User Story
+
+As a transaction analyst using the Structure tab, I need the decoded tree to be a faithful Conway transaction mirror rather than a lossy summary, so I can compare it with CQuisitor and inspect all structural fields without guessing what was omitted or merged.
+
+## Requirements
+
+- The Structure tree MUST render the Conway transaction as `transaction_hash` plus `transaction` with `body`, `witness_set`, `is_valid`, and `auxiliary_data`.
+- The `body` fields MUST appear in Conway CDDL order: `inputs`, `outputs`, `fee`, `ttl`, `certs`, `withdrawals`, `update`, `auxiliary_data_hash`, `validity_start_interval`, `mint`, `script_data_hash`, `collateral`, `required_signers`, `network_id`, `collateral_return`, `total_collateral`, `reference_inputs`, `voting_procedures`, `voting_proposals`, `donation`, `current_treasury_value`.
+- The `witness_set` fields MUST appear in Conway CDDL order: `vkeys`, `native_scripts`, `bootstraps`, `plutus_scripts`, `plutus_data`, `redeemers`.
+- `inputs`, `collateral`, and `reference_inputs` MUST render as distinct body fields and MUST NOT be merged into a single input section.
+- Absent CDDL fields MUST render explicitly as `NULL`.
+- `fee` MUST render only as the body field, with no duplicate top-level Fee section.
+- `ttl`, `withdrawals`, `required_signers`, `is_valid`, and `auxiliary_data.metadata` MUST be visible when present in the transaction structure, with metadata expanded beyond a collapsed label count.
+- Existing books, CURIE annotation, validation, graph, and layout behavior MUST continue to pass.
+
+## Acceptance
+
+- A hermetic automated parity test globs every `/code/amaru-treasury-tx/transactions/2026/**/signed-tx.hex` fixture, asserts the corpus is non-empty, key-walks each top-level Conway transaction CBOR without new dependencies, maps body and witness-set integer keys through the Conway CDDL table, and fails on any missing, merged, duplicated, or mis-ordered Structure field.
+- The same test includes an exact field-set and order golden for the `18d57a4f...` contingency transaction matching the captured CQuisitor tree in `/tmp/ux121/faithful-decode-spec.md`.
+- The parity test is observed RED against the current lossy decode, then GREEN after the Structure implementation.
+- `nix build .#packages.x86_64-linux.tx-inspector-ui`, `just test-playwright`, `just format-check`, and `just hlint` pass before the draft PR is left for epic-owner re-verification.
+
+## Non-Goals
+
+- No layout polish.
+- No history view.
+- No deduplication beyond removing the duplicate Fee row required by this ticket.
+- No production deploy or merge.

--- a/specs/124-faithful-structure-decode/tasks.md
+++ b/specs/124-faithful-structure-decode/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## Slice 1: Faithful Structure Parity
+
+- [ ] T124 Add hermetic RED Playwright parity coverage that key-walks the Amaru Conway transaction CBOR corpus, asserts non-empty corpus, and fails on missing, merged, duplicated, or mis-ordered Structure fields.
+- [ ] T125 Add the `18d57a4f...` exact CQuisitor field-tree golden assertion from `/tmp/ux121/faithful-decode-spec.md`.
+- [ ] T126 Update the decoded Structure tree to render body, witness_set, is_valid, and auxiliary_data fields in Conway CDDL order with explicit NULLs.
+- [ ] T127 Keep `inputs`, `collateral`, and `reference_inputs` distinct; show `ttl`, `withdrawals`, `required_signers`, expanded `auxiliary_data.metadata`, and remove the duplicate Fee section.
+- [ ] T128 Prove RED then GREEN in the driver/navigator protocol and run the focused parity command plus `./gate.sh`.


### PR DESCRIPTION
## Summary

This productionizes the flat `cardano:txOutRef` resolution path from the experiment.

- Joins decoded input and reference-input entities to overlay/book entities via flat `cardano:txOutRef`, alongside the existing direct entity and Bech32 resolution paths.
- Re-keys the bundled Amaru treasury overlay, journal, and generated overlay book output from padded `cardano:fromTxOutRef` values to unpadded flat `cardano:txOutRef` values.
- Repins `tx-rdf-core` to the merged `cardano-ledger-rdf` main commit `1ef103a923dc64fae7ef94cafd6e18665fefbb91` while keeping the same fixed-output hash as the experiment branch commit.

## Validation

- `nix flake prefetch github:lambdasistemi/cardano-ledger-rdf/1ef103a923dc64fae7ef94cafd6e18665fefbb91` returned the same source hash as the experiment commit: `sha256-xe3EHISwS4/roGpmtgPVlpbcSJyL8YPnYp1dkGadrQ4=`.
- `nix build .#packages.x86_64-linux.tx-inspector-ui` passed after the repin. It was not a derivation-level cache hit; Nix rebuilt the WASM/UI chain because the SRP commit text changed even though the source tree hash was unchanged.
- Contingency transaction `18d57a4f.../signed-tx.hex` measurement remains `4/4` resolved reference inputs with the flat overlay, versus `0/4` with the old padded `fromTxOutRef` overlay.

## Notes

This PR is intentionally draft and stacks on `fix/124-faithful-structure-decode` for user review.