### PR TITLE
feat(inspector): add Class A SHACL validation

### DIFF
--- a/docs/inspector/protocols/cardano-rdf/shapes.ttl
+++ b/docs/inspector/protocols/cardano-rdf/shapes.ttl
@@ -1,13 +1,159 @@
 @prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 cardano:TransactionShape
   a sh:NodeShape ;
   sh:targetClass cardano:Transaction ;
-  sh:property cardano:TransactionIdShape .
+  sh:property cardano:TransactionIdShape ;
+  sh:property cardano:ClassAInputSetNotEmptyShape ;
+  sh:sparql cardano:ClassAReferenceInputOverlapConstraint ;
+  sh:sparql cardano:ClassAZeroTreasuryWithdrawalConstraint ;
+  sh:sparql cardano:ClassACommitteeUpdateConflictConstraint ;
+  sh:sparql cardano:ClassAAuxiliaryDataHashMissingConstraint ;
+  sh:sparql cardano:ClassAAuxiliaryDataHashUnexpectedConstraint ;
+  sh:sparql cardano:ClassAInputOrderWarningConstraint ;
+  sh:sparql cardano:ClassAWithdrawalOrderWarningConstraint .
 
 cardano:TransactionIdShape
-    sh:path cardano:hasTxId ;
-    sh:minCount 1 ;
-    sh:class cardano:Identifier ;
-    sh:message "Cardano transactions must reference a transaction id identifier." .
+  sh:path cardano:hasTxId ;
+  sh:minCount 1 ;
+  sh:severity sh:Violation ;
+  sh:message "Cardano transactions must include a transaction id." .
+
+cardano:ClassAInputSetNotEmptyShape
+  sh:path cardano:hasInput ;
+  sh:minCount 1 ;
+  sh:severity sh:Violation ;
+  sh:message "InputSetEmptyUTxO: transaction input set must not be empty." .
+
+cardano:ClassAReferenceInputOverlapConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "ReferenceInputOverlapsWithInput: a reference input must not also be spent as an input." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasInput ?spendInput ;
+            cardano:hasReferenceInput ?referenceInput .
+      ?spendInput cardano:txOutRef ?value .
+      ?referenceInput cardano:txOutRef ?value .
+    }
+  """ .
+
+cardano:ClassAZeroTreasuryWithdrawalConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "TreasuryWithdrawalZero: treasury withdrawal governance actions must withdraw a positive amount." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasProposal ?proposal .
+      ?proposal cardano:hasGovAction ?action .
+      ?action a cardano:TreasuryWithdrawals ;
+              cardano:hasWithdrawal ?value .
+      ?value cardano:hasLovelace ?lovelace .
+      FILTER(xsd:integer(?lovelace) = 0)
+    }
+  """ .
+
+cardano:ClassACommitteeUpdateConflictConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "CommitteeUpdateConflict: a committee member cannot be added and removed by the same update." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasProposal ?proposal .
+      ?proposal cardano:hasGovAction ?action .
+      ?action a cardano:UpdateCommittee ;
+              cardano:removesMember ?value ;
+              cardano:addsMember ?addition .
+      ?addition cardano:hasIdentifier ?value .
+    }
+  """ .
+
+cardano:ClassAAuxiliaryDataHashMissingConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "AuxiliaryDataHashMissing: auxiliary data is present but the transaction body has no auxiliary-data hash." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasAuxiliaryData ?value .
+      FILTER NOT EXISTS { $this cardano:auxiliaryDataHash ?hash . }
+    }
+  """ .
+
+cardano:ClassAAuxiliaryDataHashUnexpectedConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "AuxiliaryDataHashPresentButNotExpected: transaction body has an auxiliary-data hash but no auxiliary data." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:auxiliaryDataHash ?value .
+      FILTER NOT EXISTS { $this cardano:hasAuxiliaryData ?auxiliaryData . }
+    }
+  """ .
+
+cardano:ClassAInputOrderWarningConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Warning ;
+  sh:message "InputsNotCanonicallySorted: input order does not match ascending txOutRef order." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasInput ?leftInput ;
+            cardano:hasInput ?rightInput .
+      ?leftInput cardano:inputOrder ?leftOrder ;
+                 cardano:txOutRef ?value .
+      ?rightInput cardano:inputOrder ?rightOrder ;
+                  cardano:txOutRef ?rightRef .
+      FILTER(xsd:integer(?leftOrder) < xsd:integer(?rightOrder))
+      FILTER(STR(?value) > STR(?rightRef))
+    }
+  """ .
+
+cardano:ClassAWithdrawalOrderWarningConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Warning ;
+  sh:message "WithdrawalsNotCanonicallySorted: withdrawal order does not match ascending reward-account order." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasWithdrawal ?leftWithdrawal ;
+            cardano:hasWithdrawal ?rightWithdrawal .
+      ?leftWithdrawal cardano:withdrawalOrder ?leftOrder ;
+                      cardano:withdrawalAccount ?value .
+      ?rightWithdrawal cardano:withdrawalOrder ?rightOrder ;
+                       cardano:withdrawalAccount ?rightAccount .
+      FILTER(xsd:integer(?leftOrder) < xsd:integer(?rightOrder))
+      FILTER(STR(?value) > STR(?rightAccount))
+    }
+  """ .
+
+cardano:UnsupportedLegacyCertificateShape
+  a sh:NodeShape ;
+  sh:targetClass cardano:GenesisKeyDelegation ;
+  sh:targetClass cardano:MoveInstantaneousRewardsCertificate ;
+  sh:targetClass cardano:MIRCertificate ;
+  sh:property cardano:UnsupportedLegacyCertificateTypeShape .
+
+cardano:UnsupportedLegacyCertificateTypeShape
+  sh:path rdf:type ;
+  sh:minCount 0 ;
+  sh:maxCount 0 ;
+  sh:severity sh:Violation ;
+  sh:message "UnsupportedLegacyCertificate: genesis-key-delegation and MIR certificates are not supported in Conway phase-1 validation." .

--- a/docs/inspector/src/FFI/OverlayBook.js
+++ b/docs/inspector/src/FFI/OverlayBook.js
@@ -40,18 +40,164 @@ overlay:scriptRole a rdf:Property ; rdfs:label "Script role" .
 `;
 
 const CARDANO_SHACL_SHAPES = `@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 cardano:TransactionShape
   a sh:NodeShape ;
   sh:targetClass cardano:Transaction ;
-  sh:property [
-    sh:path cardano:hasTxId ;
-    sh:minCount 1 ;
-    sh:datatype xsd:string ;
-    sh:message "Cardano transactions must include a transaction id." ;
-  ] .
+  sh:property cardano:TransactionIdShape ;
+  sh:property cardano:ClassAInputSetNotEmptyShape ;
+  sh:sparql cardano:ClassAReferenceInputOverlapConstraint ;
+  sh:sparql cardano:ClassAZeroTreasuryWithdrawalConstraint ;
+  sh:sparql cardano:ClassACommitteeUpdateConflictConstraint ;
+  sh:sparql cardano:ClassAAuxiliaryDataHashMissingConstraint ;
+  sh:sparql cardano:ClassAAuxiliaryDataHashUnexpectedConstraint ;
+  sh:sparql cardano:ClassAInputOrderWarningConstraint ;
+  sh:sparql cardano:ClassAWithdrawalOrderWarningConstraint .
+
+cardano:TransactionIdShape
+  sh:path cardano:hasTxId ;
+  sh:minCount 1 ;
+  sh:severity sh:Violation ;
+  sh:message "Cardano transactions must include a transaction id." .
+
+cardano:ClassAInputSetNotEmptyShape
+  sh:path cardano:hasInput ;
+  sh:minCount 1 ;
+  sh:severity sh:Violation ;
+  sh:message "InputSetEmptyUTxO: transaction input set must not be empty." .
+
+cardano:ClassAReferenceInputOverlapConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "ReferenceInputOverlapsWithInput: a reference input must not also be spent as an input." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasInput ?spendInput ;
+            cardano:hasReferenceInput ?referenceInput .
+      ?spendInput cardano:txOutRef ?value .
+      ?referenceInput cardano:txOutRef ?value .
+    }
+  """ .
+
+cardano:ClassAZeroTreasuryWithdrawalConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "TreasuryWithdrawalZero: treasury withdrawal governance actions must withdraw a positive amount." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasProposal ?proposal .
+      ?proposal cardano:hasGovAction ?action .
+      ?action a cardano:TreasuryWithdrawals ;
+              cardano:hasWithdrawal ?value .
+      ?value cardano:hasLovelace ?lovelace .
+      FILTER(xsd:integer(?lovelace) = 0)
+    }
+  """ .
+
+cardano:ClassACommitteeUpdateConflictConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "CommitteeUpdateConflict: a committee member cannot be added and removed by the same update." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasProposal ?proposal .
+      ?proposal cardano:hasGovAction ?action .
+      ?action a cardano:UpdateCommittee ;
+              cardano:removesMember ?value ;
+              cardano:addsMember ?addition .
+      ?addition cardano:hasIdentifier ?value .
+    }
+  """ .
+
+cardano:ClassAAuxiliaryDataHashMissingConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "AuxiliaryDataHashMissing: auxiliary data is present but the transaction body has no auxiliary-data hash." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasAuxiliaryData ?value .
+      FILTER NOT EXISTS { $this cardano:auxiliaryDataHash ?hash . }
+    }
+  """ .
+
+cardano:ClassAAuxiliaryDataHashUnexpectedConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Violation ;
+  sh:message "AuxiliaryDataHashPresentButNotExpected: transaction body has an auxiliary-data hash but no auxiliary data." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:auxiliaryDataHash ?value .
+      FILTER NOT EXISTS { $this cardano:hasAuxiliaryData ?auxiliaryData . }
+    }
+  """ .
+
+cardano:ClassAInputOrderWarningConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Warning ;
+  sh:message "InputsNotCanonicallySorted: input order does not match ascending txOutRef order." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasInput ?leftInput ;
+            cardano:hasInput ?rightInput .
+      ?leftInput cardano:inputOrder ?leftOrder ;
+                 cardano:txOutRef ?value .
+      ?rightInput cardano:inputOrder ?rightOrder ;
+                  cardano:txOutRef ?rightRef .
+      FILTER(xsd:integer(?leftOrder) < xsd:integer(?rightOrder))
+      FILTER(STR(?value) > STR(?rightRef))
+    }
+  """ .
+
+cardano:ClassAWithdrawalOrderWarningConstraint
+  a sh:SPARQLConstraint ;
+  sh:severity sh:Warning ;
+  sh:message "WithdrawalsNotCanonicallySorted: withdrawal order does not match ascending reward-account order." ;
+  sh:select """
+    PREFIX cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#>
+    PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+    SELECT $this ?value
+    WHERE {
+      $this cardano:hasWithdrawal ?leftWithdrawal ;
+            cardano:hasWithdrawal ?rightWithdrawal .
+      ?leftWithdrawal cardano:withdrawalOrder ?leftOrder ;
+                      cardano:withdrawalAccount ?value .
+      ?rightWithdrawal cardano:withdrawalOrder ?rightOrder ;
+                       cardano:withdrawalAccount ?rightAccount .
+      FILTER(xsd:integer(?leftOrder) < xsd:integer(?rightOrder))
+      FILTER(STR(?value) > STR(?rightAccount))
+    }
+  """ .
+
+cardano:UnsupportedLegacyCertificateShape
+  a sh:NodeShape ;
+  sh:targetClass cardano:GenesisKeyDelegation ;
+  sh:targetClass cardano:MoveInstantaneousRewardsCertificate ;
+  sh:targetClass cardano:MIRCertificate ;
+  sh:property cardano:UnsupportedLegacyCertificateTypeShape .
+
+cardano:UnsupportedLegacyCertificateTypeShape
+  sh:path rdf:type ;
+  sh:minCount 0 ;
+  sh:maxCount 0 ;
+  sh:severity sh:Violation ;
+  sh:message "UnsupportedLegacyCertificate: genesis-key-delegation and MIR certificates are not supported in Conway phase-1 validation." .
 `;
 
 const AMARU_JOURNAL = {

--- a/docs/inspector/src/FFI/RdfShapes.js
+++ b/docs/inspector/src/FFI/RdfShapes.js
@@ -1092,58 +1092,223 @@ const normalizeDecodedTreeRows = (graphTtl) => {
 const reportText = (value) =>
   value === null || value === undefined ? "" : String(value);
 
-const shapeMetadataByPath = (shapesTtl) => {
-  const query = `
+const upsertShapeMetadata = (metadata, key, fields) => {
+  if (key === "") return;
+  const existing = metadata.get(key) || {};
+  metadata.set(key, {
+    sourceShape: fields.sourceShape || existing.sourceShape || "",
+    path: fields.path || existing.path || "",
+    message: fields.message || existing.message || "",
+    severity: fields.severity || existing.severity || "",
+  });
+};
+
+const shapeMetadata = (shapesTtl) => {
+  const queries = [
+    `
 PREFIX sh: <http://www.w3.org/ns/shacl#>
-SELECT ?sourceShape ?path ?message
+SELECT ?sourceShape ?path ?message ?severity
 WHERE {
   ?sourceShape sh:path ?path .
   OPTIONAL { ?sourceShape sh:message ?message . }
+  OPTIONAL { ?sourceShape sh:severity ?severity . }
 }
-`;
+`,
+    `
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT ?sourceShape ?path ?message ?severity
+WHERE {
+  ?sourceShape sh:message ?message .
+  OPTIONAL { ?sourceShape sh:path ?path . }
+  OPTIONAL { ?sourceShape sh:message ?message . }
+  OPTIONAL { ?sourceShape sh:severity ?severity . }
+}
+`,
+    `
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT ?sourceShape ?constraint ?message ?severity ?shapeSeverity
+WHERE {
+  ?sourceShape sh:sparql ?constraint .
+  OPTIONAL { ?constraint sh:message ?message . }
+  OPTIONAL { ?constraint sh:severity ?severity . }
+  OPTIONAL { ?sourceShape sh:severity ?shapeSeverity . }
+}
+`,
+  ];
   const metadata = new Map();
 
-  try {
-    const result = globalThis.rdfShapes.query(shapesTtl, query);
-    const bindings = result?.json?.results?.bindings;
-    if (!Array.isArray(bindings)) return metadata;
+  for (const query of queries) {
+    try {
+      const result = globalThis.rdfShapes.query(shapesTtl, query);
+      const bindings = result?.json?.results?.bindings;
+      if (!Array.isArray(bindings)) continue;
 
-    for (const binding of bindings) {
-      const path = bindingValue(binding.path);
-      if (path === "" || metadata.has(path)) continue;
-      metadata.set(path, {
-        sourceShape: bindingValue(binding.sourceShape),
-        message: bindingValue(binding.message),
-      });
+      for (const binding of bindings) {
+        const sourceShape = bindingValue(binding.sourceShape);
+        const path = bindingValue(binding.path);
+        const constraint = bindingValue(binding.constraint);
+        const message = bindingValue(binding.message);
+        const severity = firstBindingValue(binding.severity, binding.shapeSeverity);
+        upsertShapeMetadata(metadata, sourceShape, {
+          sourceShape,
+          path,
+          message: constraint === "" ? message : "",
+          severity,
+        });
+        upsertShapeMetadata(metadata, constraint, {
+          sourceShape: constraint,
+          path,
+          message,
+          severity,
+        });
+        upsertShapeMetadata(metadata, path, {
+          sourceShape,
+          path,
+          message,
+          severity,
+        });
+      }
+    } catch (_) {
+      continue;
     }
-  } catch (_) {
-    return metadata;
   }
 
   return metadata;
 };
 
-const normalizeViolation = (violation, shapeMetadata) => {
-  const path = reportText(violation?.path);
-  const metadata = shapeMetadata.get(path) || {};
-  const sourceShape =
-    reportText(violation?.source_shape ?? violation?.sourceShape) ||
-    metadata.sourceShape ||
-    "";
-  const message = metadata.message || reportText(violation?.message);
+const normalizedSeverity = (rawSeverity, metadata) => {
+  const severity = String(rawSeverity || metadata.severity || "");
+  if (severity.includes("Warning")) return "warning";
+  if (severity.includes("Info")) return "info";
+  return "error";
+};
 
+const metadataForViolation = (violation, metadata) => {
+  const sourceShape = reportText(
+    violation?.source_shape ??
+      violation?.sourceShape ??
+      violation?.source ??
+      violation?.shape,
+  );
+  const path = reportText(violation?.path ?? violation?.result_path);
   return {
-    focusNode: reportText(violation?.focus_node),
-    path,
-    value: reportText(violation?.value),
     sourceShape,
-    sourceConstraintComponent: reportText(violation?.source_constraint_component),
-    message,
-    severity: reportText(violation?.severity),
+    path,
+    metadata:
+      metadata.get(sourceShape) ||
+      metadata.get(path) ||
+      {},
   };
 };
 
-const normalizeValidationReport = (result, shapesTtl) => {
+const reportSeverity = (violation) =>
+  reportText(
+    violation?.result_severity ??
+      violation?.resultSeverity ??
+      violation?.severity,
+  );
+
+const sparqlConstraintsQuery = `
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT ?sourceShape ?constraint ?select ?message ?severity ?shapeSeverity
+WHERE {
+  ?sourceShape sh:sparql ?constraint .
+  ?constraint sh:select ?select .
+  OPTIONAL { ?constraint sh:message ?message . }
+  OPTIONAL { ?constraint sh:severity ?severity . }
+  OPTIONAL { ?sourceShape sh:severity ?shapeSeverity . }
+}
+`;
+
+const normalizeViolation = (violation, metadata) => {
+  const lookup = metadataForViolation(violation, metadata);
+  const sourceShape = lookup.sourceShape || lookup.metadata.sourceShape || "";
+  const path = lookup.path || lookup.metadata.path || "";
+  const message = lookup.metadata.message || reportText(violation?.message);
+
+  return {
+    focusNode: reportText(
+      violation?.focus_node ??
+        violation?.focusNode ??
+        violation?.focus,
+    ),
+    path,
+    value: reportText(violation?.value ?? violation?.result_value),
+    sourceShape,
+    sourceConstraintComponent: reportText(
+      violation?.source_constraint_component ??
+        violation?.sourceConstraintComponent,
+    ),
+    message,
+    severity: normalizedSeverity(reportSeverity(violation), lookup.metadata),
+  };
+};
+
+const sparqlConstraintViolations = (dataTtl, shapesTtl) => {
+  let constraints = [];
+  try {
+    constraints = queryBindings(shapesTtl, sparqlConstraintsQuery);
+  } catch (_) {
+    return [];
+  }
+
+  const violations = [];
+  for (const constraint of constraints) {
+    const select = bindingValue(constraint.select);
+    if (select === "") continue;
+    const sourceShape = firstBindingValue(constraint.constraint, constraint.sourceShape);
+    const message = bindingValue(constraint.message);
+    const severity = normalizedSeverity(
+      firstBindingValue(constraint.severity, constraint.shapeSeverity),
+      {},
+    );
+    const query = select.replaceAll("$this", "?this");
+
+    let rows = [];
+    try {
+      rows = queryBindings(dataTtl, query);
+    } catch (_) {
+      continue;
+    }
+
+    for (const row of rows) {
+      violations.push({
+        focusNode: firstBindingValue(row.this, row.focusNode, row.focus_node),
+        path: "",
+        value: bindingValue(row.value),
+        sourceShape,
+        sourceConstraintComponent: "http://www.w3.org/ns/shacl#SPARQLConstraint",
+        message,
+        severity,
+      });
+    }
+  }
+
+  return violations;
+};
+
+const violationKey = (violation) =>
+  [
+    violation.focusNode,
+    violation.path,
+    violation.value,
+    violation.sourceShape,
+    violation.message,
+  ].join("\u0000");
+
+const mergeViolations = (left, right) => {
+  const seen = new Set();
+  const merged = [];
+  for (const violation of [...left, ...right]) {
+    const key = violationKey(violation);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(violation);
+  }
+  return merged;
+};
+
+const normalizeValidationReport = (dataTtl, result, shapesTtl) => {
   if (!result || typeof result !== "object") {
     throw new Error("validate did not return an object");
   }
@@ -1151,17 +1316,27 @@ const normalizeValidationReport = (result, shapesTtl) => {
     throw new Error("validate result missing conforms boolean");
   }
 
-  const shapeMetadata = shapeMetadataByPath(shapesTtl);
+  const metadata = shapeMetadata(shapesTtl);
+  const rudofViolations = Array.isArray(result.violations)
+    ? result.violations.map((violation) =>
+        normalizeViolation(violation, metadata),
+      )
+    : [];
+  const sparqlViolations = sparqlConstraintViolations(dataTtl, shapesTtl);
+  const violations = mergeViolations(rudofViolations, sparqlViolations);
 
   return {
-    conforms: result.conforms,
-    violations: Array.isArray(result.violations)
-      ? result.violations.map((violation) =>
-          normalizeViolation(violation, shapeMetadata),
-        )
-      : [],
+    conforms: result.conforms && violations.length === 0,
+    violations,
   };
 };
+
+globalThis.txInspectorValidateShacl = (dataTtl, shapesTtl) =>
+  normalizeValidationReport(
+    dataTtl,
+    globalThis.rdfShapes.validate(dataTtl, shapesTtl),
+    shapesTtl,
+  );
 
 export const queryImpl = (left) => (right) => (graphTtl) => (sparql) => () => {
   try {
@@ -1209,10 +1384,7 @@ export const queryDecodedTreeImpl = (left) => (right) => (graphTtl) => () => {
 export const validateImpl = (left) => (right) => (dataTtl) => (shapesTtl) => () => {
   try {
     return right(
-      normalizeValidationReport(
-        globalThis.rdfShapes.validate(dataTtl, shapesTtl),
-        shapesTtl,
-      ),
+      globalThis.txInspectorValidateShacl(dataTtl, shapesTtl),
     );
   } catch (err) {
     return left(errText(err));

--- a/docs/inspector/src/Main.purs
+++ b/docs/inspector/src/Main.purs
@@ -964,7 +964,9 @@ inspectorComponent initial =
         else ""
     in
       [ HH.div
-          [ classNames rowClasses ]
+          [ classNames rowClasses
+          , HP.id row.id
+          ]
           [ HH.div
               [ classNames [ "decoded-tree-main" ] ]
               [ HH.div
@@ -1553,7 +1555,7 @@ inspectorComponent initial =
       Just rdf ->
         if exitOk && rdf.valid then
           [ renderRdfGraph rdf, renderOverlayBooks state ]
-            <> renderShaclConformanceMaybe state.shaclConformance
+            <> renderShaclConformanceMaybe state state.shaclConformance
             <> renderResolvedLabelsLensMaybe state.resolvedLabelsLens
             <> renderTypedFieldsLensMaybe state.typedFieldsLens
             <> renderSparqlLensMaybe state.sparqlLens
@@ -1674,7 +1676,7 @@ inspectorComponent initial =
               <> renderWitnessPlanMaybe state
           ValidationTab ->
             renderValidationMaybe state
-              <> renderShaclConformanceMaybe state.shaclConformance
+              <> renderShaclConformanceMaybe state state.shaclConformance
           GraphRdfTab ->
             renderCompactIdentificationMaybe state
               <> renderGraphRdfMaybe state
@@ -1974,12 +1976,12 @@ inspectorComponent initial =
   selectedBlueprintArgs state =
     OverlayBook.blueprintArgs (selectedBlueprintParts state)
 
-  renderShaclConformanceMaybe conformance =
+  renderShaclConformanceMaybe state conformance =
     case conformance of
-      Just value -> [ renderShaclConformance value ]
+      Just value -> [ renderShaclConformance state value ]
       Nothing -> []
 
-  renderShaclConformance conformance =
+  renderShaclConformance state conformance =
     HH.div
       [ classNames [ "shacl-conformance-panel" ]
       , mdSurface "decoded"
@@ -2024,7 +2026,7 @@ inspectorComponent initial =
                                 "foreign/off-spec"
                           }
                       ]
-                  , renderShaclViolations report
+                  , renderShaclViolations state report
                   ]
               Nothing ->
                 HH.div
@@ -2041,32 +2043,80 @@ inspectorComponent initial =
       , HH.code_ [ HH.text label ]
       ]
 
-  renderShaclViolations report =
+  renderShaclViolations state report =
     if Array.null report.violations then
       HH.div
         [ classNames [ "witness-empty" ] ]
-        [ HH.text "No SHACL violations." ]
+        [ HH.text "No phase-1 issues." ]
     else
       HH.div
         [ classNames [ "witness-section" ] ]
         [ HH.div
             [ classNames [ "identity-section-title" ] ]
-            [ HH.text "SHACL violations" ]
+            [ HH.text "Phase-1 issues" ]
         , HH.div
             [ classNames [ "sparql-lens-row-list" ] ]
-            (map renderShaclViolationRow report.violations)
+            (map (renderShaclViolationRow state) report.violations)
         ]
 
-  renderShaclViolationRow violation =
+  renderShaclViolationRow state violation =
+    let
+      severity = normalizedShaclSeverity violation.severity
+    in
     HH.div
-      [ classNames [ "sparql-lens-row", "shacl-violation-row" ] ]
-      [ renderShaclViolationCell "Focus node" violation.focusNode
+      [ classNames [ "sparql-lens-row", "shacl-violation-row", "shacl-" <> severity ] ]
+      [ renderShaclViolationCell "Severity" severity
+      , renderShaclViolationLocationCell state violation
+      , renderShaclViolationCell "Focus node" violation.focusNode
       , renderShaclViolationCell "Path" violation.path
       , renderShaclViolationCell "Source shape" violation.sourceShape
       , renderShaclViolationCell "Message" violation.message
       , renderShaclViolationCell "Constraint" violation.sourceConstraintComponent
-      , renderShaclViolationCell "Severity" violation.severity
       ]
+
+  normalizedShaclSeverity severity =
+    if severity == "warning" then "warning"
+    else if severity == "info" then "info"
+    else "error"
+
+  renderShaclViolationLocationCell state violation =
+    HH.div
+      [ classNames [ "sparql-lens-cell" ] ]
+      [ HH.span
+          [ classNames [ "identity-section-title" ] ]
+          [ HH.text "Location" ]
+      , case shaclFocusRow state violation.focusNode of
+          Just row ->
+            HH.a
+              [ classNames [ "decoded-tree-iri", "shacl-location-link" ]
+              , HP.href ("#" <> row.id)
+              , HP.title row.entityIri
+              , HE.onClick (\_ -> SelectResultTab StructureTab)
+              ]
+              [ HH.text (shaclFocusRowLabel row) ]
+          Nothing ->
+            HH.text (if violation.focusNode == "" then "transaction graph" else violation.focusNode)
+      ]
+
+  shaclFocusRow state focusNode =
+    case state.decodedTreeLens of
+      Just lens ->
+        if focusNode == "" then
+          Nothing
+        else
+          Array.find
+            ( \row ->
+                row.entityIri == focusNode
+                  || row.value == focusNode
+                  || row.raw == focusNode
+                  || row.annotationValue == focusNode
+            )
+            lens.rows
+      Nothing -> Nothing
+
+  shaclFocusRowLabel row =
+    if row.resolvedLabel /= "" then row.resolvedLabel
+    else row.label
 
   renderShaclViolationCell label value =
     HH.div

--- a/docs/inspector/tests/tx-identify.spec.mjs
+++ b/docs/inspector/tests/tx-identify.spec.mjs
@@ -21,6 +21,10 @@ const validationFixturePath = path.join(
   repoRoot,
   "specs/001-ledger-functional-layer/fixtures/tx-validate-complete-request.json",
 );
+const cardanoShaclShapesPath = path.join(
+  repoRoot,
+  "docs/inspector/protocols/cardano-rdf/shapes.ttl",
+);
 const packagedSiteDir = path.resolve(
   process.cwd(),
   process.env.TX_INSPECTOR_SITE_DIR || "result",
@@ -57,8 +61,37 @@ cardano:TransactionShape
 cardano:RequiresSentinelShape
   sh:path cardano:requiresSentinel ;
   sh:minCount 1 ;
+  sh:severity sh:Warning ;
   sh:message "Transactions must include sentinel off-spec marker." .
 `;
+
+function classATurtle({ includeInput = true, txPredicates = [], body = "" } = {}) {
+  const predicates = [
+    "cardano:hasTxId <urn:cardano:id:TxId:class-a>",
+    ...(includeInput ? ["cardano:hasInput _:input1"] : []),
+    ...txPredicates,
+  ];
+  const inputBody = includeInput
+    ? `
+_:input1 a cardano:Input ;
+  cardano:txOutRef "0000000000000000000000000000000000000000000000000000000000000001#0" .
+`
+    : "";
+  return `
+@prefix cardano: <https://lambdasistemi.github.io/cardano-ledger-rdf/vocab/cardano#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<urn:cardano:tx:class-a>
+  a cardano:Transaction ;
+  ${predicates.join(" ;\n  ")} .
+
+<urn:cardano:id:TxId:class-a> a cardano:Identifier ;
+  cardano:leafType "TxId" ;
+  cardano:bytesHex "class-a" .
+${inputBody}
+${body}
+`;
+}
 
 const conwayBodyFields = [
   { key: 0, label: "inputs" },
@@ -2813,18 +2846,151 @@ test("renders selected library SHACL conformance for bundled Cardano RDF shapes"
   await expect(
     conformancePanel
       .locator(".metric-card", { hasText: "Author gate" })
-      .getByText("fail", { exact: true }),
+      .getByText("pass", { exact: true }),
   ).toBeVisible();
   await expect(
     conformancePanel
       .locator(".metric-card", { hasText: "Auditor classifier" })
-      .getByText("foreign/off-spec", { exact: true }),
+      .getByText("canonical-pipeline match", { exact: true }),
   ).toBeVisible();
-  const violationRow = conformancePanel.locator(".shacl-violation-row").filter({
-    hasText: "Cardano transactions must include a transaction id.",
-  });
-  await expect(violationRow).toBeVisible();
-  await expect(violationRow).toContainText("hasTxId");
+  await expect(conformancePanel.getByText("No phase-1 issues.")).toBeVisible();
+});
+
+test("Class A SHACL shapes fire on crafted phase-1 violations", async ({ page }) => {
+  const shapes = await readFile(cardanoShaclShapesPath, "utf8");
+  const cases = [
+    {
+      name: "empty input set",
+      expected: "InputSetEmptyUTxO",
+      fallback: "cardano#hasInput",
+      data: classATurtle({ includeInput: false }),
+    },
+    {
+      name: "reference input overlap",
+      expected: "ReferenceInputOverlapsWithInput",
+      data: classATurtle({
+        txPredicates: ["cardano:hasReferenceInput _:referenceInput1"],
+        body: `
+_:referenceInput1 a cardano:Input ;
+  cardano:txOutRef "0000000000000000000000000000000000000000000000000000000000000001#0" .
+`,
+      }),
+    },
+    {
+      name: "genesis legacy certificate",
+      expected: "UnsupportedLegacyCertificate",
+      fallback: "GenesisKeyDelegation",
+      data: classATurtle({
+        txPredicates: ["cardano:hasCertificate _:legacyCert"],
+        body: "_:legacyCert a cardano:GenesisKeyDelegation .",
+      }),
+    },
+    {
+      name: "MIR legacy certificate",
+      expected: "UnsupportedLegacyCertificate",
+      fallback: "MIRCertificate",
+      data: classATurtle({
+        txPredicates: ["cardano:hasCertificate _:mirCert"],
+        body: "_:mirCert a cardano:MIRCertificate .",
+      }),
+    },
+    {
+      name: "zero treasury withdrawal",
+      expected: "TreasuryWithdrawalZero",
+      data: classATurtle({
+        txPredicates: ["cardano:hasProposal _:proposal1"],
+        body: `
+_:proposal1 a cardano:Proposal ;
+  cardano:hasGovAction _:treasuryAction1 .
+_:treasuryAction1 a cardano:TreasuryWithdrawals ;
+  cardano:hasWithdrawal _:treasuryWithdrawal1 .
+_:treasuryWithdrawal1 a cardano:Withdrawal ;
+  cardano:hasLovelace 0 .
+`,
+      }),
+    },
+    {
+      name: "conflicting committee update",
+      expected: "CommitteeUpdateConflict",
+      data: classATurtle({
+        txPredicates: ["cardano:hasProposal _:proposal1"],
+        body: `
+_:proposal1 a cardano:Proposal ;
+  cardano:hasGovAction _:committeeAction1 .
+_:committeeAction1 a cardano:UpdateCommittee ;
+  cardano:removesMember <urn:cardano:id:CommitteeColdKey:bad> ;
+  cardano:addsMember _:committeeAddition1 .
+_:committeeAddition1 a cardano:CommitteeAddition ;
+  cardano:hasIdentifier <urn:cardano:id:CommitteeColdKey:bad> .
+`,
+      }),
+    },
+    {
+      name: "auxiliary data hash missing",
+      expected: "AuxiliaryDataHashMissing",
+      data: classATurtle({
+        txPredicates: ["cardano:hasAuxiliaryData _:auxiliaryData1"],
+        body: "_:auxiliaryData1 a cardano:AuxiliaryData .",
+      }),
+    },
+    {
+      name: "auxiliary data hash unexpected",
+      expected: "AuxiliaryDataHashPresentButNotExpected",
+      data: classATurtle({
+        txPredicates: [
+          "cardano:auxiliaryDataHash <urn:cardano:id:AuxiliaryDataHash:unexpected>",
+        ],
+      }),
+    },
+    {
+      name: "input canonical order warning",
+      expected: "InputsNotCanonicallySorted",
+      data: classATurtle({
+        txPredicates: ["cardano:hasInput _:input2"],
+        body: `
+_:input1 cardano:inputOrder 0 .
+_:input2 a cardano:Input ;
+  cardano:inputOrder 1 ;
+  cardano:txOutRef "0000000000000000000000000000000000000000000000000000000000000000#0" .
+`,
+      }),
+    },
+    {
+      name: "withdrawal canonical order warning",
+      expected: "WithdrawalsNotCanonicallySorted",
+      data: classATurtle({
+        txPredicates: [
+          "cardano:hasWithdrawal _:withdrawal1",
+          "cardano:hasWithdrawal _:withdrawal2",
+        ],
+        body: `
+_:withdrawal1 a cardano:Withdrawal ;
+  cardano:withdrawalOrder 0 ;
+  cardano:withdrawalAccount <urn:cardano:id:StakeKey:2> .
+_:withdrawal2 a cardano:Withdrawal ;
+  cardano:withdrawalOrder 1 ;
+  cardano:withdrawalAccount <urn:cardano:id:StakeKey:1> .
+`,
+      }),
+    },
+  ];
+
+  await page.goto("/");
+  await page.waitForFunction(() => typeof globalThis.txInspectorValidateShacl === "function");
+
+  for (const scenario of cases) {
+    const report = await page.evaluate(
+      ({ data, shapes }) => globalThis.txInspectorValidateShacl(data, shapes),
+      { data: scenario.data, shapes },
+    );
+    const payload = JSON.stringify(report);
+    expect(report.conforms, `${scenario.name} should violate Class A shapes`).toBe(false);
+    expect(
+      payload.includes(scenario.expected) ||
+        (scenario.fallback !== undefined && payload.includes(scenario.fallback)),
+      scenario.name,
+    ).toBe(true);
+  }
 });
 
 test("renders non-conforming SHACL violations for pasted shapes", async ({
@@ -2863,6 +3029,8 @@ test("renders non-conforming SHACL violations for pasted shapes", async ({
   await expect(violationRow.getByText("Focus node", { exact: true })).toBeVisible();
   await expect(violationRow.getByText("Path", { exact: true })).toBeVisible();
   await expect(violationRow.getByText("Source shape", { exact: true })).toBeVisible();
+  await expect(violationRow.getByText("warning", { exact: true })).toBeVisible();
+  await expect(violationRow.getByRole("link", { name: "Transaction" })).toBeVisible();
   await expect(violationRow).toContainText("requiresSentinel");
   await expect(violationRow).toContainText("RequiresSentinelShape");
 });


### PR DESCRIPTION
Closes #127.

## What changed

- Adds the bundled/open Cardano RDF SHACL book for Class A phase-1 validation.
- Covers the A1 structural checks with `sh:severity` and `sh:message`:
  - empty input set
  - reference input overlap with spend input via flat `cardano:txOutRef`
  - unsupported legacy genesis/MIR certificates
  - zero treasury withdrawal governance action
  - conflicting committee update member add/remove
  - auxiliary-data hash presence consistency in both directions
  - input and withdrawal canonical-order warnings when order terms are present
- Extends `RdfShapes.js` validation normalization to keep severity, focus node, authored messages, and open `sh:sparql` constraints.
- Renders SHACL results in the Validation tab as error/warning rows with decoded-tree location links.
- Keeps the shapes as a selectable SHACL book through the existing library/book pipeline.

## Coverage vs CQuisitor Class A

Implemented in this PR:

| CQuisitor/Class A area | SHACL coverage |
| --- | --- |
| `InputSetEmptyUTxO` | `cardano:ClassAInputSetNotEmptyShape` |
| `ReferenceInputOverlapsWithInput` | SPARQL join on `cardano:hasInput/cardano:hasReferenceInput` + flat `cardano:txOutRef` |
| unsupported genesis delegation certs | `cardano:UnsupportedLegacyCertificateShape` |
| unsupported MIR certs | `cardano:UnsupportedLegacyCertificateShape` |
| zero treasury withdrawals | `cardano:ClassAZeroTreasuryWithdrawalConstraint` |
| conflicting committee add/remove | `cardano:ClassACommitteeUpdateConflictConstraint` |
| aux data present but hash missing | `cardano:ClassAAuxiliaryDataHashMissingConstraint` |
| aux hash present but aux data missing | `cardano:ClassAAuxiliaryDataHashUnexpectedConstraint` |
| unsorted inputs | warning-only open shape, active when `cardano:inputOrder` exists |
| unsorted withdrawals | warning-only open shape, active when `cardano:withdrawalOrder` exists |

Deferred to A2/follow-up because the current decoded RDF does not yet expose the required proof properties: network-id validation, hash-value equality checks, signature validity, and other cryptographic/decoder-derived Class A checks. This matches the ticket scope.

## Verification

- `nix build .#packages.x86_64-linux.tx-inspector-ui`
- `just test-playwright` (42 passed)
- `just format-check`
- `just hlint`

Preview: https://cardano-ledger-inspector-pr127-class-a-shacl.surge.sh
Smoke screenshot: `/tmp/ux121/clins-127/preview-smoke.png`
